### PR TITLE
Render holder readability

### DIFF
--- a/apps/vaporgui/RenderHolder.cpp
+++ b/apps/vaporgui/RenderHolder.cpp
@@ -621,47 +621,6 @@ void RenderHolder::setRow(
 	setTypeCell(renderClass, row);
 	setDataSetCell(dataSetName, row);
 	setCheckboxCell(row, enabled);
-	//QTableWidgetItem *item = new QTableWidgetItem(renderInst.c_str());
-	//item->setFlags(item->flags() ^ Qt::ItemIsEditable);
-	//item->setTextAlignment(Qt::AlignCenter);
-	//tableWidget->setItem(row, 0, item);
-
-	//QTableWidgetItem* item = new QTableWidgetItem(renderClass.c_str());
-	//item->setFlags(item->flags() ^ Qt::ItemIsEditable);
-	//item->setTextAlignment(Qt::AlignCenter);
-	//tableWidget->setItem(row, 1, item);
-
-	//item = new QTableWidgetItem(dataSetName.c_str());
-	//item->setFlags(item->flags() ^ Qt::ItemIsEditable);
-	//item->setTextAlignment(Qt::AlignCenter);
-	//tableWidget->setItem(row, 2, item);
-
-
-	//QWidget *cbWidget = new QWidget();
-	//QCheckBox *checkBox = new QCheckBox();
-	//QHBoxLayout *cbLayout = new QHBoxLayout(cbWidget);
-	
-	//cbLayout->addWidget(checkBox);
-	//cbLayout->setAlignment(Qt::AlignCenter);
-	//cbLayout->setContentsMargins(0,0,0,0);
-	
-	//cbWidget->setProperty("row", row);
-	//cbWidget->setLayout(cbLayout);
-	
-	//tableWidget->setCellWidget(row,3,cbWidget);
-
-
-	//if (enabled) {
-	//	checkBox->setCheckState(Qt::Checked);
-	//}
-	//else {
-	//	checkBox->setCheckState(Qt::Unchecked);
-	//}
-
-	//connect(
-	//	checkBox,SIGNAL(stateChanged(int)), this, 
-	//	SLOT(checkboxChanged(int))
-	//);
 }
 
 void RenderHolder::setRow(

--- a/apps/vaporgui/RenderHolder.cpp
+++ b/apps/vaporgui/RenderHolder.cpp
@@ -60,7 +60,7 @@ RenderHolder::RenderHolder(QWidget* parent, ControlExec *ce)
 	tableWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	tableWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 
-	connect(newButton, SIGNAL(clicked()), this, SLOT(newRenderer()));
+	connect(newButton, SIGNAL(clicked()), this, SLOT(showNewRendererDialog()));
 	connect(deleteButton, SIGNAL(clicked()),this,SLOT(deleteRenderer()));
 	connect(
 		dupCombo, SIGNAL(activated(int)),
@@ -98,22 +98,11 @@ int RenderHolder::AddWidget(QWidget* wid, const char* name, string tag){
 // 
 // Slots: 
 //
-void RenderHolder::newRenderer() {
+void RenderHolder::showNewRendererDialog() {
 	ParamsMgr *paramsMgr = _controlExec->GetParamsMgr();
 	vector <string> dataSetNames = paramsMgr->GetDataMgrNames();
 
 	vector <string> renderClasses = _controlExec->GetAllRenderClasses();
-
-#ifndef HELLO_RENDERER
-    for( vector<string>::iterator it = renderClasses.begin(); it != renderClasses.end(); it++ )
-    {
-        if( *it == "Hello" )
-        {
-            renderClasses.erase( it );
-            break;
-        }
-    }
-#endif
 
 	// Launch a dialog to select a renderer type, visualizer, name
 	// Then insert a horizontal line with text and checkbox.
@@ -169,25 +158,24 @@ void RenderHolder::newRenderer() {
 
 	paramsMgr->BeginSaveStateGroup("Create new renderer");
 
-		int rc = _controlExec->ActivateRender(
-			activeViz, dataSetName, renderClass, renderInst, false
-		);
-		if (rc<0) {
-			paramsMgr->EndSaveStateGroup();
-			MSG_ERR("Can't create renderer");
-			return;
-		}
+	int rc = _controlExec->ActivateRender(
+		activeViz, dataSetName, renderClass, renderInst, false
+	);
+	if (rc<0) {
+		paramsMgr->EndSaveStateGroup();
+		MSG_ERR("Can't create renderer");
+		return;
+	}
 
-		// Save current instance to state
-		//
-		p->SetActiveRenderer(activeViz, renderClass, renderInst);
+	// Save current instance to state
+	//
+	p->SetActiveRenderer(activeViz, renderClass, renderInst);
 
-		Update();
+	Update();
 
-		emit newRenderer(activeViz, renderClass, renderInst);
+	emit newRendererSignal(activeViz, renderClass, renderInst);
 
 	paramsMgr->EndSaveStateGroup();
-
 }
 
 void RenderHolder::deleteRenderer() {
@@ -341,7 +329,7 @@ void RenderHolder::copyInstanceTo(int item) {
 
 	Update();
 
-	emit newRenderer(activeViz, activeRenderClass, renderInst);
+	emit newRendererSignal(activeViz, activeRenderClass, renderInst);
 
 }
 
@@ -573,35 +561,28 @@ void RenderHolder::getRow(
 	dataSetName = item->text().toStdString();
 }
 
-void RenderHolder::setRow(
-	int row, const string &renderInst, const string &renderClass, 
-	const string &dataSetName, bool enabled
-) {
-	int rowCount = tableWidget->rowCount();
-	if (row >= rowCount) {
-		tableWidget->setRowCount(rowCount+1);
-	}
-
+void RenderHolder::setNameCell(string renderInst, int row) {
 	QTableWidgetItem *item = new QTableWidgetItem(renderInst.c_str());
 	item->setFlags(item->flags() ^ Qt::ItemIsEditable);
 	item->setTextAlignment(Qt::AlignCenter);
 	tableWidget->setItem(row, 0, item);
+}
 
-	//QBrush brush(QColor(145,145,145));
-
-	item = new QTableWidgetItem(renderClass.c_str());
+void RenderHolder::setTypeCell(string renderClass, int row) {
+	QTableWidgetItem* item = new QTableWidgetItem(renderClass.c_str());
 	item->setFlags(item->flags() ^ Qt::ItemIsEditable);
-	//item->setForeground(brush);
 	item->setTextAlignment(Qt::AlignCenter);
 	tableWidget->setItem(row, 1, item);
+}
 
-	item = new QTableWidgetItem(dataSetName.c_str());
+void RenderHolder::setDataSetCell(string dataSetName, int row) {
+	QTableWidgetItem* item = new QTableWidgetItem(dataSetName.c_str());
 	item->setFlags(item->flags() ^ Qt::ItemIsEditable);
-	//item->setForeground(brush);
 	item->setTextAlignment(Qt::AlignCenter);
 	tableWidget->setItem(row, 2, item);
+}
 
-
+void RenderHolder::setCheckboxCell(int row, bool enabled) {
 	QWidget *cbWidget = new QWidget();
 	QCheckBox *checkBox = new QCheckBox();
 	QHBoxLayout *cbLayout = new QHBoxLayout(cbWidget);
@@ -614,8 +595,6 @@ void RenderHolder::setRow(
 	cbWidget->setLayout(cbLayout);
 	
 	tableWidget->setCellWidget(row,3,cbWidget);
-
-
 	if (enabled) {
 		checkBox->setCheckState(Qt::Checked);
 	}
@@ -627,6 +606,62 @@ void RenderHolder::setRow(
 		checkBox,SIGNAL(stateChanged(int)), this, 
 		SLOT(checkboxChanged(int))
 	);
+}
+
+void RenderHolder::setRow(
+	int row, const string &renderInst, const string &renderClass, 
+	const string &dataSetName, bool enabled
+) {
+	int rowCount = tableWidget->rowCount();
+	if (row >= rowCount) {
+		tableWidget->setRowCount(rowCount+1);
+	}
+
+	setNameCell(renderInst, row);
+	setTypeCell(renderClass, row);
+	setDataSetCell(dataSetName, row);
+	setCheckboxCell(row, enabled);
+	//QTableWidgetItem *item = new QTableWidgetItem(renderInst.c_str());
+	//item->setFlags(item->flags() ^ Qt::ItemIsEditable);
+	//item->setTextAlignment(Qt::AlignCenter);
+	//tableWidget->setItem(row, 0, item);
+
+	//QTableWidgetItem* item = new QTableWidgetItem(renderClass.c_str());
+	//item->setFlags(item->flags() ^ Qt::ItemIsEditable);
+	//item->setTextAlignment(Qt::AlignCenter);
+	//tableWidget->setItem(row, 1, item);
+
+	//item = new QTableWidgetItem(dataSetName.c_str());
+	//item->setFlags(item->flags() ^ Qt::ItemIsEditable);
+	//item->setTextAlignment(Qt::AlignCenter);
+	//tableWidget->setItem(row, 2, item);
+
+
+	//QWidget *cbWidget = new QWidget();
+	//QCheckBox *checkBox = new QCheckBox();
+	//QHBoxLayout *cbLayout = new QHBoxLayout(cbWidget);
+	
+	//cbLayout->addWidget(checkBox);
+	//cbLayout->setAlignment(Qt::AlignCenter);
+	//cbLayout->setContentsMargins(0,0,0,0);
+	
+	//cbWidget->setProperty("row", row);
+	//cbWidget->setLayout(cbLayout);
+	
+	//tableWidget->setCellWidget(row,3,cbWidget);
+
+
+	//if (enabled) {
+	//	checkBox->setCheckState(Qt::Checked);
+	//}
+	//else {
+	//	checkBox->setCheckState(Qt::Unchecked);
+	//}
+
+	//connect(
+	//	checkBox,SIGNAL(stateChanged(int)), this, 
+	//	SLOT(checkboxChanged(int))
+	//);
 }
 
 void RenderHolder::setRow(

--- a/apps/vaporgui/RenderHolder.h
+++ b/apps/vaporgui/RenderHolder.h
@@ -82,7 +82,7 @@ private:
  std::string uniqueName(std::string name);
 
 private slots:
- void newRenderer();
+ void showNewRendererDialog();
  void deleteRenderer();
  //void changeChecked(int i, int j);
  void itemTextChange(QTableWidgetItem*);
@@ -92,7 +92,7 @@ private slots:
  void checkboxChanged(int);
 
 signals:
- void newRenderer(string vizName, string renderClass, string renderInst);
+ void newRendererSignal(string vizName, string renderClass, string renderInst);
  void activeChanged(string vizName, string renderClass, string renderInst);
  
 private:
@@ -102,6 +102,11 @@ private:
 	int row, string &renderInst, string &renderClass, 
 	string &dataSetName
  ) const;
+
+ void setNameCell(string renderInst, int row);
+ void setTypeCell(string renderClass, int row);
+ void setDataSetCell(string dataSetName, int row);
+ void setCheckboxCell(int row, bool enabled);
 
  void setRow(
 	int row, const string &renderInst, 

--- a/apps/vaporgui/TabManager.cpp
+++ b/apps/vaporgui/TabManager.cpp
@@ -60,7 +60,7 @@ TabManager::TabManager(QWidget *parent, ControlExec *ce)
 		this, SLOT(setActive(string, string, string))
 	);
 	connect(
-		_renderHolder, SIGNAL(newRenderer(string, string, string)),
+		_renderHolder, SIGNAL(newRendererSignal(string, string, string)),
 		this, SLOT(newRenderer(string, string, string))
 	);
 
@@ -168,7 +168,7 @@ void TabManager::InstallWidgets() {
 	for (int topTab = 1; topTab<3; topTab++){
 		//for (int j = 0; j< _widgets[topTab].size(); j++){
 			
-			// Ugh.  I'm eliminating the for loop and setting the tabs
+			// I'm eliminating the for loop and setting the tabs
 			// explicitly, in order to have the 'VizFeatures' tab appear
 			// as the default.
 			// -Scott
@@ -354,8 +354,6 @@ void TabManager::newRenderer(
 
 	er->SetActive(renderInst);
 
-	// Ugh. Why isn't RenderEvenRouter base class a QWidget?
-	//
 	QWidget* w = dynamic_cast<QWidget*> (er);
 	assert(w);
 	w->setEnabled(true);


### PR DESCRIPTION
Changes primarily to to RenderHolder.cpp for the following:

1) Breaking down long functions (RenderHolder::setRow)
2) Using better signal names (newRenderer).  There are three or four functions named newRenderer between the RenderHolder and TabManager, and they all do different things. 