### PR TITLE
Fixed issue_626

### DIFF
--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -299,6 +299,14 @@ void TFWidget::Update(DataMgr *dataMgr,
 	_dataMgr = dataMgr;
 	_rParams = rParams;
 
+	if (getCurrentVarName() == "") {
+		setEnabled(false);
+		return;
+	}
+	else {
+		setEnabled(true);
+	}
+
 	updateAutoUpdateHistoCheckbox();
 	updateMappingFrame();
 	updateColorInterpolation();


### PR DESCRIPTION
Colormaps were being created for variables named with the empty string.