### PR TITLE
Redraw visualizers on undo/redo

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1282,7 +1282,7 @@ void MainForm::undoRedoHelper(bool undo) {
 	// Restore state saving
 	//
 	_controlExec->SetSaveStateEnabled(enabled);
-
+    _stateChangeCB();
 }
 
 void MainForm::undo() {


### PR DESCRIPTION
Currently, if undo/redo is used, the visualizer window becomes an empty white box until the user manually updates it.