### PR TITLE
Issue501

### DIFF
--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -53,8 +53,9 @@ set (SRCS
 	QRange.cpp
 	QSinglePoint.cpp
 	QIntValidatorWithFixup.cpp
-    FileOperationChecker.cpp
+	FileOperationChecker.cpp
 	Combo.cpp
+	windowsUtils.cpp
 
 	# Need to include all files that request .ui files
 	TwoDSubtabs.h
@@ -75,6 +76,7 @@ set (SRCS
 
 	MainForm.h
 	VizWinMgr.h
+	windowsUtils.h
 )
 
 set (UIS 

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -2212,14 +2212,16 @@ void MainForm::launchSeedMe(){
     _seedMe->Initialize();
 }
 
+#include <stdio.h>
+#define LOG(...) { std::fprintf(f, __VA_ARGS__); std::fflush(f); }
+
 void MainForm::installCLITools(){
 	vector<string> pths;
-	string home = GetAppPath("VAPOR","home", pths, true);
-    
     QMessageBox box;
     box.addButton(QMessageBox::Ok);
     
 #ifdef Darwin
+	string home = GetAppPath("VAPOR", "home", pths, true);
     string path = home + "/MacOS";
     home.erase(home.size() - strlen("Contents/"), strlen("Contents/"));
     
@@ -2242,26 +2244,57 @@ void MainForm::installCLITools(){
     
 #ifdef WIN32
 	HKEY key;
-	long error, errorClose;
+	long error;
+	long errorClose;
 	bool pathWasModified = false;
+	string errorFunc;
+	std::FILE *f = std::fopen("log.txt", "w");
+	Windows_setLog(f);
+	LOG("%i Log Start\n", __LINE__);
+	string home = GetAppPath("VAPOR", "", pths, true);
+	LOG("home = \"%s\"\n", home.c_str());
 
+	LOG("%i Opening registry...", __LINE__);
+	errorFunc = "OpenRegistry";
 	error = Windows_OpenRegistry(WINDOWS_HKEY_CURRENT_USER, "Environment", key);
-	if (error != WINDOWS_SUCCESS) {
+	LOG("done...");
+	if (error == WINDOWS_SUCCESS) {
+		LOG("success\n");
 		string path;
-		error = Windows_GetRegistryString(key, "Path", path, "");
-		if (error != WINDOWS_SUCCESS && path.find(home) == std::string::npos) {
-			if (path.length() > 0)
-				path += ";";
-			path += home;
-			error = Windows_SetRegistryString(key, "Path", path);
-			if (error != WINDOWS_SUCCESS)
-				pathWasModified = true;
+		LOG("%i Reading Path...", __LINE__);
+		errorFunc = "GetRegistryString";
+		error = Windows_GetRegistryString(key, "TMP", path, "");
+		LOG("done...");
+		if (error == WINDOWS_SUCCESS) {
+			LOG("success\n");
+			LOG("\"%s\".find(\"%s\") = %i (%s)\n", path.c_str(), home.c_str(), path.find(home), path.find(home) == std::string::npos ? "true" : "false");
+			if (path.find(home) == std::string::npos) {
+				LOG("%i Adding home to path\n", __LINE__);
+				if (path.length() > 0)
+					path += ";";
+				path += home;
+				errorFunc = "SetRegistryString";
+				LOG("%i Writing Registry...", __LINE__);
+				error = Windows_SetRegistryString(key, "Path", path);
+				LOG("done...");
+				if (error == WINDOWS_SUCCESS) {
+					LOG("%i Path Modified\n", __LINE__);
+					pathWasModified = true;
+				}
+				else {
+					LOG("failure\n");
+				}
+			}
+		} else {
+			LOG("failure[%li]: ", error);
+			LOG("%s\n", Windows_GetErrorString(error).c_str());
 		}
 
 		errorClose = Windows_CloseRegistry(key);
 	}
 	
-	if (error | errorClose == WINDOWS_SUCCESS) {
+	std::fclose(f);
+	if (error == WINDOWS_SUCCESS && errorClose == WINDOWS_SUCCESS) {
 		box.setIcon(QMessageBox::Information);
 		if (pathWasModified)
 			box.setText("Vapor conversion utilities were added to your path");
@@ -2270,9 +2303,9 @@ void MainForm::installCLITools(){
 	} else {
 		box.setIcon(QMessageBox::Critical);
 		box.setText("Unable to set environmental variables");
-		string errString;
-		if (error      != WINDOWS_SUCCESS) errString += Windows_GetErrorString(error) + "\n";
-		if (errorClose != WINDOWS_SUCCESS) errString += Windows_GetErrorString(errorClose);
+		string errString = "";
+		if (error      != WINDOWS_SUCCESS) errString += errorFunc + ": " + Windows_GetErrorString(error) + "\n";
+		if (errorClose != WINDOWS_SUCCESS) errString += "CloseRegistry: " + Windows_GetErrorString(errorClose);
 		box.setInformativeText(QString::fromStdString(errString));
 	}
 #endif

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -56,6 +56,7 @@
 #include "ErrorReporter.h"
 #include "MainForm.h"
 #include "FileOperationChecker.h"
+#include "windowsUtils.h"
 
 //Following shortcuts are provided:
 // CTRL_N: new session
@@ -2240,8 +2241,40 @@ void MainForm::installCLITools(){
 #endif
     
 #ifdef WIN32
-    box.setText("Windows");
-    box.setIcon(QMessageBox::Critical);
+	HKEY key;
+	long error, errorClose;
+	bool pathWasModified = false;
+
+	error = Windows_OpenRegistry(WINDOWS_HKEY_CURRENT_USER, "Environment", key);
+	if (error != WINDOWS_SUCCESS) {
+		string path;
+		error = Windows_GetRegistryString(key, "PATH", path, "");
+		if (error != WINDOWS_SUCCESS && path.find(home) == std::string::npos) {
+			if (path.length() > 0)
+				path += ";";
+			path += home;
+			error = Windows_SetRegistryString(key, "PATH", path);
+			if (error != WINDOWS_SUCCESS)
+				pathWasModified = true;
+		}
+
+		errorClose = Windows_CloseRegistry(key);
+	}
+	
+	if (error | errorClose == WINDOWS_SUCCESS) {
+		box.setIcon(QMessageBox::Information);
+		if (pathWasModified)
+			box.setText("Vapor conversion utilities were added to your path");
+		else
+			box.setText("Your path is properly configured");
+	} else {
+		box.setIcon(QMessageBox::Critical);
+		box.setText("Unable to set environmental variables");
+		string errString;
+		if (error      != WINDOWS_SUCCESS) errString += Windows_GetErrorString(error) + "\n";
+		if (errorClose != WINDOWS_SUCCESS) errString += Windows_GetErrorString(errorClose);
+		box.setInformativeText(QString::fromStdString(errString));
+	}
 #endif
 
 	box.exec();

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -2212,8 +2212,6 @@ void MainForm::launchSeedMe(){
     _seedMe->Initialize();
 }
 
-#include <stdio.h>
-#define LOG(...) { std::fprintf(f, __VA_ARGS__); std::fflush(f); }
 
 void MainForm::installCLITools(){
 	vector<string> pths;
@@ -2247,53 +2245,36 @@ void MainForm::installCLITools(){
 	long error;
 	long errorClose;
 	bool pathWasModified = false;
-	string errorFunc;
-	std::FILE *f = std::fopen("log.txt", "w");
-	Windows_setLog(f);
-	LOG("%i Log Start\n", __LINE__);
 	string home = GetAppPath("VAPOR", "", pths, true);
-	LOG("home = \"%s\"\n", home.c_str());
 
-	LOG("%i Opening registry...", __LINE__);
-	errorFunc = "OpenRegistry";
 	error = Windows_OpenRegistry(WINDOWS_HKEY_CURRENT_USER, "Environment", key);
-	LOG("done...");
 	if (error == WINDOWS_SUCCESS) {
-		LOG("success\n");
 		string path;
-		LOG("%i Reading Path...", __LINE__);
-		errorFunc = "GetRegistryString";
-		error = Windows_GetRegistryString(key, "TMP", path, "");
-		LOG("done...");
+		error = Windows_GetRegistryString(key, "Path", path, "");
+		if (error == WINDOWS_ERROR_FILE_NOT_FOUND) {
+			error = WINDOWS_SUCCESS;
+			path = "";
+		}
 		if (error == WINDOWS_SUCCESS) {
-			LOG("success\n");
-			LOG("\"%s\".find(\"%s\") = %i (%s)\n", path.c_str(), home.c_str(), path.find(home), path.find(home) == std::string::npos ? "true" : "false");
-			if (path.find(home) == std::string::npos) {
-				LOG("%i Adding home to path\n", __LINE__);
+			bool alreadyExists = false;
+			size_t index;
+			if      (path.find(";" + home + ";") != std::string::npos) alreadyExists = true;
+			else if ((index = path.find(";" + home)) != std::string::npos && index + home.length() + 1 == path.length()) alreadyExists = true;
+			else if ((index = path.find(home + ";")) != std::string::npos && index == 0) alreadyExists = true;
+			else if (path == home) alreadyExists = true;
+
+			if (!alreadyExists) {
 				if (path.length() > 0)
 					path += ";";
 				path += home;
-				errorFunc = "SetRegistryString";
-				LOG("%i Writing Registry...", __LINE__);
 				error = Windows_SetRegistryString(key, "Path", path);
-				LOG("done...");
-				if (error == WINDOWS_SUCCESS) {
-					LOG("%i Path Modified\n", __LINE__);
+				if (error == WINDOWS_SUCCESS)
 					pathWasModified = true;
-				}
-				else {
-					LOG("failure\n");
-				}
 			}
-		} else {
-			LOG("failure[%li]: ", error);
-			LOG("%s\n", Windows_GetErrorString(error).c_str());
 		}
-
 		errorClose = Windows_CloseRegistry(key);
 	}
 	
-	std::fclose(f);
 	if (error == WINDOWS_SUCCESS && errorClose == WINDOWS_SUCCESS) {
 		box.setIcon(QMessageBox::Information);
 		if (pathWasModified)
@@ -2304,7 +2285,7 @@ void MainForm::installCLITools(){
 		box.setIcon(QMessageBox::Critical);
 		box.setText("Unable to set environmental variables");
 		string errString = "";
-		if (error      != WINDOWS_SUCCESS) errString += errorFunc + ": " + Windows_GetErrorString(error) + "\n";
+		if (error      != WINDOWS_SUCCESS) errString += Windows_GetErrorString(error) + "\n";
 		if (errorClose != WINDOWS_SUCCESS) errString += "CloseRegistry: " + Windows_GetErrorString(errorClose);
 		box.setInformativeText(QString::fromStdString(errString));
 	}

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -2248,12 +2248,12 @@ void MainForm::installCLITools(){
 	error = Windows_OpenRegistry(WINDOWS_HKEY_CURRENT_USER, "Environment", key);
 	if (error != WINDOWS_SUCCESS) {
 		string path;
-		error = Windows_GetRegistryString(key, "PATH", path, "");
+		error = Windows_GetRegistryString(key, "Path", path, "");
 		if (error != WINDOWS_SUCCESS && path.find(home) == std::string::npos) {
 			if (path.length() > 0)
 				path += ";";
 			path += home;
-			error = Windows_SetRegistryString(key, "PATH", path);
+			error = Windows_SetRegistryString(key, "Path", path);
 			if (error != WINDOWS_SUCCESS)
 				pathWasModified = true;
 		}

--- a/apps/vaporgui/windowsUtils.cpp
+++ b/apps/vaporgui/windowsUtils.cpp
@@ -6,13 +6,6 @@
 #include <codecvt>
 #include "windowsUtils.h"
 
-#include <stdio.h>
-FILE *f = NULL;
-void Windows_setLog(FILE *f_)
-{
-	f = f_;
-}
-
 LONG Windows_OpenRegistry(HKEY root, std::string keyName, HKEY &key)
 {
 	return RegOpenKeyEx(root, TEXT(keyName.c_str()), 0, KEY_ALL_ACCESS, &key);
@@ -38,13 +31,9 @@ LONG Windows_GetRegistryString(HKEY hKey, const std::string &strValueName, std::
 LONG Windows_SetRegistryString(HKEY hKey, const std::string &strValueName, const std::string &strValue)
 {
 	LONG error;
-	std::fprintf(f, "utils::write..."); std::fflush(f);
 	error = RegSetValueEx(hKey, strValueName.c_str(), 0, REG_SZ, (LPBYTE)strValue.c_str(), strValue.length());
-	std::fprintf(f, "done...\n"); std::fflush(f);
 	if (error == ERROR_SUCCESS) {
-		std::fprintf(f, "utils::broadcast..."); std::fflush(f);
 		BroadcastSystemMessage(0, 0, WM_SETTINGCHANGE, 0, (LPARAM)TEXT("Environment"));
-		std::fprintf(f, "done...\n"); std::fflush(f);
 	}
 	return error;
 }

--- a/apps/vaporgui/windowsUtils.cpp
+++ b/apps/vaporgui/windowsUtils.cpp
@@ -1,0 +1,64 @@
+#ifdef WIN32
+#include <Windows.h>
+#include <string>
+#include <sstream>
+#include <locale>
+#include <codecvt>
+#include "windowsUtils.h"
+
+LONG Windows_OpenRegistry(HKEY root, std::string keyName, HKEY &key)
+{
+	return RegOpenKeyEx(root, TEXT(keyName.c_str()), 0, KEY_ALL_ACCESS, &key);
+}
+
+LONG Windows_CloseRegistry(HKEY key)
+{
+	return RegCloseKey(key);
+}
+
+LONG Windows_GetRegistryString(HKEY hKey, const std::string &strValueName, std::string &strValue, const std::string &strDefaultValue)
+{
+	strValue = strDefaultValue;
+	CHAR szBuffer[8192];
+	DWORD dwBufferSize = sizeof(szBuffer);
+	LONG error;
+	error = RegQueryValueEx(hKey, strValueName.c_str(), 0, NULL, (LPBYTE)szBuffer, &dwBufferSize);
+	if (error == ERROR_SUCCESS)
+		strValue = szBuffer;
+	return error;
+}
+
+LONG Windows_SetRegistryString(HKEY hKey, const std::string &strValueName, const std::string &strValue)
+{
+	LONG error;
+	error = RegSetValueEx(hKey, strValueName.c_str(), 0, REG_SZ, (LPBYTE)strValue.c_str(), strValue.length());
+	if (error == ERROR_SUCCESS)
+		BroadcastSystemMessage(0, 0, WM_SETTINGCHANGE, 0, (LPARAM)TEXT("Environment"));
+	return error;
+}
+
+std::string Windows_GetErrorString(LONG errorCode)
+{
+	LPVOID lpMsgBuf;
+
+	FormatMessage(
+		FORMAT_MESSAGE_ALLOCATE_BUFFER |
+		FORMAT_MESSAGE_FROM_SYSTEM |
+		FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL,
+		errorCode,
+		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+		(LPTSTR)&lpMsgBuf,
+		0, NULL);
+
+	std::wstringstream wss;
+	wss << (LPCTSTR)lpMsgBuf;
+	std::wstring ws = wss.str();
+
+	std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+	std::string s = converter.to_bytes(ws);
+	LocalFree(lpMsgBuf);
+
+	return s;
+}
+#endif

--- a/apps/vaporgui/windowsUtils.cpp
+++ b/apps/vaporgui/windowsUtils.cpp
@@ -6,6 +6,13 @@
 #include <codecvt>
 #include "windowsUtils.h"
 
+#include <stdio.h>
+FILE *f = NULL;
+void Windows_setLog(FILE *f_)
+{
+	f = f_;
+}
+
 LONG Windows_OpenRegistry(HKEY root, std::string keyName, HKEY &key)
 {
 	return RegOpenKeyEx(root, TEXT(keyName.c_str()), 0, KEY_ALL_ACCESS, &key);
@@ -31,9 +38,14 @@ LONG Windows_GetRegistryString(HKEY hKey, const std::string &strValueName, std::
 LONG Windows_SetRegistryString(HKEY hKey, const std::string &strValueName, const std::string &strValue)
 {
 	LONG error;
+	std::fprintf(f, "utils::write..."); std::fflush(f);
 	error = RegSetValueEx(hKey, strValueName.c_str(), 0, REG_SZ, (LPBYTE)strValue.c_str(), strValue.length());
-	if (error == ERROR_SUCCESS)
+	std::fprintf(f, "done...\n"); std::fflush(f);
+	if (error == ERROR_SUCCESS) {
+		std::fprintf(f, "utils::broadcast..."); std::fflush(f);
 		BroadcastSystemMessage(0, 0, WM_SETTINGCHANGE, 0, (LPARAM)TEXT("Environment"));
+		std::fprintf(f, "done...\n"); std::fflush(f);
+	}
 	return error;
 }
 

--- a/apps/vaporgui/windowsUtils.h
+++ b/apps/vaporgui/windowsUtils.h
@@ -5,6 +5,7 @@
 #include <Windows.h>
 
 #define WINDOWS_SUCCESS ERROR_SUCCESS
+#define WINDOWS_ERROR_FILE_NOT_FOUND ERROR_FILE_NOT_FOUND
 #define WINDOWS_HKEY_CLASSES_ROOT HKEY_CLASSES_ROOT
 #define WINDOWS_HKEY_CURRENT_CONFIG HKEY_CURRENT_CONFIG
 #define WINDOWS_HKEY_CURRENT_USER HKEY_CURRENT_USER
@@ -16,8 +17,6 @@ LONG Windows_CloseRegistry(HKEY key);
 LONG Windows_GetRegistryString(HKEY hKey, const std::string &strValueName, std::string &strValue, const std::string &strDefaultValue);
 LONG Windows_SetRegistryString(HKEY hKey, const std::string &strValueName, const std::string &strValue);
 std::string Windows_GetErrorString(LONG errorCode);
-
-void Windows_setLog(FILE *f);
 
 #endif
 #endif

--- a/apps/vaporgui/windowsUtils.h
+++ b/apps/vaporgui/windowsUtils.h
@@ -1,0 +1,21 @@
+#ifndef WINDOWS_UTILS_H
+#define WINDOWS_UTILS_H
+#ifdef WIN32
+
+#include <Windows.h>
+
+#define WINDOWS_SUCCESS ERROR_SUCCESS
+#define WINDOWS_HKEY_CLASSES_ROOT HKEY_CLASSES_ROOT
+#define WINDOWS_HKEY_CURRENT_CONFIG HKEY_CURRENT_CONFIG
+#define WINDOWS_HKEY_CURRENT_USER HKEY_CURRENT_USER
+#define WINDOWS_HKEY_LOCAL_MACHINE HKEY_LOCAL_MACHINE
+#define WINDOWS_HKEY_USERS HKEY_USERS
+
+LONG Windows_OpenRegistry(HKEY root, std::string keyName, HKEY &key);
+LONG Windows_CloseRegistry(HKEY key);
+LONG Windows_GetRegistryString(HKEY hKey, const std::string &strValueName, std::string &strValue, const std::string &strDefaultValue);
+LONG Windows_SetRegistryString(HKEY hKey, const std::string &strValueName, const std::string &strValue);
+std::string Windows_GetErrorString(LONG errorCode);
+
+#endif
+#endif

--- a/apps/vaporgui/windowsUtils.h
+++ b/apps/vaporgui/windowsUtils.h
@@ -17,5 +17,7 @@ LONG Windows_GetRegistryString(HKEY hKey, const std::string &strValueName, std::
 LONG Windows_SetRegistryString(HKEY hKey, const std::string &strValueName, const std::string &strValue);
 std::string Windows_GetErrorString(LONG errorCode);
 
+void Windows_setLog(FILE *f);
+
 #endif
 #endif

--- a/include/vapor/CMakeConfig.h
+++ b/include/vapor/CMakeConfig.h
@@ -9,7 +9,7 @@ extern const char VERSION_RC[];
 extern const char VERSION_DATE[];
 extern const char VERSION_COMMIT[];
 extern const char VERSION_STRING[];
-extern const char VERSION_FULL[];
+extern const char VERSION_STRING_FULL[];
 
 extern const char SOURCE_DIR[];
 


### PR DESCRIPTION
## Why this took so long:

```
LONG WINAPI RegQueryValueEx(
  _In_        HKEY    hKey,
  _In_opt_    LPCTSTR lpValueName,
  _Reserved_  LPDWORD lpReserved,
  _Out_opt_   LPDWORD lpType,
  _Out_opt_   LPBYTE  lpData,
  _Inout_opt_ LPDWORD lpcbData
);
```

### Lets find what lpValueName is:

```
typedef LPWCH LPTCH, PTCH;
typedef LPCWCH LPCTCH, PCTCH;
typedef LPWSTR PTSTR, LPTSTR;
typedef LPCWSTR PCTSTR, LPCTSTR;      <------
typedef LPUWSTR PUTSTR, LPUTSTR;
typedef LPCUWSTR PCUTSTR, LPCUTSTR;
typedef LPWSTR LP;
typedef PZZWSTR PZZTSTR;
typedef PCZZWSTR PCZZTSTR;
typedef PUZZWSTR PUZZTSTR;
typedef PCUZZWSTR PCUZZTSTR;
typedef PZPWSTR PZPTSTR;
typedef PNZWCH PNZTCH;
typedef PCNZWCH PCNZTCH;
typedef PUNZWCH PUNZTCH;
typedef PCUNZWCH PCUNZTCH;
```

```
typedef _Null_terminated_ WCHAR *NWPSTR, *LPWSTR, *PWSTR;
typedef _Null_terminated_ PWSTR *PZPWSTR;
typedef _Null_terminated_ CONST PWSTR *PCZPWSTR;
typedef _Null_terminated_ WCHAR UNALIGNED *LPUWSTR, *PUWSTR;
typedef _Null_terminated_ CONST WCHAR *LPCWSTR, *PCWSTR;            <--------
typedef _Null_terminated_ PCWSTR *PZPCWSTR;
typedef _Null_terminated_ CONST PCWSTR *PCZPCWSTR;
typedef _Null_terminated_ CONST WCHAR UNALIGNED *LPCUWSTR, *PCUWSTR;
```

```
typedef wchar_t WCHAR;
```

Except it really expects an std::string. But not really this depends on the locale the build is configured for so sometimes it might expect an std::wstring.

# 🥇 Microsoft 🥇 