### PR TITLE
Fix barb performance by caching OpenGL calls

### DIFF
--- a/include/vapor/BarbRenderer.h
+++ b/include/vapor/BarbRenderer.h
@@ -59,6 +59,8 @@ namespace VAPoR {
 	string _currentHgtVar;				// new!
 	vector<double> _currentBoxMinExtsTex;	// new, do we need this?
 	vector<double> _currentBoxMaxExtsTex;	// new, do we need this?
+      
+    GLuint _drawList;
 	
 	// Copied from TwoDRenderer.h
 	//
@@ -106,7 +108,31 @@ namespace VAPoR {
 //! \param[in] const float endPoint[3] ending position of barb
 //! \param[in] float radius Radius of barb in voxels
 	void drawBarb(const float startPoint[3], const float endPoint[3], float radius);
-
+  
+      
+      struct {
+          vector<string> fieldVarNames;
+          string heightVarName;
+          string colorVarName;
+          size_t ts;
+          int level;
+          int lod;
+          bool useSingleColor;
+          float constantColor[3];
+          double lineThickness;
+          double opacity;
+          double lengthScale;
+          vector<long> grid;
+          vector<double> boxMin, boxMax;
+          float minMapValue;
+          float maxMapValue;
+          float colorSamples[10][3];
+          float alphaSamples[10];
+      } _cacheParams;
+      
+      bool _isCacheDirty() const;
+      void _saveCacheParams();
+      
   };
 };
 

--- a/lib/render/BarbRenderer.cpp
+++ b/lib/render/BarbRenderer.cpp
@@ -146,7 +146,6 @@ int BarbRenderer::_paintGL(){
         glCallList(_drawList);
         return 0;
     }
-    printf("dirty %i\n", ++i);
     _saveCacheParams();
     glNewList(_drawList, GL_COMPILE_AND_EXECUTE);
     

--- a/lib/render/BarbRenderer.cpp
+++ b/lib/render/BarbRenderer.cpp
@@ -45,6 +45,7 @@ BarbRenderer::BarbRenderer(
 ) : Renderer(pm, winName, dataSetName, BarbParams::GetClassType(), 
 		BarbRenderer::GetClassType(), instName, dataMgr) {
 
+    _drawList = 0;
 	_fieldVariables.clear();
 	_vectorScaleFactor = 1.0;
 }
@@ -60,15 +61,102 @@ BarbRenderer::~BarbRenderer()
 //
 int BarbRenderer::_initializeGL(){
 	//_initialized = true;
+    _drawList = glGenLists(1);
 	return(0);
 }
 
