### PR TITLE
Added .vdc to our accepted VDC file names for loading data

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1422,7 +1422,7 @@ void MainForm::loadData(string fileName)
 		
 	loadDataHelper(
 		files, "Choose the Master data File to load", 
-		"Vapor VDC files (*.nc)", "vdc", false
+		"Vapor VDC files (*.nc;*.vdc)", "vdc", false
 	);
 
 }


### PR DESCRIPTION
The original PR for #1107 restricted the user to picking .nc files when loading VDC data.  This PR adds .vdc to that list of accepted file extensions.