### PR TITLE
Revert "Added .vdc to our accepted VDC file names for loading data"

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1455,7 +1455,7 @@ void MainForm::loadData(string fileName)
 		
 	loadDataHelper(
 		files, "Choose the Master data File to load", 
-		"Vapor VDC files (*.nc;*.vdc)", "vdc", false
+		"Vapor VDC files (*.nc)", "vdc", false
 	);
 
 }


### PR DESCRIPTION
Reverts NCAR/VAPOR#1131 .

PR #1131 breaks the file selector on Linux: not showing `.nc` file. Thus revert it.  