### PR TITLE
Stas

### DIFF
--- a/include/vapor/VDC_c.h
+++ b/include/vapor/VDC_c.h
@@ -110,6 +110,7 @@ int  VDC_CoordVarExists(const VDC *p, const char *varname);
 int  VDC_GetCRatios(const VDC *p, const char *varname, size_t **ratios, int *count);
 int  VDC_GetCRatiosCount(const VDC *p, const char *varname);
 
+int  VDC_GetVarDimLens(const VDC*p, const char *varname, int spatial, size_t **lens, int *count);
 int  VDC_GetVarDimNames(const VDC*p, const char *varname, int spatial, char ***names, int *count);
 int  VDC_GetVarCoordVars(const VDC *p, const char *varname, int spatial, char ***names, int *count);
 

--- a/lib/vdc/DC.cpp
+++ b/lib/vdc/DC.cpp
@@ -728,6 +728,9 @@ int DC::_getVarTemplate(string varname, int level, int lod, T *data) {
 	return(0);
 }
 
+template int DC::_getVarTemplate<float>(string varname, int level, int lod, float *data);
+template int DC::_getVarTemplate<int>  (string varname, int level, int lod, int   *data);
+
 
 template <class T>
 int DC::_getVarTemplate(
@@ -744,6 +747,10 @@ int DC::_getVarTemplate(
 
 	return(rc);
 }
+
+template int DC::_getVarTemplate<float>(size_t ts, string varname, int level, int lod, float *data);
+template int DC::_getVarTemplate<int>  (size_t ts, string varname, int level, int lod, int   *data);
+
 
 bool DC::GetVarDimensions(
 	string varname, bool spatial,

--- a/lib/vdc/VDC_c.cpp
+++ b/lib/vdc/VDC_c.cpp
@@ -458,33 +458,33 @@ const char *VDC_GetErrMsg()
 void VDC_FreeStringArray(char ***str, int *count)
 {
 	for (int i = 0; i < *count; i++)
-		delete (*str)[i];
-	delete *str;
+		delete [] (*str)[i];
+	delete [] *str;
 	*str = 0;
 	*count = 0;
 }
 
 void VDC_FreeString(char **str)
 {
-	delete *str;
+	delete [] *str;
 	*str = 0;
 }
 
 void VDC_FreeLongArray(long **data)
 {
-	delete *data;
+	delete [] *data;
 	*data = 0;
 }
 
 void VDC_FreeDoubleArray(double **data)
 {
-	delete *data;
+	delete [] *data;
 	*data = 0;
 }
 
 void VDC_FreeSize_tArray(size_t **data)
 {
-	delete *data;
+	delete [] *data;
 	*data = 0;
 }
 

--- a/lib/vdc/VDC_c.cpp
+++ b/lib/vdc/VDC_c.cpp
@@ -252,6 +252,15 @@ int  VDC_GetCRatiosCount(const VDC *p, const char *varname)
 }
 
 
+int  VDC_GetVarDimLens(const VDC*p, const char *varname, int spatial, size_t **lens, int *count)
+{
+	VDC_DEBUG_called(); 
+	vector<size_t> lens_v;
+	bool ret = p->GetVarDimLens(string(varname), spatial, lens_v);
+	if (ret)
+		_size_tVectorToCArray(lens_v, lens, count);
+	return ret;
+}
 
 int  VDC_GetVarDimNames(const VDC*p, const char *varname, int spatial, char ***names, int *count)
 {


### PR DESCRIPTION
Fixes/Changes:

- Fixed mismatched new[] / delete[]
- Added GetVarDimLens to VDC c interface
- Template pattern definitions for DC::_getVarTemplate were missing. This would could cause the linker to fail depending on how it was compiled.