### PR TITLE
fix crash in issue #837

### DIFF
--- a/apps/vaporgui/Plot.cpp
+++ b/apps/vaporgui/Plot.cpp
@@ -140,6 +140,7 @@ void Plot::Update()
     if( dmNames.empty() )
     {
         this->close();
+        return;
     }
     GUIStateParams* guiParams = dynamic_cast<GUIStateParams*>
                     (_paramsMgr->GetParams( GUIStateParams::GetClassType() ));


### PR DESCRIPTION
This PR fixes Plot crash. 
It turns out Statistics does not crash with a similar return statement. 