-int BarbRenderer::_paintGL(){
+void BarbRenderer::_saveCacheParams()
+{
+    BarbParams* p = (BarbParams*)GetActiveParams();
+    _cacheParams.fieldVarNames = p->GetFieldVariableNames();
+    _cacheParams.heightVarName = p->GetHeightVariableName();
+    _cacheParams.colorVarName = p->GetColorMapVariableName();
+    _cacheParams.ts = p->GetCurrentTimestep();
+    _cacheParams.level = p->GetRefinementLevel();
+    _cacheParams.lod = p->GetCompressionLevel();
+    _cacheParams.useSingleColor = p->UseSingleColor();
+    _cacheParams.lineThickness = p->GetLineThickness();
+    _cacheParams.lengthScale = p->GetLengthScale();
+    _cacheParams.grid = p->GetGrid();
+    p->GetConstantColor(_cacheParams.constantColor);
+    p->GetBox()->GetExtents(_cacheParams.boxMin, _cacheParams.boxMax);
+    
+    if (_cacheParams.useSingleColor)
+        return;
+    
+    MapperFunction *tf = p->GetMapperFunc(_cacheParams.colorVarName);
+    _cacheParams.opacity = tf->getOpacityScale();
+    _cacheParams.minMapValue = tf->getMinMapValue();
+    _cacheParams.maxMapValue = tf->getMaxMapValue();
+    for (int i = 0; i < 10; i++) {
+        float point = _cacheParams.minMapValue + i/10.f * (_cacheParams.maxMapValue - _cacheParams.minMapValue);
+        tf->rgbValue(point, _cacheParams.colorSamples[i]);
+        _cacheParams.alphaSamples[i] = tf->getOpacityValueData(point);
+    }
+}
 
+bool BarbRenderer::_isCacheDirty() const
+{
+    BarbParams *p = (BarbParams*)GetActiveParams();
+    if (_cacheParams.fieldVarNames != p->GetFieldVariableNames()) return true;
+    if (_cacheParams.heightVarName != p->GetHeightVariableName()) return true;
+    if (_cacheParams.colorVarName != p->GetColorMapVariableName()) return true;
+    if (_cacheParams.ts      != p->GetCurrentTimestep()) return true;
+    if (_cacheParams.level   != p->GetRefinementLevel()) return true;
+    if (_cacheParams.lod     != p->GetCompressionLevel()) return true;
+    if (_cacheParams.useSingleColor != p->UseSingleColor()) return true;
+    if (_cacheParams.lineThickness != p->GetLineThickness()) return true;
+    if (_cacheParams.lengthScale != p->GetLengthScale()) return true;
+    if (_cacheParams.grid != p->GetGrid()) return true;
+    
+    vector<double> min, max, contourValues;
+    p->GetBox()->GetExtents(min, max);
+    
+    if (_cacheParams.boxMin != min) return true;
+    if (_cacheParams.boxMax != max) return true;
+    
+    float constantColor[3];
+    p->GetConstantColor(constantColor);
+    if (memcmp(_cacheParams.constantColor, constantColor, sizeof(constantColor))) return true;
+    
+    if (_cacheParams.useSingleColor)
+        return false;
+    
+    MapperFunction *tf = p->GetMapperFunc(_cacheParams.colorVarName);
+    if (_cacheParams.opacity != tf->getOpacityScale()) return true;
+    if (_cacheParams.minMapValue != tf->getMinMapValue()) return true;
+    if (_cacheParams.maxMapValue != tf->getMaxMapValue()) return true;
+    
+    for (int i = 0; i < 10; i++) {
+        float point = _cacheParams.minMapValue + i/10.f * (_cacheParams.maxMapValue - _cacheParams.minMapValue);
+        float color[3];
+        tf->rgbValue(point, color);
+        if (_cacheParams.colorSamples[i][0] != color[0]) return true;
+        if (_cacheParams.colorSamples[i][1] != color[1]) return true;
+        if (_cacheParams.colorSamples[i][2] != color[2]) return true;
+        if (_cacheParams.alphaSamples[i] != tf->getOpacityValueData(point)) return true;
+    }
+    
+    return false;
+}
+
+int BarbRenderer::_paintGL(){
+    static int i = 0;
+    if (!_isCacheDirty()) {
+        glCallList(_drawList);
+        return 0;
+    }
+    printf("dirty %i\n", ++i);
+    _saveCacheParams();
+    glNewList(_drawList, GL_COMPILE_AND_EXECUTE);
+    
 	// Set up the variable data required, while determining data 
 	// extents to use in rendering
 	//
 	vector <Grid *> varData;
+    float vectorLengthScale;
+    string hname;
+    string colorVar;
 
 	BarbParams* bParams = (BarbParams*) GetActiveParams();
 	size_t ts = bParams->GetCurrentTimestep();
@@ -95,13 +183,13 @@ int BarbRenderer::_paintGL(){
 		);
 
 
-	if(rc<0) return(rc);
+	if(rc<0) goto RETURN;
 	varData.push_back(NULL);
 	varData.push_back(NULL);
 
 	// Get grids for our height variable
 	//
-	string hname = bParams->GetHeightVariableName();
+    hname = bParams->GetHeightVariableName();
 	if (! hname.empty()) {
 		Grid *sg = NULL;
 		int rc = DataMgrUtils::GetGrids(
@@ -112,14 +200,14 @@ int BarbRenderer::_paintGL(){
 			for (int i = 0; i<varData.size(); i++){
 				if (varData[i]) _dataMgr->UnlockGrid(varData[i]);
 			}
-			return(rc);
+			goto RETURN;
 		}
 		varData[3] = sg;
 	}
 
 	// Get grids for our auxillary variables
 	//
-	string colorVar = bParams->GetColorMapVariableName();
+    colorVar = bParams->GetColorMapVariableName();
 	if (!bParams->UseSingleColor() && !colorVar.empty()) {
 		Grid *sg;
 		int rc = DataMgrUtils::GetGrids(
@@ -130,12 +218,12 @@ int BarbRenderer::_paintGL(){
 			for (int i = 0; i<varData.size(); i++){
 				if (varData[i]) _dataMgr->UnlockGrid(varData[i]);
 			}
-			return(rc);
+			goto RETURN;
 		}
 		varData[4] = sg;
 	}
 	
-	float vectorLengthScale = bParams->GetLengthScale() * _vectorScaleFactor;
+	vectorLengthScale = bParams->GetLengthScale() * _vectorScaleFactor;
 	
 	//
 	//Perform OpenGL rendering of barbs
@@ -148,6 +236,9 @@ int BarbRenderer::_paintGL(){
 	for (int i = 0; i<varData.size(); i++){
 		if (varData[i]) _dataMgr->UnlockGrid(varData[i]);
 	}
+    
+RETURN:
+    glEndList();
 	return(rc);
 }
 


### PR DESCRIPTION
#604 Barb renderer should be rewritten however this fixes the performance issues for now. Since the performance bottleneck was the CPU, I record the gl calls and only refresh them if the params change. 

50x50 barbs will render seamlessly:
![barb](https://user-images.githubusercontent.com/2772687/38661635-cdf298d6-3dee-11e8-9535-c83d2be595c8.gif)

