### PR TITLE
Issue 466

### DIFF
--- a/apps/vaporgui/BarbSubtabs.cpp
+++ b/apps/vaporgui/BarbSubtabs.cpp
@@ -47,7 +47,7 @@ BarbGeometrySubtab::BarbGeometrySubtab(QWidget* parent) {
 BarbAppearanceSubtab::BarbAppearanceSubtab(QWidget* parent) {
 	setupUi(this);
 	_TFWidget->Reinit((TFWidget::Flags)
-		(TFWidget::COLORVAR | TFWidget::PRIORITY_COLORVAR | TFWidget::CONSTANT));
+		(TFWidget::COLORVAR | TFWidget::CONSTANT));
 
 	hideZDimWidgets();
 

--- a/apps/vaporgui/Histo.cpp
+++ b/apps/vaporgui/Histo.cpp
@@ -27,7 +27,7 @@ Histo::Histo(int numberBins, float mnData, float mxData){
 	_minData = mnData;
 	_maxData = mxData;
 	_binArray = new int[_numBins];
-	reset();
+	reset(numberBins);
 }
 
 #ifdef	DEAD

--- a/apps/vaporgui/Histo.cpp
+++ b/apps/vaporgui/Histo.cpp
@@ -22,12 +22,23 @@ using namespace VAPoR;
 using namespace Wasp;
 
 
-Histo::Histo(int numberBins, float mnData, float mxData){
+Histo::Histo(
+	int numberBins, 
+	float mnData, 
+	float mxData, 
+	string var,
+	int ts
+){
 	_numBins = numberBins;
 	_minData = mnData;
 	_maxData = mxData;
 	_binArray = new int[_numBins];
 	reset(numberBins);
+
+	_varnameOfUpdate = var;
+	_timestepOfUpdate = ts;
+
+	cout << "Histo::Histo " << mnData << " " << mxData << endl;
 }
 
 #ifdef	DEAD

--- a/apps/vaporgui/Histo.cpp
+++ b/apps/vaporgui/Histo.cpp
@@ -37,8 +37,6 @@ Histo::Histo(
 
 	_varnameOfUpdate = var;
 	_timestepOfUpdate = ts;
-
-	cout << "Histo::Histo " << mnData << " " << mxData << endl;
 }
 
 #ifdef	DEAD

--- a/apps/vaporgui/Histo.h
+++ b/apps/vaporgui/Histo.h
@@ -26,7 +26,7 @@
 
 class Histo{
 public:
-	Histo(int numberBins, float mnData, float mxData);
+	Histo(int numberBins, float mnData, float mxData, string var, int ts);
 
 #ifdef	DEAD
 	//Special constructor for unsigned char data:
@@ -44,6 +44,9 @@ public:
 	float getMinData(){return _minData;}
 	float getMaxData(){return _maxData;}
 	
+	int getTimestepOfUpdate() {return _timestepOfUpdate;}
+	string getVarnameOfUpdate() {return _varnameOfUpdate;}
+	
 private:
 	
 	Histo() {}
@@ -53,6 +56,9 @@ private:
 	float _minData, _maxData;
 	int _maxBinSize;
 	int _largestBin;
+
+	int _timestepOfUpdate;
+	string _varnameOfUpdate;
 };
 
 #endif //HISTO_H

--- a/apps/vaporgui/MappingFrame.cpp
+++ b/apps/vaporgui/MappingFrame.cpp
@@ -185,47 +185,25 @@ MappingFrame::~MappingFrame()
   _axisTextPos.clear();
 }
 
-//bool MappingFrame::skipRefreshHistogram(MapperFunction* mf) const {
 bool MappingFrame::skipRefreshHistogram() const {
 	bool skip = true;
-	if (_histogram==NULL) {cout << "NULL _histogram" << endl; return false;}
+	if (_histogram==NULL) return false;
 
 	size_t ts = _rParams->GetCurrentTimestep();	
 	if (ts != _histogram->getTimestepOfUpdate()) {
 		skip = false;
-		cout << "differentTimestep in _histogram " << _histogram->getTimestepOfUpdate() << " " << ts << endl;
-		//mf->setTimestepOfUpdate(ts);
 	}
 
 	string varName = _rParams->GetColorMapVariableName();
 	if (varName != _histogram->getVarnameOfUpdate()) {
 		skip = false;
-		cout << "differentVarname in _histogram " << _histogram->getVarnameOfUpdate() << " " << varName << endl;
-		//mf->setVariableNameOfUpdate(varName);
 	}
 	
-/*	float minRange = mf->getMinMapValue();
-	float maxRange = mf->getMaxMapValue();
-	float minPrevious = mf->getMinOfUpdate();
-	float maxPrevious = mf->getMaxOfUpdate();
-	float newRange = maxRange - minRange;
-	float rangeOfUpdate = maxPrevious - minPrevious;
-
-	// If our range has been reduced by more than 10% of our alst refresh size,
-	// then we will refresh.
-	if (newRange < .9*rangeOfUpdate) shouldWe = true;
-
-	// If our range has grown, we will not refresh.
-	if (newRange > rangeOfUpdate) shouldWe = true;
-*/
-
 	return skip;
 }
 
 string MappingFrame::getActiveRendererName() const {
-    //assert(_controlExec != NULL);
-    GUIStateParams *p = //(GUIStateParams *) _controlExec->
-   //     GetParamsMgr()->GetParams(GUIStateParams::GetClassType());
+    GUIStateParams *p = 
 	(GUIStateParams*)_paramsMgr->GetParams(GUIStateParams::GetClassType());
 	string activeViz = p->GetActiveVizName();
 	string activeRenderClass, activeRenderInst;
@@ -239,8 +217,6 @@ void MappingFrame::RefreshHistogram(bool force) {
 	string rendererName = getActiveRendererName();
 	_histogram = _histogramMap[rendererName];
 
-	cout << endl << endl << endl << "MappingFrame::RefreshHistogram " << _histogram << " " << rendererName << endl;
-
 	if (!force) {	
 		if (skipRefreshHistogram()) return;
 	}
@@ -249,12 +225,8 @@ void MappingFrame::RefreshHistogram(bool force) {
 	var = _rParams->GetColorMapVariableName();
 	MapperFunction* mf = _rParams->GetMapperFunc(var);
 
-	cout << "refreshing " << mf << " " << var << " " << mf->getMinMapValue() << " " << mf->getMaxMapValue() << endl;
-
 	float minRange = mf->getMinMapValue();
 	float maxRange = mf->getMaxMapValue();
-	//mf->setBoundsOfUpdate(minRange, maxRange); 
-
 	size_t ts = _rParams->GetCurrentTimestep();	
 
 	if (_histogram) delete _histogram;
@@ -262,6 +234,14 @@ void MappingFrame::RefreshHistogram(bool force) {
 	_histogram = new Histo(256, minRange,
 	maxRange, var, ts);
 
+	populateHistogram();
+	
+	_histogramMap[rendererName] = _histogram;
+}
+
+void MappingFrame::populateHistogram() {
+	string var = _rParams->GetColorMapVariableName();
+	size_t ts = _rParams->GetCurrentTimestep();	
 	int refLevel = _rParams->GetRefinementLevel();
 	int lod = _rParams->GetCompressionLevel();
 
@@ -288,8 +268,6 @@ void MappingFrame::RefreshHistogram(bool force) {
 		_histogram->addToBin(v);
 	}
 	delete grid;
-
-	_histogramMap[rendererName] = _histogram;
 }
 
 //----------------------------------------------------------------------------
@@ -441,7 +419,6 @@ void MappingFrame::Update(DataMgr *dataMgr,
 
 	deselectWidgets();
 
-	//_histogram = getHistogram();
 	RefreshHistogram();
 	_minValue = getMinEditBound();
 	_maxValue = getMaxEditBound();

--- a/apps/vaporgui/MappingFrame.cpp
+++ b/apps/vaporgui/MappingFrame.cpp
@@ -185,20 +185,23 @@ MappingFrame::~MappingFrame()
   _axisTextPos.clear();
 }
 
-bool MappingFrame::shouldWeRefreshHistogram(MapperFunction* mf) const {
-	bool shouldWe = false;
-	if (_histogram==NULL) shouldWe = true;
+//bool MappingFrame::skipRefreshHistogram(MapperFunction* mf) const {
+bool MappingFrame::skipRefreshHistogram() const {
+	bool skip = true;
+	if (_histogram==NULL) {cout << "NULL _histogram" << endl; return false;}
 
 	size_t ts = _rParams->GetCurrentTimestep();	
-	if (ts != mf->getTimestepOfUpdate()) {
-		shouldWe = true;
-		mf->setTimestepOfUpdate(ts);
+	if (ts != _histogram->getTimestepOfUpdate()) {
+		skip = false;
+		cout << "differentTimestep in _histogram " << _histogram->getTimestepOfUpdate() << " " << ts << endl;
+		//mf->setTimestepOfUpdate(ts);
 	}
 
 	string varName = _rParams->GetColorMapVariableName();
-	if (varName != mf->getVariableNameOfUpdate()) {
-		shouldWe = true;
-		mf->setVariableNameOfUpdate(varName);
+	if (varName != _histogram->getVarnameOfUpdate()) {
+		skip = false;
+		cout << "differentVarname in _histogram " << _histogram->getVarnameOfUpdate() << " " << varName << endl;
+		//mf->setVariableNameOfUpdate(varName);
 	}
 	
 /*	float minRange = mf->getMinMapValue();
@@ -216,28 +219,48 @@ bool MappingFrame::shouldWeRefreshHistogram(MapperFunction* mf) const {
 	if (newRange > rangeOfUpdate) shouldWe = true;
 */
 
-	return shouldWe;
+	return skip;
 }
 
-void MappingFrame::RefreshHistogram() {
+string MappingFrame::getActiveRendererName() const {
+    //assert(_controlExec != NULL);
+    GUIStateParams *p = //(GUIStateParams *) _controlExec->
+   //     GetParamsMgr()->GetParams(GUIStateParams::GetClassType());
+	(GUIStateParams*)_paramsMgr->GetParams(GUIStateParams::GetClassType());
+	string activeViz = p->GetActiveVizName();
+	string activeRenderClass, activeRenderInst;
+	p->GetActiveRenderer(
+		activeViz, activeRenderClass, activeRenderInst
+	);
+	return activeRenderInst;
+}
+
+void MappingFrame::RefreshHistogram(bool force) {
+	string rendererName = getActiveRendererName();
+	_histogram = _histogramMap[rendererName];
+
+	cout << endl << endl << endl << "MappingFrame::RefreshHistogram " << _histogram << " " << rendererName << endl;
+
+	if (!force) {	
+		if (skipRefreshHistogram()) return;
+	}
 
 	string var;
 	var = _rParams->GetColorMapVariableName();
 	MapperFunction* mf = _rParams->GetMapperFunc(var);
 
 	cout << "refreshing " << mf << " " << var << " " << mf->getMinMapValue() << " " << mf->getMaxMapValue() << endl;
- 
-	if (_histogram) delete _histogram;
-	_histogram = new Histo(256,mf->getMinMapValue(),
-	mf->getMaxMapValue());
 
-//	float minRange = mf->getMinMapValue();
-//	float maxRange = mf->getMaxMapValue();
+	float minRange = mf->getMinMapValue();
+	float maxRange = mf->getMaxMapValue();
 	//mf->setBoundsOfUpdate(minRange, maxRange); 
 
 	size_t ts = _rParams->GetCurrentTimestep();	
 
-//	_histogram->reset(256, minRange, maxRange);
+	if (_histogram) delete _histogram;
+	_histogram = NULL;
+	_histogram = new Histo(256, minRange,
+	maxRange, var, ts);
 
 	int refLevel = _rParams->GetRefinementLevel();
 	int lod = _rParams->GetCompressionLevel();
@@ -265,6 +288,8 @@ void MappingFrame::RefreshHistogram() {
 		_histogram->addToBin(v);
 	}
 	delete grid;
+
+	_histogramMap[rendererName] = _histogram;
 }
 
 //----------------------------------------------------------------------------
@@ -274,8 +299,6 @@ void MappingFrame::updateMapperFunction(MapperFunction *mapper)
 {
   assert(mapper);
   deleteOpacityWidgets();
- 
-  cout << "updateMapperFunction() " << endl;
  
   _mapper = mapper;
   
@@ -397,7 +420,6 @@ void MappingFrame::Update(DataMgr *dataMgr,
 						ParamsMgr *paramsMgr,
 						RenderParams *rParams)
 {
-	cout << "MappiongFrame::Update()" << endl;
 	assert(dataMgr);
 	assert(paramsMgr);
 	assert(rParams);
@@ -419,7 +441,8 @@ void MappingFrame::Update(DataMgr *dataMgr,
 
 	deselectWidgets();
 
-	_histogram = getHistogram();
+	//_histogram = getHistogram();
+	RefreshHistogram();
 	_minValue = getMinEditBound();
 	_maxValue = getMaxEditBound();
 
@@ -2253,17 +2276,19 @@ float MappingFrame::getOpacityData(float value)
 //----------------------------------------------------------------------------
 // Return the histogram
 //----------------------------------------------------------------------------
-Histo* MappingFrame::getHistogram()
-{
-	string varname;
-	varname = _rParams->GetColorMapVariableName();
-	MapperFunction* mapFunc = _rParams->GetMapperFunc(varname);
-	assert(mapFunc);
+Histo* MappingFrame::getHistogram() {
+	//string varname;
+	//varname = _rParams->GetColorMapVariableName();
+	//MapperFunction* mapFunc = _rParams->GetMapperFunc(varname);
+	//assert(mapFunc);
 
-	if (shouldWeRefreshHistogram(mapFunc)) {	
+	//if (skipRefreshHistogram(mapFunc)) {	
+	if (skipRefreshHistogram()) {	
 	    RefreshHistogram();
 	}
-    return _histogram;
+
+	string rendererName = _rParams->GetName();
+	return _histogramMap[rendererName];
 }
 
 //----------------------------------------------------------------------------

--- a/apps/vaporgui/MappingFrame.cpp
+++ b/apps/vaporgui/MappingFrame.cpp
@@ -185,17 +185,59 @@ MappingFrame::~MappingFrame()
   _axisTextPos.clear();
 }
 
+bool MappingFrame::shouldWeRefreshHistogram(MapperFunction* mf) const {
+	bool shouldWe = false;
+	if (_histogram==NULL) shouldWe = true;
+
+	size_t ts = _rParams->GetCurrentTimestep();	
+	if (ts != mf->getTimestepOfUpdate()) {
+		shouldWe = true;
+		mf->setTimestepOfUpdate(ts);
+	}
+
+	string varName = _rParams->GetColorMapVariableName();
+	if (varName != mf->getVariableNameOfUpdate()) {
+		shouldWe = true;
+		mf->setVariableNameOfUpdate(varName);
+	}
+	
+/*	float minRange = mf->getMinMapValue();
+	float maxRange = mf->getMaxMapValue();
+	float minPrevious = mf->getMinOfUpdate();
+	float maxPrevious = mf->getMaxOfUpdate();
+	float newRange = maxRange - minRange;
+	float rangeOfUpdate = maxPrevious - minPrevious;
+
+	// If our range has been reduced by more than 10% of our alst refresh size,
+	// then we will refresh.
+	if (newRange < .9*rangeOfUpdate) shouldWe = true;
+
+	// If our range has grown, we will not refresh.
+	if (newRange > rangeOfUpdate) shouldWe = true;
+*/
+
+	return shouldWe;
+}
+
 void MappingFrame::RefreshHistogram() {
-	cout << "begin refresh histogram" << endl;
+
 	string var;
 	var = _rParams->GetColorMapVariableName();
+	MapperFunction* mf = _rParams->GetMapperFunc(var);
+
+	cout << "refreshing " << mf << " " << var << " " << mf->getMinMapValue() << " " << mf->getMaxMapValue() << endl;
+ 
+	if (_histogram) delete _histogram;
+	_histogram = new Histo(256,mf->getMinMapValue(),
+	mf->getMaxMapValue());
+
+//	float minRange = mf->getMinMapValue();
+//	float maxRange = mf->getMaxMapValue();
+	//mf->setBoundsOfUpdate(minRange, maxRange); 
 
 	size_t ts = _rParams->GetCurrentTimestep();	
 
-	float minRange = _rParams->GetMapperFunc(var)->getMinMapValue();
-	float maxRange = _rParams->GetMapperFunc(var)->getMaxMapValue();
-
-	_histogram->reset(256, minRange, maxRange);
+//	_histogram->reset(256, minRange, maxRange);
 
 	int refLevel = _rParams->GetRefinementLevel();
 	int lod = _rParams->GetCompressionLevel();
@@ -223,7 +265,6 @@ void MappingFrame::RefreshHistogram() {
 		_histogram->addToBin(v);
 	}
 	delete grid;
-	cout << "end refresh histogram" << endl;
 }
 
 //----------------------------------------------------------------------------
@@ -233,7 +274,9 @@ void MappingFrame::updateMapperFunction(MapperFunction *mapper)
 {
   assert(mapper);
   deleteOpacityWidgets();
-  
+ 
+  cout << "updateMapperFunction() " << endl;
+ 
   _mapper = mapper;
   
   if (_opacityMappingEnabled)
@@ -354,6 +397,7 @@ void MappingFrame::Update(DataMgr *dataMgr,
 						ParamsMgr *paramsMgr,
 						RenderParams *rParams)
 {
+	cout << "MappiongFrame::Update()" << endl;
 	assert(dataMgr);
 	assert(paramsMgr);
 	assert(rParams);
@@ -398,7 +442,6 @@ void MappingFrame::Update(DataMgr *dataMgr,
 	xDataToWorld(getMaxDomainBound()));
 
 	_updateTexture = true;
-
 }
 
 //----------------------------------------------------------------------------
@@ -2214,16 +2257,12 @@ Histo* MappingFrame::getHistogram()
 {
 	string varname;
 	varname = _rParams->GetColorMapVariableName();
-
-    MapperFunction* mapFunc = _rParams->GetMapperFunc(varname);
+	MapperFunction* mapFunc = _rParams->GetMapperFunc(varname);
 	assert(mapFunc);
 
-    if (_histogram) delete _histogram;
-
-    _histogram = new Histo(256,mapFunc->getMinMapValue(),
-		mapFunc->getMaxMapValue());
-
-    RefreshHistogram();
+	if (shouldWeRefreshHistogram(mapFunc)) {	
+	    RefreshHistogram();
+	}
     return _histogram;
 }
 

--- a/apps/vaporgui/MappingFrame.cpp
+++ b/apps/vaporgui/MappingFrame.cpp
@@ -186,6 +186,7 @@ MappingFrame::~MappingFrame()
 }
 
 void MappingFrame::RefreshHistogram() {
+	cout << "begin refresh histogram" << endl;
 	string var;
 	var = _rParams->GetColorMapVariableName();
 
@@ -222,6 +223,7 @@ void MappingFrame::RefreshHistogram() {
 		_histogram->addToBin(v);
 	}
 	delete grid;
+	cout << "end refresh histogram" << endl;
 }
 
 //----------------------------------------------------------------------------

--- a/apps/vaporgui/MappingFrame.h
+++ b/apps/vaporgui/MappingFrame.h
@@ -32,6 +32,7 @@
 #include <QPaintEvent>
 #include <QMouseEvent>
 #include "vapor/Visualizer.h"
+#include "GUIStateParams.h"
 
 #include <qpoint.h>
 #include <list>
@@ -107,7 +108,7 @@ public:
   MappingFrame(QWidget* parent);
   virtual ~MappingFrame();
 
-  void RefreshHistogram();
+  void RefreshHistogram(bool force=false);
  
   //! Enable or disable the color mapping in the Transfer Function.
   //! Should be specified in the RenderEventRouter constructor
@@ -209,7 +210,9 @@ private:
   float xVariable(const QPoint &pos);
   float yVariable(const QPoint &pos);
   bool  canBind();
-  bool shouldWeRefreshHistogram(VAPoR::MapperFunction* mf) const;
+  bool skipRefreshHistogram() const;
+  void updateHistogram();
+  string getActiveRendererName() const;
   
 protected slots:
   void setEditMode(bool);
@@ -319,6 +322,7 @@ private:
   QTabWidget* _myTabWidget;
   VAPoR::MapperFunction *_mapper;
   Histo          *_histogram;
+  map<string, Histo*> _histogramMap;
 
   bool            _opacityMappingEnabled;
   bool            _colorMappingEnabled;

--- a/apps/vaporgui/MappingFrame.h
+++ b/apps/vaporgui/MappingFrame.h
@@ -168,6 +168,8 @@ public:
   }
   //static void SetControlExec(VAPoR::ControlExec* ce){_controlExec = ce;}
 
+  void updateMapperFunction(VAPoR::MapperFunction *mapper);
+
 signals:
 
    //! Signal that is invoked when user starts to modify the transfer function.
@@ -194,7 +196,7 @@ public slots:
 	void updateMap();
 
 private:
-  void updateMapperFunction(VAPoR::MapperFunction *mapper);
+  //void updateMapperFunction(VAPoR::MapperFunction *mapper);
 
   bool colorMapping() const { return _colorMappingEnabled; }
   bool opacityMapping() const { return _opacityMappingEnabled; }
@@ -207,6 +209,7 @@ private:
   float xVariable(const QPoint &pos);
   float yVariable(const QPoint &pos);
   bool  canBind();
+  bool shouldWeRefreshHistogram(VAPoR::MapperFunction* mf) const;
   
 protected slots:
   void setEditMode(bool);

--- a/apps/vaporgui/MappingFrame.h
+++ b/apps/vaporgui/MappingFrame.h
@@ -213,6 +213,7 @@ private:
   bool skipRefreshHistogram() const;
   void updateHistogram();
   string getActiveRendererName() const;
+  void populateHistogram();
   
 protected slots:
   void setEditMode(bool);

--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -275,6 +275,9 @@ void TFWidget::updateSliders() {
 	getRange(range, values);
 	_rangeCombo->Update(range[0], range[1], values[0], values[1]);
 	opacitySlider->setValue(getOpacity() * 100);
+
+	minLabel->setText(QString::number(range[0]));
+	maxLabel->setText(QString::number(range[1]));
 }
 
 void TFWidget::updateMappingFrame() {

--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -362,13 +362,10 @@ void TFWidget::setRange(double min, double max) {
 
 void TFWidget::updateHisto() {
 	bool buttonRequest = sender() == updateHistoButton ? true : false;
-	cout << "button pressed? " << buttonRequest << endl;
 	if (autoUpdateHisto() || buttonRequest) {
-		if (isRefreshingSmart())
-			mappingFrame->RefreshHistogram();
-		//mappingFrame->fitToView();
-		//mappingFrame->updateMap();
-		//mappingFrame->Update(_dataMgr, _paramsMgr, _rParams);
+		MapperFunction *mf = getCurrentMapperFunction();
+		mappingFrame->updateMapperFunction(mf);
+		mappingFrame->RefreshHistogram();
 	}
 	else mappingFrame->fitToView();
 }
@@ -446,7 +443,6 @@ void TFWidget::loadTF() {
 
 bool TFWidget::autoUpdateHisto() {
 	MapperFunction *tf = getCurrentMapperFunction();
-	cout << "autoUpdateHisto() " << tf->GetAutoUpdateHisto() << endl;
 	if (tf->GetAutoUpdateHisto()) return true;
 	else return false;
 }	
@@ -467,17 +463,4 @@ MapperFunction* TFWidget::getCurrentMapperFunction() {
 	MapperFunction *tf = _rParams->GetMapperFunc(varname);
 	assert(tf);
 	return tf;
-}
-
-bool TFWidget::isRefreshingSmart() {
-	float dummyRange[2], currentRange[2];
-	getRange(dummyRange, currentRange);
-
-	float currentSpan = currentRange[1] - currentRange[0];
-	float savedSpan = _savedMapperValues[1] - _savedMapperValues[0];
-
-	if ((currentSpan > savedSpan) || (currentSpan < .9*savedSpan))
-		return true;
-	else 
-		return false;
 }

--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -362,6 +362,8 @@ void TFWidget::setRange(double min, double max) {
 void TFWidget::updateHisto() {
 	bool buttonRequest = sender() == updateHistoButton ? true : false;
 	if (autoUpdateHisto() || buttonRequest) {
+		MapperFunction *mf = getCurrentMapperFunction();
+		mappingFrame->updateMapperFunction(mf);
 		bool force = true;
 		mappingFrame->RefreshHistogram(force);
 		updateMappingFrame();

--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -49,17 +49,6 @@ TFWidget::TFWidget(QWidget* parent)
 	_rangeCombo = new RangeCombo(_minCombo, _maxCombo);
 
 	connectWidgets();
-
-	collapseAutoUpdateHistoCheckbox();
-}
-
-void TFWidget::collapseAutoUpdateHistoCheckbox() {
-	autoUpdateHistoLabel->hide();
-	autoUpdateHistoLabel->resize(0,0);
-	autoUpdateHistoCheckbox->hide();
-	autoUpdateHistoCheckbox->resize(0,0);
-	autoUpdateHistoFrame->resize(0,7);
-	adjustSize();
 }
 
 void TFWidget::collapseConstColorWidgets() {
@@ -180,23 +169,12 @@ void TFWidget::fileSaveTF() {
 	}   
 }
 
-string TFWidget::getVariableName() {
-	string varName = "";
-	if (_flags & COLORVAR) {
-		varName = _rParams->GetColorMapVariableName();
-	}	
-	else {
-		varName = _rParams->GetVariableName();
-	}
-	return varName;
-}
-
 void TFWidget::getRange(float range[2], 
 						float values[2]) {
 
 	range[0] = range[1] = 0.0;
 	values[0] = values[1] = 0.0;
-	string varName = getVariableName();
+	string varName = getCurrentVarName();
 	if (varName.empty() || varName=="Constant") return;
 
 	size_t ts = _rParams->GetCurrentTimestep();
@@ -226,13 +204,7 @@ float TFWidget::getOpacity()
 }
 
 void TFWidget::updateColorInterpolation() {
-	string varName = getVariableName();
-	if (varName == "") {
-		return;
-	}
-
-	MapperFunction* tf = _rParams->GetMapperFunc(varName);
-	assert(tf);
+	MapperFunction* tf = getCurrentMapperFunction();
 	
 	TFInterpolator::type t = tf->getColorInterpType();
 	colorInterpCombo->blockSignals(true);
@@ -249,12 +221,7 @@ void TFWidget::updateColorInterpolation() {
 }
 
 void TFWidget::updateAutoUpdateHistoCheckbox() {
-	string varName = getVariableName();
-	
-	return;
-
-	MapperFunction* tf = _rParams->GetMapperFunc(varName);
-	assert(tf);
+	MapperFunction* tf = getCurrentMapperFunction();
 
 	// Update the state of autoUpdateHisto according to params
 	//
@@ -301,7 +268,7 @@ void TFWidget::Update(DataMgr *dataMgr,
 	updateMappingFrame();
 	updateColorInterpolation();
 	updateSliders();
-	updateHisto();
+	//updateHisto();
 	updateConstColorWidgets();
 }
 
@@ -384,41 +351,41 @@ void TFWidget::setRange() {
 }
 
 void TFWidget::setRange(double min, double max) {
-	string varName;
-	if (_flags & COLORVAR) {
-		varName = _rParams->GetColorMapVariableName();
-	}	
-	else {
-		varName = _rParams->GetVariableName();
-	}
-	if (varName.empty()) return;
-
-	MapperFunction* tf = _rParams->GetMapperFunc(varName);
+	MapperFunction* tf = getCurrentMapperFunction();
 
 	tf->setMinMapValue(min);
 	tf->setMaxMapValue(max);
 
-	if (_autoUpdateHisto) {
-		updateHisto();
-	}
-	else mappingFrame->fitToView(); 
+	updateHisto();
 	emit emitChange();
 }
 
 void TFWidget::updateHisto() {
-	mappingFrame->fitToView();
-	mappingFrame->updateMap();
-	mappingFrame->Update(_dataMgr, _paramsMgr, _rParams);
+	bool buttonRequest = sender() == updateHistoButton ? true : false;
+	cout << "button pressed? " << buttonRequest << endl;
+	if (autoUpdateHisto() || buttonRequest) {
+		if (isRefreshingSmart())
+			mappingFrame->RefreshHistogram();
+		//mappingFrame->fitToView();
+		//mappingFrame->updateMap();
+		//mappingFrame->Update(_dataMgr, _paramsMgr, _rParams);
+	}
+	else mappingFrame->fitToView();
 }
 
 void TFWidget::autoUpdateHistoChecked(int state) {
-	if (state==0) _autoUpdateHisto = false;
-	else _autoUpdateHisto = true;
+	bool bstate;
+	if (state==0) bstate = false;
+	else bstate = true;
+	
+	MapperFunction *tf = getCurrentMapperFunction();
+
+	tf->SetAutoUpdateHisto(bstate);
+
 	updateHisto();
 }
 
 void TFWidget::setSingleColor() {
-	_paramsMgr->BeginSaveStateGroup("VariablesWidget::setSingleColor()");
 	QPalette palette(colorDisplay->palette());
 	QColor color = QColorDialog::getColor(palette.color(QPalette::Base), this);
 	if (!color.isValid()) return;
@@ -434,12 +401,9 @@ void TFWidget::setSingleColor() {
 	myRGB[2] = rgb[2];
 
 	_rParams->SetConstantColor(myRGB);
-	_paramsMgr->EndSaveStateGroup();
 }
 
 void TFWidget::setUsingSingleColor(int state) {
-	_paramsMgr->BeginSaveStateGroup("Set the use of a single color"
-		" in renderer");
 	if (state > 0) {
 		 _rParams->SetUseSingleColor(true);
 
@@ -448,20 +412,10 @@ void TFWidget::setUsingSingleColor(int state) {
 		_rParams->SetUseSingleColor(false);
 
 	}
-	_paramsMgr->EndSaveStateGroup();
 }
 
 void TFWidget::colorInterpChanged(int index) {
-	string varName;
-	if (_flags & COLORVAR) {
-		varName = _rParams->GetColorMapVariableName();
-	}	
-	else {
-		varName = _rParams->GetVariableName();
-	}
-	if (varName.empty()) return;
-
-	MapperFunction* tf = _rParams->GetMapperFunc(varName);
+	MapperFunction* tf = getCurrentMapperFunction();
 
 	if (index==0) {
 		tf->setColorInterpType(TFInterpolator::diverging);
@@ -476,13 +430,7 @@ void TFWidget::colorInterpChanged(int index) {
 }
 
 void TFWidget::loadTF() {
-	string varname;
-	if (_flags & COLORVAR) {
-		varname = _rParams->GetColorMapVariableName();
-	}	
-	else {
-		varname = _rParams->GetVariableName();
-	}
+	string varname = getCurrentVarName();
 	if (varname.empty()) return;
 
 	//Ignore TF's in session, for now.
@@ -495,30 +443,41 @@ void TFWidget::loadTF() {
 
 	Update(_dataMgr, _paramsMgr, _rParams);
 }
-	
 
-#ifdef DEAD
-void TFWidget::makeItRed(QLineEdit* edit) {
-	QPalette p;
-	p.setColor(QPalette::Base, QColor(255,150,150));
-	edit->setPalette(p);
+bool TFWidget::autoUpdateHisto() {
+	MapperFunction *tf = getCurrentMapperFunction();
+	cout << "autoUpdateHisto() " << tf->GetAutoUpdateHisto() << endl;
+	if (tf->GetAutoUpdateHisto()) return true;
+	else return false;
+}	
+
+string TFWidget::getCurrentVarName() {
+	string varname = "";
+	if (_flags & COLORVAR) {
+		varname = _rParams->GetColorMapVariableName();
+	}	
+	else {
+		varname = _rParams->GetVariableName();
+	}
+	return varname;
 }
 
-void TFWidget::makeItWhite(QLineEdit* edit) {
-	QPalette p;
-	p.setColor(QPalette::Base, QColor(255,255,255));
-	edit->setPalette(p);
+MapperFunction* TFWidget::getCurrentMapperFunction() {
+	string varname = getCurrentVarName();
+	MapperFunction *tf = _rParams->GetMapperFunc(varname);
+	assert(tf);
+	return tf;
 }
 
-void TFWidget::makeItGreen(QLineEdit* edit) {
-	QPalette p;
-	p.setColor(QPalette::Base, QColor(150,255,150));
-	edit->setPalette(p);
-}
+bool TFWidget::isRefreshingSmart() {
+	float dummyRange[2], currentRange[2];
+	getRange(dummyRange, currentRange);
 
-void TFWidget::makeItYellow(QLineEdit* edit) {
-	QPalette p;
-	p.setColor(QPalette::Base, QColor(255,255,150));
-	edit->setPalette(p);
+	float currentSpan = currentRange[1] - currentRange[0];
+	float savedSpan = _savedMapperValues[1] - _savedMapperValues[0];
+
+	if ((currentSpan > savedSpan) || (currentSpan < .9*savedSpan))
+		return true;
+	else 
+		return false;
 }
-#endif

--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -268,7 +268,6 @@ void TFWidget::Update(DataMgr *dataMgr,
 	updateMappingFrame();
 	updateColorInterpolation();
 	updateSliders();
-	//updateHisto();
 	updateConstColorWidgets();
 }
 
@@ -363,8 +362,6 @@ void TFWidget::setRange(double min, double max) {
 void TFWidget::updateHisto() {
 	bool buttonRequest = sender() == updateHistoButton ? true : false;
 	if (autoUpdateHisto() || buttonRequest) {
-		//MapperFunction *mf = getCurrentMapperFunction();
-		//mappingFrame->updateMapperFunction(mf);
 		bool force = true;
 		mappingFrame->RefreshHistogram(force);
 		updateMappingFrame();

--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -363,9 +363,11 @@ void TFWidget::setRange(double min, double max) {
 void TFWidget::updateHisto() {
 	bool buttonRequest = sender() == updateHistoButton ? true : false;
 	if (autoUpdateHisto() || buttonRequest) {
-		MapperFunction *mf = getCurrentMapperFunction();
-		mappingFrame->updateMapperFunction(mf);
-		mappingFrame->RefreshHistogram();
+		//MapperFunction *mf = getCurrentMapperFunction();
+		//mappingFrame->updateMapperFunction(mf);
+		bool force = true;
+		mappingFrame->RefreshHistogram(force);
+		updateMappingFrame();
 	}
 	else mappingFrame->fitToView();
 }

--- a/apps/vaporgui/TFWidget.h
+++ b/apps/vaporgui/TFWidget.h
@@ -30,10 +30,6 @@ public:
 
 		// We can map the color of our renderer to a constant value
 		CONSTANT = (1u << 1),
-
-		// PRIORITY_COLORVAR just moves the color mapped variable
-		// settings up higher in the gui for better visibility
-		PRIORITY_COLORVAR = (1u << 2)
 	};  
 
 	TFWidget(QWidget *parent=0);
@@ -77,10 +73,8 @@ private slots:
 	void setUsingSingleColor(int checkState);
 
 private:
-	void collapseAutoUpdateHistoCheckbox();
 	void collapseConstColorWidgets();
 	void showConstColorWidgets();
-	string getVariableName();
 	void connectWidgets();
 	void updateSliders();
 	void updateAutoUpdateHistoCheckbox();
@@ -88,6 +82,10 @@ private:
 	void updateMappingFrame();
 	void enableTFWidget(bool state);
 	void updateConstColorWidgets();
+	bool autoUpdateHisto();
+	string getCurrentVarName();
+	VAPoR::MapperFunction* getCurrentMapperFunction();
+	bool isRefreshingSmart();
 
 	int confirmMinRangeEdit(VAPoR::MapperFunction* tf, float* range);
 	int confirmMaxRangeEdit(VAPoR::MapperFunction* tf, float* range);
@@ -96,6 +94,7 @@ private:
 	bool _discreteColormap = false;
 	bool _textChanged = false;
 	float _myRGB[3];
+	float _savedMapperValues[2];
 
 	RenderEventRouter* _eventRouter;
 	VAPoR::ParamsMgr* _paramsMgr;

--- a/apps/vaporgui/TFWidget.h
+++ b/apps/vaporgui/TFWidget.h
@@ -85,7 +85,6 @@ private:
 	bool autoUpdateHisto();
 	string getCurrentVarName();
 	VAPoR::MapperFunction* getCurrentMapperFunction();
-	bool isRefreshingSmart();
 
 	int confirmMinRangeEdit(VAPoR::MapperFunction* tf, float* range);
 	int confirmMaxRangeEdit(VAPoR::MapperFunction* tf, float* range);

--- a/include/vapor/MapperFunction.h
+++ b/include/vapor/MapperFunction.h
@@ -124,6 +124,14 @@ public:
 	return(getMinMaxMapValue()[1]);
  };
 
+ float getMinOfUpdate() const {
+	return(getBoundsOfUpdate()[0]);
+ };
+
+ float getMaxOfUpdate() const {
+	return(getBoundsOfUpdate()[1]);
+ };
+
  //! Set both minimum and maximum mapping (histo) values
  //! \param[in] val1 minimum value
  //! \param[in] val2 maximum value
@@ -135,6 +143,32 @@ public:
 
  void setMaxMapValue(float val) {
 	setMinMaxMapValue(getMinMapValue(), val);
+ }
+
+ void setBoundsOfUpdate(float val1, float val2);
+
+ vector<double> getBoundsOfUpdate() const;
+
+ void setTimestepOfUpdate(size_t ts) {
+	SetValueDouble(
+		_timestepOfUpdateTag, 
+		"Timestep of last histogram update",
+		ts);
+ }
+
+ size_t getTimestepOfUpdate() const {
+	return (size_t)GetValueDouble(_timestepOfUpdateTag, 0.0);
+ }
+
+ void setVariableNameOfUpdate(string varName) {
+	SetValueString(
+		_variableNameOfUpdateTag,
+		"Variable name of last histogram update",
+		varName);
+ }
+
+ string getVariableNameOfUpdate() const {
+	return GetValueString(_variableNameOfUpdateTag, "");
  }
 
  //! Obtain min and max mapping (histo) values
@@ -302,7 +336,7 @@ private:
  //
  // XML tags
  //
-
+ 
  static const string _dataBoundsTag;
  static const string _opacityCompositionTag;
  static const string _opacityScaleTag;
@@ -310,6 +344,9 @@ private:
  static const string _opacityMapTag;
  static const string _autoUpdateHistoTag;
  static const string _secondaryVarMapperTag;
+ static const string _dataBoundsOfUpdateTag;
+ static const string _variableNameOfUpdateTag;
+ static const string _timestepOfUpdateTag;
 
  //
  // Size of lookup table.  Always 1<<8 currently!

--- a/include/vapor/MapperFunction.h
+++ b/include/vapor/MapperFunction.h
@@ -124,13 +124,6 @@ public:
 	return(getMinMaxMapValue()[1]);
  };
 
- float getMinOfUpdate() const {
-	return(getBoundsOfUpdate()[0]);
- };
-
- float getMaxOfUpdate() const {
-	return(getBoundsOfUpdate()[1]);
- };
 
  //! Set both minimum and maximum mapping (histo) values
  //! \param[in] val1 minimum value
@@ -143,32 +136,6 @@ public:
 
  void setMaxMapValue(float val) {
 	setMinMaxMapValue(getMinMapValue(), val);
- }
-
- void setBoundsOfUpdate(float val1, float val2);
-
- vector<double> getBoundsOfUpdate() const;
-
- void setTimestepOfUpdate(size_t ts) {
-	SetValueDouble(
-		_timestepOfUpdateTag, 
-		"Timestep of last histogram update",
-		ts);
- }
-
- size_t getTimestepOfUpdate() const {
-	return (size_t)GetValueDouble(_timestepOfUpdateTag, 0.0);
- }
-
- void setVariableNameOfUpdate(string varName) {
-	SetValueString(
-		_variableNameOfUpdateTag,
-		"Variable name of last histogram update",
-		varName);
- }
-
- string getVariableNameOfUpdate() const {
-	return GetValueString(_variableNameOfUpdateTag, "");
  }
 
  //! Obtain min and max mapping (histo) values
@@ -344,9 +311,6 @@ private:
  static const string _opacityMapTag;
  static const string _autoUpdateHistoTag;
  static const string _secondaryVarMapperTag;
- static const string _dataBoundsOfUpdateTag;
- static const string _variableNameOfUpdateTag;
- static const string _timestepOfUpdateTag;
 
  //
  // Size of lookup table.  Always 1<<8 currently!

--- a/lib/params/MapperFunction.cpp
+++ b/lib/params/MapperFunction.cpp
@@ -42,10 +42,6 @@ const string MapperFunction::_opacityMapsTag = "OpacityMaps";
 const string MapperFunction::_opacityMapTag = "OpacityMap";
 const string MapperFunction::_autoUpdateHistoTag = "AutoUpdateHisto";
 const string MapperFunction::_secondaryVarMapperTag = "SecondaryVarMapper";
-const string MapperFunction::_dataBoundsOfUpdateTag = "DataBoundsOfUpdate";
-const string MapperFunction::_variableNameOfUpdateTag = "VariableNameOfUpdate";
-const string MapperFunction::_timestepOfUpdateTag = "TimeStepOfUpdate";
-
 
 //
 // Register class with object factory!!!
@@ -320,22 +316,6 @@ void MapperFunction::makeLut(float* clut) const
     cmap->color(v).toRGB(&clut[4*i]);
     clut[4*i+3] = getOpacityValueData(v);
   }
-}
-
-void MapperFunction::setBoundsOfUpdate(float val1, float val2) {
-	vector<double> updatedBounds;
-	updatedBounds.push_back(val1);
-	updatedBounds.push_back(val2);
-	SetValueDoubleVec(_dataBoundsOfUpdateTag, "Saving the updated bounds of"
-		" the MapperFunction", updatedBounds);
-}
-
-vector<double> MapperFunction::getBoundsOfUpdate() const {
-	vector<double> updatedBounds, defaultBounds;
-	defaultBounds.push_back(std::numeric_limits<double>::lowest());
-	defaultBounds.push_back(std::numeric_limits<double>::max());
-	updatedBounds = GetValueDoubleVec(_dataBoundsOfUpdateTag, defaultBounds);
-	return updatedBounds;
 }
 
  //! Set both minimum and maximum mapping (histo) values

--- a/lib/params/MapperFunction.cpp
+++ b/lib/params/MapperFunction.cpp
@@ -42,6 +42,9 @@ const string MapperFunction::_opacityMapsTag = "OpacityMaps";
 const string MapperFunction::_opacityMapTag = "OpacityMap";
 const string MapperFunction::_autoUpdateHistoTag = "AutoUpdateHisto";
 const string MapperFunction::_secondaryVarMapperTag = "SecondaryVarMapper";
+const string MapperFunction::_dataBoundsOfUpdateTag = "DataBoundsOfUpdate";
+const string MapperFunction::_variableNameOfUpdateTag = "VariableNameOfUpdate";
+const string MapperFunction::_timestepOfUpdateTag = "TimeStepOfUpdate";
 
 
 //
@@ -317,6 +320,22 @@ void MapperFunction::makeLut(float* clut) const
     cmap->color(v).toRGB(&clut[4*i]);
     clut[4*i+3] = getOpacityValueData(v);
   }
+}
+
+void MapperFunction::setBoundsOfUpdate(float val1, float val2) {
+	vector<double> updatedBounds;
+	updatedBounds.push_back(val1);
+	updatedBounds.push_back(val2);
+	SetValueDoubleVec(_dataBoundsOfUpdateTag, "Saving the updated bounds of"
+		" the MapperFunction", updatedBounds);
+}
+
+vector<double> MapperFunction::getBoundsOfUpdate() const {
+	vector<double> updatedBounds, defaultBounds;
+	defaultBounds.push_back(std::numeric_limits<double>::lowest());
+	defaultBounds.push_back(std::numeric_limits<double>::max());
+	updatedBounds = GetValueDoubleVec(_dataBoundsOfUpdateTag, defaultBounds);
+	return updatedBounds;
 }
 
  //! Set both minimum and maximum mapping (histo) values

--- a/lib/params/ParamsBase.cpp
+++ b/lib/params/ParamsBase.cpp
@@ -175,6 +175,7 @@ vector <double> ParamsBase::GetValueDoubleVec( const string tag) const {
 vector <double> ParamsBase::GetValueDoubleVec( const string tag, 
                                                const vector<double>& defaultVal) const 
 {
+	if (tag == "PreviousDataBounds") cout << "No tag? " << !_node->HasElementDouble(tag) << " ";
 	if (! _node->HasElementDouble(tag)) return(defaultVal);
 
 	vector <double> v = _node->GetElementDouble(tag);
@@ -189,6 +190,7 @@ vector <double> ParamsBase::GetValueDoubleVec( const string tag,
 		}
 	}
 
+	if (tag == "PreviousDataBounds") cout << v[0] << " " << v[1] << endl;
 	return(v);
 }
 

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -731,8 +731,6 @@ RenderParams *RenParamsContainer::Create(string className, string name) {
 	ParamsSeparator mySep(_ssave, name);
 	mySep.SetParent(_separator);
 
-	cout << (_dataMgr==NULL) << endl;
-
 	// Create the desired class
 	//
     RenderParams *mypb = RenParamsFactory::Instance()->CreateInstance(


### PR DESCRIPTION
I believe that this employs the expected behavior.

Note: reducing the transfer function bounds with the MappingFrame's red arrows will not make a call to Update, if auto-update is enabled.  I think that the correct thing to do is to remove them, since they're redundant, and the user can control the bounds of the mapping frame via the sliders.