### PR TITLE
Implemented 573

### DIFF
--- a/apps/vaporgui/RenderHolder.cpp
+++ b/apps/vaporgui/RenderHolder.cpp
@@ -89,7 +89,7 @@ QPushButton* NewRendererDialog::_createButton(
 		QString name, 
 		int index) 
 {
-	QPushButton *button = new QPushButton(name, this);
+	QPushButton *button = new QPushButtonWithDoubleClick(name, this);
 	button->setIconSize(QSize(50,50));
 	button->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 	button->setLayoutDirection(Qt::RightToLeft);
@@ -97,6 +97,7 @@ QPushButton* NewRendererDialog::_createButton(
 	button->setProperty("index", index);
 
 	connect(button, SIGNAL(toggled(bool)), this, SLOT(_buttonChecked()));
+    connect(button, SIGNAL(doubleClicked()), this, SLOT(_buttonDoubleClicked()));
 	return button;
 }
 
@@ -135,6 +136,10 @@ void NewRendererDialog::_buttonChecked() {
 	descriptionLabel->setText(description);
 
 	_selectedRenderer = _rendererNames[index];
+}
+
+void NewRendererDialog::_buttonDoubleClicked() {
+    this->accept();
 }
 
 void NewRendererDialog::_uncheckAllButtons() {

--- a/apps/vaporgui/RenderHolder.h
+++ b/apps/vaporgui/RenderHolder.h
@@ -19,6 +19,17 @@ namespace VAPoR {
 	class ParamsMgr;
 }
 
+class QPushButtonWithDoubleClick : public QPushButton {
+    Q_OBJECT
+    using QPushButton::QPushButton;
+    void mouseDoubleClickEvent(QMouseEvent * e) {
+        emit doubleClicked();
+    }
+    
+signals:
+    void doubleClicked();
+};
+
 class NewRendererDialog : public QDialog, public Ui_NewRendererDialog {
 
 	Q_OBJECT
@@ -40,6 +51,7 @@ public:
 
 private slots:
  void _buttonChecked();
+ void _buttonDoubleClicked();
 
 private:
  void _createButtons();


### PR DESCRIPTION
QPushButtonWithDoubleClick is required to be a public class. This is an ugly workaround but it is required by Qt.