### PR TITLE
Fixed 692.

### DIFF
--- a/apps/vaporgui/GeometryWidget.cpp
+++ b/apps/vaporgui/GeometryWidget.cpp
@@ -290,7 +290,7 @@ void GeometryWidget::updateCopyCombo() {
 	
 				std::vector<string> renNames;
 				renNames = _paramsMgr->GetRenderParamInstances(visNames[i],
-																typeNames[j]
+					_dataSetNames[ii], typeNames[j]
 				);
 	
 				for (int k=0; k<renNames.size(); k++) {


### PR DESCRIPTION
Problem was in GeometryWidget's use of ParamsMgr::GetRenderParamInstances(),
not in ParamsMgr::GetRenderParamInstances() itself.