### PR TITLE
Made auto-stretching of thin domains a default

### DIFF
--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -187,7 +187,7 @@ bool SettingsParams::GetWinSizeLock() const {
 }
 
 bool SettingsParams::GetAutoStretchEnabled() const {
-	return (0!= GetValueLong(_autoStretchTag, (long) false));
+	return (0!= GetValueLong(_autoStretchTag, (long) true));
 }
 
 void SettingsParams::SetAutoStretchEnabled(bool val) {


### PR DESCRIPTION
Making auto-stretch a default setting for thin domains to fix bug #1087 