### PR TITLE
More correct OpenGL state cleanup

### DIFF
--- a/lib/render/DVRenderer.cpp
+++ b/lib/render/DVRenderer.cpp
@@ -49,8 +49,6 @@ void DVRenderer::_3rdPassSpecialHandling( bool fast, int castingMode ) const
     glCopyTexImage2D(GL_TEXTURE_2D,   0, GL_DEPTH_COMPONENT32, _currentViewport[0], 
                      _currentViewport[1], _currentViewport[2], _currentViewport[3], 0);
     _3rdPassShader->SetUniform(   "depthTexture", _depthTexOffset);
-    // Note: Don't bind 0 to GL_TEXTURE_2D at this point yet; it'll result in bad rendering, 
-    //   though I don't know why...
 }
 
 void DVRenderer::_colormapSpecialHandling( )

--- a/lib/render/IsoSurfaceRenderer.cpp
+++ b/lib/render/IsoSurfaceRenderer.cpp
@@ -73,8 +73,6 @@ void IsoSurfaceRenderer::_3rdPassSpecialHandling( bool fast, int castingMode ) c
     glActiveTexture(  GL_TEXTURE0 +                    _2ndVarMaskTexOffset );
     glBindTexture(    GL_TEXTURE_3D,                   _2ndVarMaskTexId     );
     _3rdPassShader->SetUniform("secondVarMaskTexture", _2ndVarMaskTexOffset );
-    
-    glBindTexture(    GL_TEXTURE_3D,        0 );
 }
 
 void IsoSurfaceRenderer::_colormapSpecialHandling( )
@@ -148,6 +146,4 @@ void IsoSurfaceRenderer::_update2ndVarTextures( )
                       GL_RED_INTEGER, GL_UNSIGNED_BYTE, dummyMask );
     }
     glPixelStorei( GL_UNPACK_ALIGNMENT, 4 );    // Restore default alignment.
-
-    glBindTexture( GL_TEXTURE_3D, 0 );
 }

--- a/lib/render/RayCaster.cpp
+++ b/lib/render/RayCaster.cpp
@@ -829,7 +829,6 @@ int RayCaster::_paintGL( bool fast )
     glBindTexture( GL_TEXTURE_1D,  _colorMapTextureId );
     glTexImage1D(  GL_TEXTURE_1D, 0, GL_RGBA32F,     _colorMap.size()/4,
                    0, GL_RGBA,       GL_FLOAT,       _colorMap.data() );
-    glBindTexture( GL_TEXTURE_1D, 0 );
 
     glBindFramebuffer( GL_FRAMEBUFFER, 0 );
     glViewport( 0, 0, _currentViewport[2], _currentViewport[3] );
@@ -842,6 +841,9 @@ int RayCaster::_paintGL( bool fast )
     glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, 0 );
     glDepthFunc(GL_LESS);
     glActiveTexture( GL_TEXTURE0 );
+    glBindTexture(GL_TEXTURE_1D, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glBindTexture(GL_TEXTURE_3D, 0);
 
     delete grid;
 
@@ -937,11 +939,6 @@ int RayCaster::_initializeFramebufferTextures()
     glActiveTexture( GL_TEXTURE0 + _depthTexOffset );
     glBindTexture(GL_TEXTURE_2D, _depthTextureId);
     this->_configure2DTextureLinearInterpolation();
-
-    /* Bind the default textures */
-    glBindTexture(GL_TEXTURE_1D, 0);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    glBindTexture(GL_TEXTURE_3D, 0);
 
     return 0;
 }
@@ -1203,10 +1200,6 @@ void RayCaster::_load3rdPassUniforms( int                castingMode,
         glBindTexture(    GL_TEXTURE_3D,        _vertCoordsTextureId );
         shader->SetUniform("vertCoordsTexture", _vertCoordsTexOffset);
     }
-
-    glBindTexture( GL_TEXTURE_1D, 0 );
-    glBindTexture( GL_TEXTURE_2D, 0 );
-    glBindTexture( GL_TEXTURE_3D, 0 );
 }
     
 void RayCaster::_3rdPassSpecialHandling( bool fast, int castingMode ) const
@@ -1525,8 +1518,6 @@ void RayCaster::_updateViewportWhenNecessary( const GLint* viewport )
         glBindTexture(GL_TEXTURE_2D,   _frontFaceTextureId); 
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, _currentViewport[2], _currentViewport[3], 
                      0, GL_RGBA, GL_FLOAT, nullptr);
-
-        glBindTexture( GL_TEXTURE_2D, 0 );
     }
 }
     
@@ -1604,8 +1595,6 @@ void RayCaster::_updateDataTextures( )
                       GL_RED_INTEGER, GL_UNSIGNED_BYTE, dummyMask );
     }
     glPixelStorei( GL_UNPACK_ALIGNMENT, 4 );    // Restore default alignment.
-
-    glBindTexture( GL_TEXTURE_3D, 0 );
 }
 
 int RayCaster::_updateVertCoordsTexture( const glm::mat4& MV )
@@ -1643,8 +1632,6 @@ int RayCaster::_updateVertCoordsTexture( const glm::mat4& MV )
     glTexImage3D( GL_TEXTURE_3D, 0, GL_RGB32F, _userCoordinates.dims[0], 
                   _userCoordinates.dims[1],    _userCoordinates.dims[2],
                   0, GL_RGB, GL_FLOAT,         coordEye               );
-
-    glBindTexture( GL_TEXTURE_3D, 0 );
     
     delete[] coordEye;
 


### PR DESCRIPTION
This PR standardizes OpenGL texture state cleanup routines in RayCaster and its subclasses. 