### PR TITLE
Change plot utility point selection behavior

### DIFF
--- a/apps/vaporgui/Plot.cpp
+++ b/apps/vaporgui/Plot.cpp
@@ -625,11 +625,10 @@ void Plot::_timeTabPlotClicked()
         {
             VAPoR::Grid* grid = dataMgr->GetVariable( t, enabledVars[v], 
                                 refinementLevel, compressLevel ); 
-            float missingVal  = grid->GetMissingValue();
             if( grid )
             {
                 float fieldVal    = grid->GetValue( singlePt );
-                if( fieldVal     != missingVal )
+                if( fieldVal     != grid->GetMissingValue() )
                     seq.push_back( fieldVal );
                 else
                     seq.push_back( std::nanf("1") );

--- a/apps/vaporgui/Plot.cpp
+++ b/apps/vaporgui/Plot.cpp
@@ -616,10 +616,11 @@ void Plot::_timeTabPlotClicked()
         {
             VAPoR::Grid* grid = dataMgr->GetVariable( t, enabledVars[v], 
                                 refinementLevel, compressLevel ); 
+            float missingVal  = grid->GetMissingValue();
             if( grid )
             {
                 float fieldVal    = grid->GetValue( singlePt );
-                if( fieldVal     != grid->GetMissingValue() )
+                if( fieldVal     != missingVal )
                     seq.push_back( fieldVal );
                 else
                     seq.push_back( std::nanf("1") );

--- a/apps/vaporgui/Plot.cpp
+++ b/apps/vaporgui/Plot.cpp
@@ -237,29 +237,38 @@ void Plot::Update()
         timeTabSinglePoint->SetExtents( min, max);
 
         std::vector<double> pt = plotParams->GetPoint1();
-        if( pt.size() == axes.size() )
-            spaceTabP1->SetValue( pt );
-        else
-        {
-            spaceTabP1->SetValue(  min );
-            plotParams->SetPoint1( min );
-        }
+        if( pt.size() == 0 )   // 1st time
+            pt = min;
+        else if( pt.size() == 2 && axes.size() == 3 )
+            pt.push_back( min.at(2) );
+        else if( pt.size() == 3 && axes.size() == 2 )
+            pt.pop_back(); 
+        spaceTabP1->SetValue(  pt );
+        plotParams->SetPoint1( pt );
+
         pt = plotParams->GetPoint2();
-        if( pt.size() == axes.size() )
-            spaceTabP2->SetValue( pt );
-        else
-        {
-            spaceTabP2->SetValue(  max );
-            plotParams->SetPoint2( max );
-        }
+        if( pt.size() == 0 ) 
+            pt = max;
+        else if( pt.size() == 2 && axes.size() == 3 )
+            pt.push_back( max.at(2) );
+        else if( pt.size() == 3 && axes.size() == 2 )
+            pt.pop_back();
+        spaceTabP2->SetValue(  pt );
+        plotParams->SetPoint2( pt );
+
+    
         pt = plotParams->GetSinglePoint( );
-        if( pt.size() == axes.size() )
-            timeTabSinglePoint->SetValue( pt );
-        else
+        if( pt.size() == 0 )
         {
-            timeTabSinglePoint->SetValue( min );
-            plotParams->SetSinglePoint(   min );
+            for( size_t i = 0; i < min.size(); i++ )
+                pt.push_back( min.at(i) + 0.5 * (max.at(i) - min.at(i)) );
         }
+        else if( pt.size() == 2 && axes.size() == 3 )
+            pt.push_back( min.at(2) + 0.5 * (max.at(2) - min.at(2)) );
+        else if( pt.size() == 3 && axes.size() == 2 )
+            pt.pop_back();
+        timeTabSinglePoint->SetValue( pt );
+        plotParams->SetSinglePoint(   pt );
     }
 
     // Update LOD, Refinement


### PR DESCRIPTION
This PR changes the behavior of point selectors. 
With the new behavior, the X, Y coordinates are not going to be changed even if the user adds/removes variables of different dimensionalities. 