### PR TITLE
revert a naive interpolation of position inside a cell

### DIFF
--- a/include/vapor/RayCaster.h
+++ b/include/vapor/RayCaster.h
@@ -200,6 +200,8 @@ protected:
     //
     int  _initializeFramebufferTextures();
 
+    int  _selectDefaultCastingMethod() const;
+
     void _updateViewportWhenNecessary( const GLint* viewport );
     void _updateColormap( RayCasterParams* params );
     void _updateDataTextures();

--- a/lib/render/RayCaster.cpp
+++ b/lib/render/RayCaster.cpp
@@ -90,6 +90,9 @@ RayCaster::RayCaster( const ParamsMgr*    pm,
 
     for( int i = 0; i < 4; i++ )
         _currentViewport[i] = 0;
+
+    // Set the default ray casting method upon creation of the RayCaster.
+    _selectDefaultCastingMethod();
 }
 
 // Destructor
@@ -1664,6 +1667,37 @@ int RayCaster::_updateVertCoordsTexture( const glm::mat4& MV )
     }
     
     delete[] coordEye;
+
+    return 0;
+}
+
+int RayCaster::_selectDefaultCastingMethod() const
+{
+    RayCasterParams* params = dynamic_cast<RayCasterParams*>( GetActiveParams() );
+    if( !params )
+    {
+        MyBase::SetErrMsg("Error occured during retrieving RayCaster parameters!");
+        return PARAMSERROR;
+    }
+
+    StructuredGrid*  grid = nullptr;
+    if( _userCoordinates.GetCurrentGrid( params, _dataMgr, &grid ) != 0 )
+    {
+        MyBase::SetErrMsg( "Failed to retrieve a StructuredGrid" );
+        return GRIDERROR;
+    }
+
+    //
+    // In case of a regular grid, use "fixed step" ray casting.
+    // In other cases, use "cell traversal" ray casting.
+    //
+    RegularGrid* regular = dynamic_cast<RegularGrid*>( grid );
+    if( regular )
+        params->SetCastingMode( FixedStep );
+    else
+        params->SetCastingMode( CellTraversal );
+
+    delete grid;
 
     return 0;
 }

--- a/share/shaders/DVR3rdPassMode2.frag
+++ b/share/shaders/DVR3rdPassMode2.frag
@@ -291,25 +291,8 @@ bool LocateNextCell( const in ivec3 currentCellIdx, const in vec3 pos, out ivec3
 //
 vec3 CalculatePosTex( const ivec3 cellIdx, const vec3 pos )
 {
-    // Find texture coordinates of two corners
-    vec3 tc1  = vec3( cellIdx     ) * volumeDims1o;
-    vec3 tc2  = vec3( cellIdx + 1 ) * volumeDims1o;
-
-    // Find the eye coordinates of two cornders
-    vec4 ec1  = texelFetch( vertCoordsTexture,  cellIdx,     0 );
-    vec4 ec2  = texelFetch( vertCoordsTexture,  cellIdx + 1, 0 );
-
-    // Transform eye coordinates to model coordinates
-    ec1.w     = 1.0;
-    ec2.w     = 1.0;
-    vec3 mc1  = (inversedMV * ec1).xyz;
-    vec3 mc2  = (inversedMV * ec2).xyz;
-    vec3 mpos = (inversedMV * vec4(pos, 1.0)).xyz;
-
-    vec3 weight = (mpos - mc1) / (mc2 - mc1);
-    weight      = clamp( weight, 0.0, 1.0 );
-
-    return mix( tc1, tc2, weight );
+    // For VAPOR 3.1, we simply take the center point of the cell.
+    return ( vec3(cellIdx) + 0.5 ) * volumeDims1o;
 }
 
 


### PR DESCRIPTION
This PR has 2 changes:
1. It makes DVR mode 2 to use a cell center texture for color retrieving. This method will make blocks visible on big cells, as the screenshot shows. 

![screenshot from 2019-01-23 15-10-53](https://user-images.githubusercontent.com/814885/51640981-37fa2400-1f22-11e9-9378-2cde09953dce.png)

2. A second change of this PR is that it implements a smart ray casting method selection based on the grid type.
