### PR TITLE
Issue 1213

### DIFF
--- a/include/vapor/RenderParams.h
+++ b/include/vapor/RenderParams.h
@@ -370,12 +370,12 @@ public:
  void InitBox();
 protected:
 	DataMgr *_dataMgr;
+    int _maxDim;
 	
 private:
 
  void _init();
  void _calculateStride(string varName);
- int _maxDim;
  int _stride;
  ParamsContainer *_TFs; 
  Box *_Box;

--- a/lib/params/BarbParams.cpp
+++ b/lib/params/BarbParams.cpp
@@ -74,6 +74,13 @@ bool BarbParams::usingVariable(const std::string& varname) {
 
 void BarbParams::_init() {
 	SetDiagMsg("BarbParams::_init()");
+
+    vector <string> varnames;
+    varnames = _dataMgr->GetDataVarNames(_maxDim);
+    if (varnames.empty()){
+        varnames = _dataMgr->GetDataVarNames(_maxDim-1);
+    }
+    SetVariableName(varnames[0]);
 	
 	SetUseSingleColor(true);
 	float rgb[] = {1.f,1.f,1.f};

--- a/lib/params/BarbParams.cpp
+++ b/lib/params/BarbParams.cpp
@@ -77,10 +77,10 @@ void BarbParams::_init() {
 
     vector <string> varnames;
     varnames = _dataMgr->GetDataVarNames(_maxDim);
-    if (varnames.empty()){
+    if (varnames.empty())
         varnames = _dataMgr->GetDataVarNames(_maxDim-1);
-    }
-    SetVariableName(varnames[0]);
+    if (!varnames.empty())
+        SetVariableName(varnames[0]);
 	
 	SetUseSingleColor(true);
 	float rgb[] = {1.f,1.f,1.f};

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -83,6 +83,8 @@ void RenderParams::SetDefaultVariables(
 	}
 	SetVariableName(varname);
 
+    cout << "varname " << varname << endl;
+
 	vector <string> fieldVarNames(3, "");
 	fieldVarNames[0] = _findVarStartingWithLetter(varnames, 'u');
 	fieldVarNames[1] = _findVarStartingWithLetter(varnames, 'v');
@@ -98,7 +100,7 @@ void RenderParams::SetDefaultVariables(
 void RenderParams::_init() {
 	SetEnabled(true);
 
-	SetDefaultVariables();
+	SetDefaultVariables(_maxDim);
 
 	SetRefinementLevel(0);
 	SetCompressionLevel(0);

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -83,8 +83,6 @@ void RenderParams::SetDefaultVariables(
 	}
 	SetVariableName(varname);
 
-    cout << "varname " << varname << endl;
-
 	vector <string> fieldVarNames(3, "");
 	fieldVarNames[0] = _findVarStartingWithLetter(varnames, 'u');
 	fieldVarNames[1] = _findVarStartingWithLetter(varnames, 'v');

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -95,7 +95,7 @@ void RenderParams::SetDefaultVariables(
 void RenderParams::_init() {
 	SetEnabled(true);
 
-	SetDefaultVariables(_maxDim);
+	SetDefaultVariables();
 
 	SetRefinementLevel(0);
 	SetCompressionLevel(0);

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -73,9 +73,6 @@ void RenderParams::SetDefaultVariables(
 ) {
 	vector <string> varnames;
 	varnames = _dataMgr->GetDataVarNames(dim);
-	if (varnames.empty()){
-		varnames = _dataMgr->GetDataVarNames(dim-1);
-	}
 
 	string varname = "";
 	if (varnames.size()) {


### PR DESCRIPTION
Fixed issue #1213 where our 3D renderers were able to operate on 2D variables whenever there were no 3D variables present in the currently opened dataset.