### PR TITLE
Fix for bug 1154

### DIFF
--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -355,7 +355,7 @@ void RenderParams::_calculateStride( string varName ) {
 
     _stride = 1;
     if ( size > REQUIRED_SAMPLE_SIZE)
-        _stride = size / REQUIRED_SAMPLE_SIZE;
+        _stride = 1 + size / REQUIRED_SAMPLE_SIZE;
 }
 
 MapperFunction* RenderParams::GetMapperFunc(string varname) {


### PR DESCRIPTION
@clyne and @shaomeng, we talked about bug #1154 yesterday and deemed it to be medium, however I was in the middle of troubleshooting it and mentioned that I would finish the effort and submit a PR for after release.

The bug was a regression within the calculateStride function.  As you guys may remember, calculateStride is duplicated in two different areas of the code: in the TFWidget and in RenderParams.  One of the functions was modified without updating the other, so we were calculating variable ranges with different stride values.

The fix is really simple so I'm wondering if we can reconsider bringing the fix into the code base for this release.