### PR TITLE
Fix for issue #690

### DIFF
--- a/apps/vaporgui/SettingsEventRouter.cpp
+++ b/apps/vaporgui/SettingsEventRouter.cpp
@@ -442,6 +442,7 @@ void SettingsEventRouter::_restoreDefaults() {
 	delete newParams;
 	
 	_saveSettings();
+	_updateTab();
 
 	paramsMgr->EndSaveStateGroup();
 }


### PR DESCRIPTION
Fix for #690.  

We're now forcing _updateTab() after restoring default parameters in SettingsEv…entRouter