### PR TITLE
Fix for #1348 - Isosurface colormap interpolation

### DIFF
--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -930,7 +930,13 @@ void TFWidget::setUsingSingleColor(int state) {
 }
 
 void TFWidget::setColorInterpolation(int index) {
-	MapperFunction* mf = getMainMapperFunction();
+	MapperFunction* mf;
+    if (_flags & COLORMAP_VAR_IS_IN_TF2) {
+		mf = getSecondaryMapperFunction();
+	}
+	else {
+		mf = getMainMapperFunction();
+	}
 
 	if (index==0) {
 		mf->setColorInterpType(TFInterpolator::diverging);


### PR DESCRIPTION
Fix for #1348 where isosurface color mapped variables can only be divergently interpolated