### PR TITLE
remove code that's bringing in warnings

### DIFF
--- a/apps/vaporgui/Plot.cpp
+++ b/apps/vaporgui/Plot.cpp
@@ -225,12 +225,14 @@ QDialog(parent), Ui_PlotWindow() {
 	connect(removeVarCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(removeVar(int)));
 	connect(dataMgrCombo, SIGNAL(currentIndexChanged(int)), 
 		this, SLOT(reinitDataMgr()));
+#ifdef GETPOINTFROMRENDERER
 	connect(timeCopyCombo, SIGNAL(activated(int)), 
 		this, SLOT(getPointFromRenderer()));
 	connect(spaceP1CopyCombo, SIGNAL(activated(int)), 
 		this, SLOT(getPointFromRenderer()));
 	connect(spaceP2CopyCombo, SIGNAL(activated(int)), 
 		this, SLOT(getPointFromRenderer()));
+#endif
 	connect(refCombo, SIGNAL(currentIndexChanged(int)), 
 		this, SLOT(refinementChanged(int)));
 	connect(cRatioCombo, SIGNAL(currentIndexChanged(int)), 
@@ -1289,7 +1291,7 @@ void Plot::getRanges(QObject*& sender, QComboBox*& qcb, Range*& x, Range*& y, Ra
 	}
 }
 
-#ifdef DEAD
+#ifdef GETPOINTFROMRENDERER
 void Plot::getPointFromRenderer(){
 	QComboBox* qcb = NULL;
 	Range* x = NULL;


### PR DESCRIPTION
This pr really isn't fixing anything. It's just removing code that's complaining... 
It won't cause any lose of functionality though, since the implementation of `getPointFromRenderer()` is already DEAD.