### PR TITLE
Fixed #1179 - Accessing non-existent variables causes crash

### DIFF
--- a/apps/vaporgui/BarbSubtabs.cpp
+++ b/apps/vaporgui/BarbSubtabs.cpp
@@ -99,7 +99,6 @@ void BarbAppearanceSubtab::_showZDimWidgets() {
 }
 
 bool BarbAppearanceSubtab::_isVariable2D() const {
-	VAPoR::Grid* grid;
 	int ts, level, lod;
 	std::vector<string> varNames = _bParams->GetFieldVariableNames();
 
@@ -112,11 +111,9 @@ bool BarbAppearanceSubtab::_isVariable2D() const {
 		ts    = _bParams->GetCurrentTimestep();
 		level = _bParams->GetRefinementLevel();
 		lod   = _bParams->GetCompressionLevel();
-		grid  = _dataMgr->GetVariable(ts, varName, level, lod);
 
-		int dimSize = grid->GetDimensions().size();
-		if (dimSize == 2)
-			return true;		
+		size_t nDims = _dataMgr->GetVarTopologyDim(varName);
+		if (nDims == 2) return true;		
 	}
 
 	return false;

--- a/apps/vaporgui/IsoSurfaceSubtabs.cpp
+++ b/apps/vaporgui/IsoSurfaceSubtabs.cpp
@@ -74,11 +74,16 @@ void IsoSurfaceAppearanceSubtab::Update( VAPoR::DataMgr      *dataMgr,
 
     // Get the value range
     std::vector<double> valueRanged;
-    dataMgr->GetDataRange( params->GetCurrentTimestep(),
+	bool errEnabled = MyBase::EnableErrMsg(false);
+    int rc = dataMgr->GetDataRange( params->GetCurrentTimestep(),
                            params->GetVariableName(),
                            params->GetRefinementLevel(),
                            params->GetCompressionLevel(), 1,
                            valueRanged );
+	MyBase::EnableErrMsg(errEnabled);
+
+	if (rc<0)  return;
+
     float valueRange[2] =  { float(valueRanged[0]), float(valueRanged[1]) };
 
     // Retrieve Iso Values

--- a/lib/render/BarbRenderer.cpp
+++ b/lib/render/BarbRenderer.cpp
@@ -263,7 +263,6 @@ int BarbRenderer::_getVarGrid(
 			for (int i = 0; i<varData.size(); i++){
 				if (varData[i]) _dataMgr->UnlockGrid(varData[i]);
 			}
-    		glEndList();
 			return(rc);
 		}
 		varData[varData.size()-1] = sg;
@@ -290,7 +289,6 @@ int BarbRenderer::_paintGL(bool) {
 	// Get vector variables
 	rc = _getVectorVarGrids(ts, refLevel, lod, minExts, maxExts, varData);
 	if(rc<0) {
-    	glEndList();
 		SetErrMsg("One or more selected field variables does not exist");
 		return -1;
 	}

--- a/lib/render/ContourRenderer.cpp
+++ b/lib/render/ContourRenderer.cpp
@@ -129,7 +129,6 @@ int ContourRenderer::_buildCache()
     
     if (cParams->GetVariableName().empty())
     {
-        glEndList();
         return 0;
     }
     MapperFunction *tf = cParams->GetMapperFunc(_cacheParams.varName);
@@ -155,7 +154,6 @@ int ContourRenderer::_buildCache()
     }
     
     if (grid == NULL || (heightGrid == NULL && !_cacheParams.heightVarName.empty())) {
-        glEndList();
         return -1;
     }
     

--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -405,14 +405,14 @@ int SliceRenderer::_saveTextureData() {
         &_cacheParams.compressionLevel,
         &grid
     );
-
-    grid->SetInterpolationOrder(1);
     
     if (rc<0) {
         SetErrMsg("Unable to acquire Grid for Slice texture");
         return(rc);
     }
     assert(grid);
+
+    grid->SetInterpolationOrder(1);
 
     _setVertexPositions();
 


### PR DESCRIPTION
Also fixed several other renderers that failed in when variables were missing.