### PR TITLE
Enabled anti-aliasing for contours

### DIFF
--- a/lib/render/ContourRenderer.cpp
+++ b/lib/render/ContourRenderer.cpp
@@ -151,6 +151,11 @@ int ContourRenderer::_buildCache()
         return -1;
     }
     
+    glEnable(GL_LINE_SMOOTH);
+    glEnable(GL_BLEND);
+    glDepthMask(GL_FALSE);
+    glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
+    
     Grid::ConstCellIterator it = grid->ConstCellBegin(_cacheParams.boxMin, _cacheParams.boxMax);
     Grid::ConstCellIterator end = grid->ConstCellEnd();
     for (; it != end; ++it)


### PR DESCRIPTION
## Without anti-aliasing
(This is exacerbated by aliasing from github resizing the image)

![screen shot 2018-05-03 at 2 22 37 pm](https://user-images.githubusercontent.com/2772687/39601273-a79524b4-4ede-11e8-9729-5faa16c4d20f.png)


## With anti-aliasing
![screen shot 2018-05-03 at 2 22 45 pm](https://user-images.githubusercontent.com/2772687/39601278-a98d436e-4ede-11e8-86e2-2e1811faa455.png)
