### PR TITLE
add precision control for combo

### DIFF
--- a/apps/vaporgui/ImageSubtabs.h
+++ b/apps/vaporgui/ImageSubtabs.h
@@ -74,10 +74,11 @@ class ImageAppearanceSubtab : public QWidget, public Ui_ImageAppearanceGUI {
 
 public:
 	ImageAppearanceSubtab(QWidget* parent) 
-  {
+    {
     _rParams = NULL;
-		setupUi(this);
+    setupUi(this);
     _opacityCombo = new Combo( OpacityEdit, OpacitySlider );
+    _opacityCombo->SetPrecision( 2 );
 
     connect( GeoRefCheckbox, SIGNAL(clicked()), this, SLOT( GeoRefClicked() ) );
     connect( IgnoreTransparencyCheckbox, SIGNAL(clicked()), this, SLOT( IgnoreTransparencyClicked() ) );

--- a/apps/vaporgui/RangeCombos.cpp
+++ b/apps/vaporgui/RangeCombos.cpp
@@ -21,6 +21,8 @@ Combo::Combo(QLineEdit* edit, QSlider* slider, bool intType)
 	_value = _minValid;
 	_intType = intType;
 
+    _floatPrecision = 6;   // 6 is default in QT
+
 	_lineEdit = NULL;
 	_lineEditValidator = NULL;
 	_slider = NULL;
@@ -104,7 +106,7 @@ void Combo::Update(double min, double max, double value) {
 		_lineEdit->setText(QString::number((int) value));
 	}
 	else {
-		_lineEdit->setText(QString::number(value));
+		_lineEdit->setText(QString::number( value, 'g', _floatPrecision ));
 	}
 	_lineEdit->blockSignals(oldState);
 
@@ -140,7 +142,7 @@ void Combo::setLineEdit() {
 			_lineEdit->setText(QString::number((int) value));
 		}
 		else {
-			_lineEdit->setText(QString::number(value));
+			_lineEdit->setText(QString::number( value, 'g', _floatPrecision ));
 		}
 	}
 	if (value > _maxValid) {
@@ -149,7 +151,7 @@ void Combo::setLineEdit() {
 			_lineEdit->setText(QString::number((int) value));
 		}
 		else {
-			_lineEdit->setText(QString::number(value));
+			_lineEdit->setText(QString::number( value, 'g', _floatPrecision ));
 		}
 	}
 
@@ -200,7 +202,7 @@ void Combo::setSliderMini( int pos ) {
 	if (_intType)
 		_lineEdit->setText(QString::number((int) value));
 	else 
-		_lineEdit->setText(QString::number(value));
+	    _lineEdit->setText(QString::number( value, 'g', _floatPrecision ));
 	_lineEdit->blockSignals(oldState);
 }
 
@@ -210,6 +212,12 @@ void Combo::SetSliderLineEdit(double value) {
 	// and the new value
 	//
 	Update(_minValid, _maxValid, value);
+}
+ 
+void Combo::SetPrecision( int precision )
+{
+    if( precision > 0 )
+        _floatPrecision = precision;
 }
 
 //////////////////////////////////////////////////////

--- a/apps/vaporgui/RangeCombos.h
+++ b/apps/vaporgui/RangeCombos.h
@@ -49,6 +49,11 @@ public:
  //
  double GetValue() const { return(_value); };
 
+ // set how many digits to show for floating-point precision
+ // This setting won't change anything for displaying integers.
+ // The input precision value should be at least 1.
+ void SetPrecision( int precision );
+
  void SetEnabled(bool on);
 
 private slots:
@@ -80,6 +85,8 @@ private:
  double _maxValid;
  double _value;
  bool _intType;
+
+ int _floatPrecision;   // how many digits after the decimal point?
 
  QLineEdit *_lineEdit;
  QValidator *_lineEditValidator;


### PR DESCRIPTION
The change to the `Combo` class is to allow individual instances to specify a precision for the text box, i.e., how many digits after the decimal point. It won't change the default behavior of `Combo` if not specified.

The change to `ImageSubtabs` is a demonstration on how this is used. 