### PR TITLE
Issue 1197

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1197,7 +1197,7 @@ void MainForm::_fileSaveHelper(string path)
         );
 
         fileDialog.setAcceptMode(QFileDialog::AcceptSave);
-        //fileDialog.setDefaultSuffix( QString::fromAscii("vs3") );
+        fileDialog.setDefaultSuffix( QString::fromAscii("vs3") );
         if (fileDialog.exec() != QDialog::Accepted) return;
 
         QStringList files = fileDialog.selectedFiles();

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1187,15 +1187,17 @@ void MainForm::_fileSaveHelper(string path)
         
         string dir;
         if (!guiStateParams->GetCurrentSessionFile().empty())
-            dir = FileUtils::Dirname(guiStateParams->GetCurrentSessionFile());
+            dir = guiStateParams->GetCurrentSessionFile();
         else
             dir = sP->GetSessionDir();
 
         QFileDialog fileDialog(this, "Save VAPOR session file",
                     QString::fromStdString( dir ),
-                    QString::fromAscii("Vapor 3 Session Save file (*.vs3)" ));
+                    QString::fromAscii("Vapor 3 Session Save file (*.vs3)" )
+        );
+
         fileDialog.setAcceptMode(QFileDialog::AcceptSave);
-        fileDialog.setDefaultSuffix( QString::fromAscii("vs3") );
+        //fileDialog.setDefaultSuffix( QString::fromAscii("vs3") );
         if (fileDialog.exec() != QDialog::Accepted) return;
 
         QStringList files = fileDialog.selectedFiles();


### PR DESCRIPTION
Fix for issue #1197 

When the user does a "Save Session As..." operation, and currently has a saved session, the QFileDialog will point to the current session file by default, instead of defaulting to "Untitled.vs3".