### PR TITLE
suppress warning -Woverloaded-virtual

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 
 # compiler warning flags
 if (NOT WIN32)
-  SET( COMPILE_FLAGS "-Wall -Wno-sign-compare")
+  SET( COMPILE_FLAGS "-Wall -Wno-sign-compare -Wno-overloaded-virtual")
   SET( CMAKE_CXX_FLAGS  "${COMPILE_FLAGS}" )
   SET( CMAKE_C_FLAGS  "${COMPILE_FLAGS}" )
 endif()


### PR DESCRIPTION
This PR suppress the `overloaded_virtual_warning` that we are not going to fix for this release...