### PR TITLE
Load Session: 2D variable in 2D/3D renderer not loaded properly

### DIFF
--- a/apps/vaporgui/VariablesWidget.cpp
+++ b/apps/vaporgui/VariablesWidget.cpp
@@ -227,6 +227,7 @@ void VariablesWidget::set2DOrientation(const QString& orientation) {
     cout << "2D orientation is currently a no-op" << endl;
 }
 
+// This takes the dropdown menu index, not the dimension
 void VariablesWidget::setVariableDims(int index){
 	assert(_rParams);
 	if (! ((_dimFlags & TWOD) && (_dimFlags & THREED)) ) return;
@@ -370,6 +371,10 @@ string VariablesWidget::updateVarCombo(
 void VariablesWidget::updateScalarCombo() {
 	if (_variableFlags & SCALAR) {
 		string setVarReq = _rParams->GetVariableName();
+        
+        if (_dataMgr->VariableExists(_rParams->GetCurrentTimestep(), setVarReq))
+            _activeDim = _dataMgr->GetNumDimensions(setVarReq);
+        
 		vector<string> vars = _dataMgr->GetDataVarNames(_activeDim);
 		string setVar = updateVarCombo(varnameCombo, vars, false, setVarReq);
 		if (setVar != setVarReq) {

--- a/apps/vaporgui/VariablesWidget.cpp
+++ b/apps/vaporgui/VariablesWidget.cpp
@@ -372,9 +372,6 @@ void VariablesWidget::updateScalarCombo() {
 	if (_variableFlags & SCALAR) {
 		string setVarReq = _rParams->GetVariableName();
         
-        if (_dataMgr->VariableExists(_rParams->GetCurrentTimestep(), setVarReq))
-            _activeDim = _dataMgr->GetNumDimensions(setVarReq);
-        
 		vector<string> vars = _dataMgr->GetDataVarNames(_activeDim);
 		string setVar = updateVarCombo(varnameCombo, vars, false, setVarReq);
 		if (setVar != setVarReq) {
@@ -461,15 +458,19 @@ void VariablesWidget::updateCombos() {
 	
 	vector<string> vars = _dataMgr->GetDataVarNames(_activeDim);
 
+	updateDimCombo();
 	updateScalarCombo();
 	updateVectorCombo();
 	updateColorCombo();
 	updateHeightCombo();
-	updateDimCombo();
 }
 
 void VariablesWidget::updateDimCombo() {
-	// Only update if we support multiple dimensions
+	string varName = _rParams->GetVariableName();
+    if (_dataMgr->VariableExists(_rParams->GetCurrentTimestep(), varName))
+        _activeDim = _dataMgr->GetNumDimensions(varName);
+	
+    // Only update if we support multiple dimensions
 	if (((_dimFlags & TWOD) && (_dimFlags & THREED))) {
 		int index = _activeDim-2;
 		dimensionCombo->setCurrentIndex(index);


### PR DESCRIPTION
Fixed a bug where if you saved a session with a 2D variable with a renderer that supports both 2D and 3D variables, the VariablesWidget would reset the variable to a 3D variable upon loading the session file.

This feels like a hack but I couldn't think of a better fix currently.