### PR TITLE
get extents default at refinement level 0

### DIFF
--- a/lib/params/BarbParams.cpp
+++ b/lib/params/BarbParams.cpp
@@ -79,7 +79,7 @@ void BarbParams::_init() {
 	if (varname.empty()) return;
 
     vector <double> minExt, maxExt;
-    int rc = _dataMgr->GetVariableExtents(0, varname, -1, minExt, maxExt);
+    int rc = _dataMgr->GetVariableExtents(0, varname, 0, minExt, maxExt);
 
 	SetUseSingleColor(true);
 	float rgb[] = {1.f,1.f,1.f};

--- a/lib/params/ContourParams.cpp
+++ b/lib/params/ContourParams.cpp
@@ -157,7 +157,7 @@ void ContourParams::_init() {
 	if (varname.empty()) return;
 
 	vector <double> minExt, maxExt;
-	int rc = _dataMgr->GetVariableExtents(0, varname, -1, minExt, maxExt);
+	int rc = _dataMgr->GetVariableExtents(0, varname, 0, minExt, maxExt);
 
 	SetUseSingleColor(true);
 	float rgb[] = {.95,.66,.27};

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -105,7 +105,7 @@ void RenderParams::_initBox() {
 	if (varname.empty()) return;
 
 	vector <double> minExt, maxExt;
-	int rc = _dataMgr->GetVariableExtents(0, varname, -1, minExt, maxExt);
+	int rc = _dataMgr->GetVariableExtents(0, varname, 0, minExt, maxExt);
 	
 	// Crap. No error handling from constructor. Need Initialization()
 	// method.
@@ -125,7 +125,6 @@ void RenderParams::_initBox() {
 
 	_Box->SetExtents(minExt, maxExt);
 	_Box->SetPlanar(planar);	
-	
 }
 	
 

--- a/lib/params/TwoDDataParams.cpp
+++ b/lib/params/TwoDDataParams.cpp
@@ -72,7 +72,7 @@ void TwoDDataParams::_init() {
 	if (varname.empty()) return;
 
     vector <double> minExt, maxExt;
-    int rc = _dataMgr->GetVariableExtents(0, varname, -1, minExt, maxExt);
+    int rc = _dataMgr->GetVariableExtents(0, varname, 0, minExt, maxExt);
 
 	// Crap. No error handling from constructor. Need Initialization()
 	// method.


### PR DESCRIPTION
This fixes issue #206 . 

The cause of the reported problem isn't actually a bug in GeometryWidget, but how different parameters initialize. 
More specifically, the parameters initialize refinement levels to be 0, but retrieve data extents at refinement level -1.  