### PR TITLE
avoid creation of texture objects at every iteration

### DIFF
--- a/lib/render/RayCaster.cpp
+++ b/lib/render/RayCaster.cpp
@@ -1635,14 +1635,33 @@ int RayCaster::_updateVertCoordsTexture( const glm::mat4& MV )
     // Second, send these eye coordinates to the GPU
     glActiveTexture( GL_TEXTURE0 +  _vertCoordsTexOffset );
     glBindTexture(   GL_TEXTURE_3D, _vertCoordsTextureId );
+
 #ifdef Darwin
     // Apply a dummy texture
     float dummyVolume[8] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
     glTexImage3D( GL_TEXTURE_3D, 0, GL_R32F, 2, 2, 2, 0, GL_RED, GL_FLOAT, dummyVolume );
 #endif
-    glTexImage3D( GL_TEXTURE_3D, 0, GL_RGB32F, _userCoordinates.dims[0], 
-                  _userCoordinates.dims[1],    _userCoordinates.dims[2],
-                  0, GL_RGB, GL_FLOAT,         coordEye               );
+
+    // Test if the existing texture has the same dimensions. 
+    //   If so, simply substitute its content.
+    //   If not, create a new object.
+    int width, height, depth;
+    glGetTexLevelParameteriv( GL_TEXTURE_3D, 0, GL_TEXTURE_WIDTH,  &width );
+    glGetTexLevelParameteriv( GL_TEXTURE_3D, 0, GL_TEXTURE_HEIGHT, &height );
+    glGetTexLevelParameteriv( GL_TEXTURE_3D, 0, GL_TEXTURE_DEPTH,  &depth );
+    if( (size_t)width  == _userCoordinates.dims[0] && 
+        (size_t)height == _userCoordinates.dims[1] &&
+        (size_t)depth  == _userCoordinates.dims[2]  )
+    {
+        glTexSubImage3D( GL_TEXTURE_3D, 0, 0, 0, 0, width, height, depth, 
+                         GL_RGB, GL_FLOAT, coordEye                    );
+    }
+    else
+    {
+        glTexImage3D( GL_TEXTURE_3D, 0, GL_RGB32F, _userCoordinates.dims[0], 
+                      _userCoordinates.dims[1],    _userCoordinates.dims[2],
+                      0, GL_RGB, GL_FLOAT,         coordEye               );
+    }
     
     delete[] coordEye;
 

--- a/share/shaders/DVR3rdPassMode2.frag
+++ b/share/shaders/DVR3rdPassMode2.frag
@@ -286,15 +286,30 @@ bool LocateNextCell( const in ivec3 currentCellIdx, const in vec3 pos, out ivec3
 
 
 //
-// Input:  a cell index, and a position that's inside of this cell.
+// Input:  a cell index, and a position of eye coordinate that's inside of this cell.
 // Output: the texture coordinate of that position.
 //
 vec3 CalculatePosTex( const ivec3 cellIdx, const vec3 pos )
 {
-    // For VAPOR 3.1, we just use the center of the cell.
-    vec3 t1 = vec3( cellIdx     ) * volumeDims1o;
-    vec3 t2 = vec3( cellIdx + 1 ) * volumeDims1o;
-    return (t1 + t2) * 0.5;
+    // Find texture coordinates of two corners
+    vec3 tc1 = vec3( cellIdx     ) * volumeDims1o;
+    vec3 tc2 = vec3( cellIdx + 1 ) * volumeDims1o;
+
+    // Find the eye coordinates of two cornders
+    vec4 ec1  = texelFetch( vertCoordsTexture,  cellIdx,     0 );
+    vec4 ec2  = texelFetch( vertCoordsTexture,  cellIdx + 1, 0 );
+
+    // Transform eye coordinates to model coordinates
+    ec1.w     = 1.0;
+    ec2.w     = 1.0;
+    vec3 mc1  = (inversedMV * ec1).xyz;
+    vec3 mc2  = (inversedMV * ec2).xyz;
+    vec3 mpos = (inversedMV * vec4(pos, 1.0)).xyz;
+
+    vec3 weight = (mpos - mc1) / (mc2 - mc1);
+    weight      = clamp( weight, 0.0, 1.0 );
+
+    return mix( tc1, tc2, weight );
 }
 
 

--- a/share/shaders/DVR3rdPassMode2.frag
+++ b/share/shaders/DVR3rdPassMode2.frag
@@ -292,8 +292,8 @@ bool LocateNextCell( const in ivec3 currentCellIdx, const in vec3 pos, out ivec3
 vec3 CalculatePosTex( const ivec3 cellIdx, const vec3 pos )
 {
     // Find texture coordinates of two corners
-    vec3 tc1 = vec3( cellIdx     ) * volumeDims1o;
-    vec3 tc2 = vec3( cellIdx + 1 ) * volumeDims1o;
+    vec3 tc1  = vec3( cellIdx     ) * volumeDims1o;
+    vec3 tc2  = vec3( cellIdx + 1 ) * volumeDims1o;
 
     // Find the eye coordinates of two cornders
     vec4 ec1  = texelFetch( vertCoordsTexture,  cellIdx,     0 );


### PR DESCRIPTION
1. This PR modifies the code so that `glTexSubImage3d()` is used appropriately, instead of using `glTexImage3D()` every time. 
2. This PR also implements a linear interpolation of texture coordinate inside of a cell. 