### PR TITLE
Fix for issue 1190

### DIFF
--- a/apps/vaporgui/RenderHolder.cpp
+++ b/apps/vaporgui/RenderHolder.cpp
@@ -174,9 +174,11 @@ RenderHolder::RenderHolder(
 		this, widgetNames, descriptions, iconPaths, smallIconPaths
 	);
 	_vaporTable = new VaporTable(tableWidget, false, true);
-	_vaporTable->Reinit((VaporTable::ValidatorFlags)(0),
-		(VaporTable::MutabilityFlags)(0),
-		(VaporTable::HighlightFlags)(VaporTable::ROWS));
+	_vaporTable->Reinit(
+        (VaporTable::ValidatorFlags)(0),
+		(VaporTable::MutabilityFlags)(VaporTable::IMMUTABLE),
+		(VaporTable::HighlightFlags)(VaporTable::ROWS)
+    );
     _vaporTable->ShowToolTips(true);
 	_currentRow = 0;
 


### PR DESCRIPTION
Fix for #1190 where editing a cell in the RenderHolder's table would cause a crash