### PR TITLE
Issue1123 TFWidget opacity slider maps to opacity quadratically for DVR

### DIFF
--- a/apps/vaporgui/DVRSubtabs.h
+++ b/apps/vaporgui/DVRSubtabs.h
@@ -80,6 +80,7 @@ public:
         _dvrParams = nullptr;
 
         setupUi(this);
+        _TFWidget->SetOpacityIntegrated(true);
         _TFWidget->Reinit((TFFlags)(0));
 
         _ambientWidget->SetLabel( QString::fromAscii("Ambient   ") );

--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -56,6 +56,7 @@ TFWidget::TFWidget(QWidget* parent)
 	_mainHistoRangeChanged		= false;
 	_secondaryHistoRangeChanged = false;
 	_discreteColormap 			= false;
+	_isOpacityIntegrated        = false;
 	_mainVarName	  			= "";
 	_secondaryVarName 			= "";
 
@@ -1042,7 +1043,7 @@ string TFWidget::getTFVariableName(bool mainTF=true) {
 
 int TFWidget::convertOpacityToSliderValue(float opacity) const
 {
-    if (_rParams->GetName() == DVRParams::GetClassType())
+    if (IsOpacityIntegrated())
         return 100 * sqrtf(opacity);
     else
         return 100 * opacity;
@@ -1050,10 +1051,20 @@ int TFWidget::convertOpacityToSliderValue(float opacity) const
 
 float TFWidget::convertSliderValueToOpacity(int value) const
 {
-    if (_rParams->GetName() == DVRParams::GetClassType())
+    if (IsOpacityIntegrated())
         return powf(value/100.f, 2);
     else
         return value/100.f;
+}
+
+bool TFWidget::IsOpacityIntegrated() const
+{
+    return _isOpacityIntegrated;
+}
+
+void TFWidget::SetOpacityIntegrated(bool value)
+{
+    _isOpacityIntegrated = value;
 }
 
 LoadTFDialog::LoadTFDialog( QWidget* parent )

--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -423,7 +423,7 @@ void TFWidget::updateMainSliders() {
 	getVariableRange(range, values);
 
 	_rangeCombo->Update(range[0], range[1], values[0], values[1]);
-	_opacitySlider->setValue(getOpacity() * 100);
+    _opacitySlider->setValue(convertOpacityToSliderValue(getOpacity()));
 
 	_minLabel->setText(QString::number(range[0]));
 	_maxLabel->setText(QString::number(range[1]));
@@ -821,7 +821,7 @@ void TFWidget::opacitySliderChanged(int value)
 	string varName = getTFVariableName(mainTF);
 	MapperFunction *tf = _rParams->GetMapperFunc(varName);
 	assert(tf);
-	tf->setOpacityScale(value/100.f);
+	tf->setOpacityScale(convertSliderValueToOpacity(value));
 	emit emitChange();
 }
 
@@ -1037,6 +1037,16 @@ string TFWidget::getTFVariableName(bool mainTF=true) {
 	}
 
 	return varname;
+}
+
+int TFWidget::convertOpacityToSliderValue(float opacity) const
+{
+    return 100 * sqrtf(opacity);
+}
+
+float TFWidget::convertSliderValueToOpacity(int value) const
+{
+    return powf(value/100.f, 2);
 }
 
 LoadTFDialog::LoadTFDialog( QWidget* parent )

--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -29,6 +29,7 @@
 #include "RenderEventRouter.h"
 #include "vapor/RenderParams.h"
 #include "vapor/TwoDDataParams.h"
+#include "vapor/DVRParams.h"
 #include "vapor/ResourcePath.h"
 #include "TFWidget.h"
 #include "ErrorReporter.h"
@@ -1041,12 +1042,18 @@ string TFWidget::getTFVariableName(bool mainTF=true) {
 
 int TFWidget::convertOpacityToSliderValue(float opacity) const
 {
-    return 100 * sqrtf(opacity);
+    if (_rParams->GetName() == DVRParams::GetClassType())
+        return 100 * sqrtf(opacity);
+    else
+        return 100 * opacity;
 }
 
 float TFWidget::convertSliderValueToOpacity(int value) const
 {
-    return powf(value/100.f, 2);
+    if (_rParams->GetName() == DVRParams::GetClassType())
+        return powf(value/100.f, 2);
+    else
+        return value/100.f;
 }
 
 LoadTFDialog::LoadTFDialog( QWidget* parent )

--- a/apps/vaporgui/TFWidget.h
+++ b/apps/vaporgui/TFWidget.h
@@ -140,9 +140,9 @@ private:
 	VAPoR::MapperFunction* getSecondaryMapperFunction();
 
 	string getTFVariableName(bool mainTF);
-
-	int confirmMinRangeEdit(VAPoR::MapperFunction* tf, float* range);
-	int confirmMaxRangeEdit(VAPoR::MapperFunction* tf, float* range);
+    
+    int convertOpacityToSliderValue(float opacity) const;
+    float convertSliderValueToOpacity(int value) const;
 
 	std::vector<double> _minExt;
 	std::vector<double> _maxExt;

--- a/apps/vaporgui/TFWidget.h
+++ b/apps/vaporgui/TFWidget.h
@@ -75,6 +75,8 @@ public:
 	float getOpacity();
 	void RefreshHistogram();
     void SetAutoUpdateParamChanged(bool changed);
+    bool IsOpacityIntegrated() const;
+    void SetOpacityIntegrated(bool value);
 
 private slots:
 	void loadTF();
@@ -159,6 +161,7 @@ private:
 	bool _secondaryHistoRangeChanged;
 	bool _mainHistoNeedsRefresh;
 	bool _secondaryHistoNeedsRefresh;
+    bool _isOpacityIntegrated;
 
 	bool _discreteColormap;
 	bool _textChanged;

--- a/lib/params/CMakeLists.txt
+++ b/lib/params/CMakeLists.txt
@@ -53,6 +53,10 @@ set (HEADERS
 	${PROJECT_SOURCE_DIR}/include/vapor/AxisAnnotation.h
 	${PROJECT_SOURCE_DIR}/include/vapor/WireFrameParams.h
 	${PROJECT_SOURCE_DIR}/include/vapor/DatasetsParams.h
+	${PROJECT_SOURCE_DIR}/include/vapor/SliceParams.h
+	${PROJECT_SOURCE_DIR}/include/vapor/RayCasterParams.h
+	${PROJECT_SOURCE_DIR}/include/vapor/DVRParams.h
+	${PROJECT_SOURCE_DIR}/include/vapor/IsoSurfaceParams.h
 )
 
 add_library (params SHARED ${SRC} ${HEADERS})


### PR DESCRIPTION
#1123 

This results in a linear opacity adjustment for volume renderings. Flat renderers still have a linear opacity slider.

![out](https://user-images.githubusercontent.com/2772687/50505650-35df9b00-0a32-11e9-9aa1-469a74aeeefd.gif)
