### PR TITLE
Issue 121

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -2046,20 +2046,26 @@ void MainForm::updateMenus() {
 	_closeVDCMenu->clear();
 	vector <string> currentPaths, currentDataSets;
 	p->GetOpenDataSets(currentPaths, currentDataSets);
-	for (int i=0; i<currentDataSets.size(); i++) {
+	int size = currentDataSets.size();
+	if (size < 1)
+		_closeVDCMenu->setEnabled(false);
+	else {
+		_closeVDCMenu->setEnabled(true);
+		for (int i=0; i<currentDataSets.size(); i++) {
 
-		// Add menu option to close the dataset in the File menu
-		//
-		QAction* closeAction = new QAction(
-			QString::fromStdString(currentDataSets[i]),
-			_closeVDCMenu
-		);
-		_closeVDCMenu->addAction(closeAction);
+			// Add menu option to close the dataset in the File menu
+			//
+			QAction* closeAction = new QAction(
+				QString::fromStdString(currentDataSets[i]),
+				_closeVDCMenu
+			);
+			_closeVDCMenu->addAction(closeAction);
 
-		connect( 
-			closeAction, SIGNAL( triggered() ),
-			this, SLOT( closeData() ) 
-		);
+			connect( 
+				closeAction, SIGNAL( triggered() ),
+				this, SLOT( closeData() ) 
+			);
+		}
 	}
 }
 

--- a/lib/render/BarbRenderer.cpp
+++ b/lib/render/BarbRenderer.cpp
@@ -73,8 +73,6 @@ int BarbRenderer::_paintGL(){
 	BarbParams* bParams = (BarbParams*) GetActiveParams();
 	size_t ts = bParams->GetCurrentTimestep();
 
-	cout << "Current timestep " << ts << endl;
-
 	int refLevel = bParams->GetRefinementLevel();
 	int lod = bParams->GetCompressionLevel();
 	vector<double> minExts, maxExts;

--- a/lib/render/BarbRenderer.cpp
+++ b/lib/render/BarbRenderer.cpp
@@ -73,6 +73,7 @@ int BarbRenderer::_paintGL(){
 	BarbParams* bParams = (BarbParams*) GetActiveParams();
 	size_t ts = bParams->GetCurrentTimestep();
 
+	cout << "Current timestep " << ts << endl;
 
 	int refLevel = bParams->GetRefinementLevel();
 	int lod = bParams->GetCompressionLevel();
@@ -317,7 +318,7 @@ int BarbRenderer::performRendering(
 	rakeExts[3] = rMaxExtents[0];
 	rakeExts[4] = rMaxExtents[1];
 	rakeExts[5] = rMaxExtents[2];
-	
+
 	string winName = GetVisualizer();
 	ViewpointParams* vpParams =  _paramsMgr->GetViewpointParams(winName);
 	//Barb thickness is .001*LineThickness*viewDiameter.


### PR DESCRIPTION
Fixed issue 121, where our "Close VDC" menu was empty when no datasets were loaded.  This menu option is now disabled when there are no datasets to close.

https://github.com/NCAR/vapor/issues/121