### PR TITLE
Fix for issue_583

### DIFF
--- a/apps/vaporgui/ContourAppearanceGUI.ui
+++ b/apps/vaporgui/ContourAppearanceGUI.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>403</width>
-    <height>1095</height>
+    <height>1098</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+   <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -366,6 +366,12 @@
    </item>
    <item>
     <widget class="TFWidget" name="_TFWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -393,6 +399,12 @@
    </item>
    <item>
     <widget class="ColorbarWidget" name="_ColorbarWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
        <width>0</width>

--- a/apps/vaporgui/TFWidgetGUI.ui
+++ b/apps/vaporgui/TFWidgetGUI.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>539</height>
+    <height>549</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -38,7 +38,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -47,6 +47,12 @@
       <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <attribute name="title">
        <string>Transfer Function Editor</string>
       </attribute>
@@ -185,7 +191,7 @@
             <item>
              <widget class="MappingFrame" name="mappingFrame" native="true">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>


### PR DESCRIPTION
The issue was that the MappingFrame was not being given adequate vertical space to display its full frame.  The issue is now fixed, but there has been a long-standing problem that if the MappingFrame has its vertical real-estate reduced through resizing, it will incorrectly register mouse clicks.  I'm not sure whether or not we want to tackle that one this release.