### PR TITLE
Fix Issue #156

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -622,7 +622,7 @@ void MainForm::hookupSignals() {
 	);
 }
 
-/*
+#if 0
 QWidgetAction* MainForm::createTextSeparator(const QString& text)
 {
     auto* pLabel = new QLabel(text);
@@ -637,7 +637,7 @@ QWidgetAction* MainForm::createTextSeparator(const QString& text)
     separator->setDefaultWidget(pLabel);
     return separator;
 }
-*/
+#endif
 
 void MainForm::createMenus(){
 	

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -622,6 +622,7 @@ void MainForm::hookupSignals() {
 	);
 }
 
+/*
 QWidgetAction* MainForm::createTextSeparator(const QString& text)
 {
     auto* pLabel = new QLabel(text);
@@ -636,6 +637,7 @@ QWidgetAction* MainForm::createTextSeparator(const QString& text)
     separator->setDefaultWidget(pLabel);
     return separator;
 }
+*/
 
 void MainForm::createMenus(){
 	

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -631,6 +631,8 @@ QWidgetAction* MainForm::createTextSeparator(const QString& text)
     // possible alignment
     // pLabel->setAlignment(Qt::AlignCenter);
     auto* separator = new QWidgetAction(this);
+
+	// This triggers a bug in Qt and prevents the app from exiting on window close
     separator->setDefaultWidget(pLabel);
     return separator;
 }
@@ -640,7 +642,7 @@ void MainForm::createMenus(){
 	// menubar
     _main_Menubar = menuBar();
     _File = menuBar()->addMenu(tr("File"));
-	_File->addAction(createTextSeparator(" Data"));
+	// _File->addAction(createTextSeparator(" Data"));
 	_File->addAction(_dataLoad_MetafileAction );
 	_closeVDCMenu = _File->addMenu("Close VDC");
 	//_File->addAction(_dataClose_MetafileAction );
@@ -649,7 +651,7 @@ void MainForm::createMenus(){
     _importMenu->addAction(_dataImportCF_Action);
     _importMenu->addAction(_dataImportMPAS_Action);
 	_File->addSeparator();
-	_File->addAction(createTextSeparator(" Session"));
+	// _File->addAction(createTextSeparator(" Session"));
     _File->addAction(_fileNew_SessionAction);
     _File->addAction(_fileOpenAction);
     _File->addAction(_fileSaveAction);
@@ -800,19 +802,19 @@ void MainForm::languageChange()
 {
 	setWindowTitle( tr( "VAPoR:  NCAR Visualization and Analysis Platform for Research" ) );
 
-    _fileNew_SessionAction->setText( tr( "&New" ) );
+    _fileNew_SessionAction->setText( tr( "&New Session" ) );
     
 	_fileNew_SessionAction->setToolTip("Restart the session with default settings");
 	_fileNew_SessionAction->setShortcut( Qt::CTRL + Qt::Key_N );
     
-    _fileOpenAction->setText( tr( "&Open" ) );
+    _fileOpenAction->setText( tr( "&Open Session" ) );
     _fileOpenAction->setShortcut( tr( "Ctrl+O" ) );
 	_fileOpenAction->setToolTip("Launch a file open dialog to reopen a previously saved session file");
     
-    _fileSaveAction->setText( tr( "&Save" ) );
+    _fileSaveAction->setText( tr( "&Save Session" ) );
     _fileSaveAction->setShortcut( tr( "Ctrl+S" ) );
 	_fileSaveAction->setToolTip("Launch a file-save dialog to save the state of this session in current session file");
-    _fileSaveAsAction->setText( tr( "Save As..." ) );
+    _fileSaveAsAction->setText( tr( "Save Session As..." ) );
     
 	_fileSaveAsAction->setToolTip("Launch a file-save dialog to save the state of this session in another session file");
  

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -160,7 +160,9 @@ protected:
  bool eventFilter(QObject *obj, QEvent *event);
 
 private:
- // QWidgetAction* createTextSeparator(const QString& text);
+#if 0
+ QWidgetAction* createTextSeparator(const QString& text);
+#endif
 
  class ParamsChangeEvent : public QEvent {
  public:

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -160,7 +160,7 @@ protected:
  bool eventFilter(QObject *obj, QEvent *event);
 
 private:
- QWidgetAction* createTextSeparator(const QString& text);
+ // QWidgetAction* createTextSeparator(const QString& text);
 
  class ParamsChangeEvent : public QEvent {
  public:


### PR DESCRIPTION
QWidgetAction::setDefaultWidget() was triggering a bug in Qt that prevented the application from exiting. It was being used to add labels in the file menu so I disabled that code and renamed the session menu options from "Save/Load/..." to "Save/Load/... Session".