### PR TITLE
Opening a VDC now forces users to select .nc files

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1422,7 +1422,7 @@ void MainForm::loadData(string fileName)
 		
 	loadDataHelper(
 		files, "Choose the Master data File to load", 
-		"Vapor VDC files (*.*)", "vdc", false
+		"Vapor VDC files (*.nc)", "vdc", false
 	);
 
 }


### PR DESCRIPTION
Fix for #1107 

I believe we should filter the files presented to the user when selecting VDC to *.nc files.