### PR TITLE
Issue 1362 - SliceRenderer reinitialization resets Geometry

### DIFF
--- a/apps/vaporgui/GeometryWidget.cpp
+++ b/apps/vaporgui/GeometryWidget.cpp
@@ -102,16 +102,21 @@ void GeometryWidget::hideOrientationOptions() {
     _zPointFrame->hide();
 }
 
-void GeometryWidget::adjustPlanarOrientation(int plane) {
+void GeometryWidget::adjustPlanarOrientation(
+    int plane,
+    bool reinit // = true by default
+) {
     if (plane == XY)
-        adjustLayoutToPlanarXY();
+        adjustLayoutToPlanarXY(reinit);
     else if (plane == XZ)
-        adjustLayoutToPlanarXZ();
+        adjustLayoutToPlanarXZ(reinit);
     else if (plane == YZ)
-        adjustLayoutToPlanarYZ();
+        adjustLayoutToPlanarYZ(reinit);
 }
 
-void GeometryWidget::adjustLayoutToPlanarXY() {
+void GeometryWidget::adjustLayoutToPlanarXY(
+    bool reinit
+) {
     _xMinMaxFrame->show();
     _yMinMaxFrame->show();
     _zMinMaxFrame->hide();
@@ -119,21 +124,27 @@ void GeometryWidget::adjustLayoutToPlanarXY() {
     _xPointFrame->hide();
     _yPointFrame->hide();
     _zPointFrame->show();
-   
+
     if (!_rParams) return; 
-	std::vector<double> minExt(3,0);
-    std::vector<double> maxExt(3,1);
-    getFullExtents(minExt, maxExt);
-    double average = (minExt[Z]+maxExt[Z])/2.f;
-    _zSinglePoint->SetValue(average);
     
-    minExt[Z] = average;
-    maxExt[Z] = average;
-	Box* box = _rParams->GetBox();
-    box->SetExtents(minExt, maxExt);
+    std::vector<double> minExt(3,0);
+    std::vector<double> maxExt(3,1);
+    Box* box = _rParams->GetBox();
+    if (reinit) {   
+        cout << "reinitXY" << endl;
+        getFullExtents(minExt, maxExt);
+        double average = (minExt[Z]+maxExt[Z])/2.f;
+        _zSinglePoint->SetValue(average);
+        
+        minExt[Z] = average;
+        maxExt[Z] = average;
+        box->SetExtents(minExt, maxExt);
+    }
 }
 
-void GeometryWidget::adjustLayoutToPlanarXZ() {
+void GeometryWidget::adjustLayoutToPlanarXZ(
+    bool reinit
+) {
     _xMinMaxFrame->show();
     _yMinMaxFrame->hide();
     _zMinMaxFrame->show();
@@ -145,18 +156,22 @@ void GeometryWidget::adjustLayoutToPlanarXZ() {
     if (!_rParams) return; 
 	std::vector<double> minExt(3,0);
     std::vector<double> maxExt(3,1);
-    getFullExtents(minExt, maxExt);
-	//box->GetExtents(minExt, maxExt);
-    double average = (minExt[Y]+maxExt[Y])/2.f;
-    _ySinglePoint->SetValue(average);
-    
-    minExt[Y] = average;
-    maxExt[Y] = average;
-	Box* box = _rParams->GetBox();
-    box->SetExtents(minExt, maxExt);
+    Box* box = _rParams->GetBox();
+    if (reinit) {
+        cout << "reinitXZ" << endl;
+        getFullExtents(minExt, maxExt);
+        double average = (minExt[Y]+maxExt[Y])/2.f;
+        _ySinglePoint->SetValue(average);
+        
+        minExt[Y] = average;
+        maxExt[Y] = average;
+        box->SetExtents(minExt, maxExt);
+    }
 }
 
-void GeometryWidget::adjustLayoutToPlanarYZ() {
+void GeometryWidget::adjustLayoutToPlanarYZ(
+    bool reinit
+) {
     _xMinMaxFrame->hide();
     _yMinMaxFrame->show();
     _zMinMaxFrame->show();
@@ -168,15 +183,17 @@ void GeometryWidget::adjustLayoutToPlanarYZ() {
     if (!_rParams) return; 
 	std::vector<double> minExt(3,0);
     std::vector<double> maxExt(3,1);
-    getFullExtents(minExt, maxExt);
-	//box->GetExtents(minExt, maxExt);
-    double average = (minExt[X]+maxExt[X])/2.f;
-    _xSinglePoint->SetValue(average);
-    
-    minExt[X] = average;
-    maxExt[X] = average;
-	Box* box = _rParams->GetBox();
-    box->SetExtents(minExt, maxExt);
+    Box* box = _rParams->GetBox();
+    if (reinit) {
+        cout << "reinitYZ" << endl;
+        getFullExtents(minExt, maxExt);
+        double average = (minExt[X]+maxExt[X])/2.f;
+        _xSinglePoint->SetValue(average);
+        
+        minExt[X] = average;
+        maxExt[X] = average;
+        box->SetExtents(minExt, maxExt);
+    }
 }
 
 void GeometryWidget::adjustLayoutTo2D() {
@@ -205,7 +222,7 @@ void GeometryWidget::Reinit(
 
     if (_geometryFlags & PLANAR) {
         showOrientationOptions();
-        adjustPlanarOrientation(XY);
+        adjustPlanarOrientation(XY, false);
     }
     else
         hideOrientationOptions();
@@ -430,8 +447,17 @@ void GeometryWidget::Update(ParamsMgr *paramsMgr,
 	updateBoxCombos(minFullExt, maxFullExt);
 
     if (_geometryFlags & PLANAR) {
-        int orientation = _rParams->GetBox()->GetOrientation();
-        _planeComboBox->setCurrentIndex(orientation);
+        //int guiOrientation = _planeComboBox->currentIndex();
+        //if ( rParamsOrientation != guiOrientation ) {
+        _planeComboBox->blockSignals(true);
+
+        int rParamsOrientation = _rParams->GetBox()->GetOrientation();
+        _planeComboBox->setCurrentIndex(rParamsOrientation);
+
+        bool reinit=false;
+        adjustPlanarOrientation(rParamsOrientation, reinit);
+
+        _planeComboBox->blockSignals(false);
     }
 }
 

--- a/apps/vaporgui/GeometryWidget.cpp
+++ b/apps/vaporgui/GeometryWidget.cpp
@@ -127,18 +127,8 @@ void GeometryWidget::adjustLayoutToPlanarXY(
 
     if (!_rParams) return; 
     
-    if (reinit) {   
-        std::vector<double> minExt(3,0);
-        std::vector<double> maxExt(3,1);
-        getFullExtents(minExt, maxExt);
-        double average = (minExt[Z]+maxExt[Z])/2.f;
-        _zSinglePoint->SetValue(average);
-        
-        minExt[Z] = average;
-        maxExt[Z] = average;
-        Box* box = _rParams->GetBox();
-        box->SetExtents(minExt, maxExt);
-    }
+    if (reinit)
+        reinitBoxToPlanarAxis(Z, _zSinglePoint);
 }
 
 void GeometryWidget::adjustLayoutToPlanarXZ(
@@ -154,18 +144,8 @@ void GeometryWidget::adjustLayoutToPlanarXZ(
 
     if (!_rParams) return; 
 
-    if (reinit) {
-        std::vector<double> minExt(3,0);
-        std::vector<double> maxExt(3,1);
-        getFullExtents(minExt, maxExt);
-        double average = (minExt[Y]+maxExt[Y])/2.f;
-        _ySinglePoint->SetValue(average);
-        
-        minExt[Y] = average;
-        maxExt[Y] = average;
-        Box* box = _rParams->GetBox();
-        box->SetExtents(minExt, maxExt);
-    }
+    if (reinit)
+        reinitBoxToPlanarAxis(Y, _ySinglePoint);
 }
 
 void GeometryWidget::adjustLayoutToPlanarYZ(
@@ -180,18 +160,25 @@ void GeometryWidget::adjustLayoutToPlanarYZ(
     _zPointFrame->hide();
 
     if (!_rParams) return; 
-    if (reinit) {
-        std::vector<double> minExt(3,0);
-        std::vector<double> maxExt(3,1);
-        getFullExtents(minExt, maxExt);
-        double average = (minExt[X]+maxExt[X])/2.f;
-        _xSinglePoint->SetValue(average);
-        
-        minExt[X] = average;
-        maxExt[X] = average;
-        Box* box = _rParams->GetBox();
-        box->SetExtents(minExt, maxExt);
-    }
+
+    if (reinit)
+        reinitBoxToPlanarAxis(X, _xSinglePoint);
+}
+
+void GeometryWidget::reinitBoxToPlanarAxis(
+    int planarAxis,
+    QSliderEdit *slider
+) {
+    std::vector<double> minExt(3,0);
+    std::vector<double> maxExt(3,1);
+    getFullExtents(minExt, maxExt);
+    double average = (minExt[planarAxis]+maxExt[planarAxis])/2.f;
+    slider->SetValue(average);
+    
+    minExt[planarAxis] = average;
+    maxExt[planarAxis] = average;
+    Box* box = _rParams->GetBox();
+    box->SetExtents(minExt, maxExt);
 }
 
 void GeometryWidget::adjustLayoutTo2D() {

--- a/apps/vaporgui/GeometryWidget.cpp
+++ b/apps/vaporgui/GeometryWidget.cpp
@@ -102,7 +102,7 @@ void GeometryWidget::hideOrientationOptions() {
     _zPointFrame->hide();
 }
 
-void GeometryWidget::adjustPlanarOrientation(
+void GeometryWidget::adjustLayoutToPlanar(
     int plane,
     bool reinit // = true by default
 ) {
@@ -222,7 +222,7 @@ void GeometryWidget::Reinit(
 
     if (_geometryFlags & PLANAR) {
         showOrientationOptions();
-        adjustPlanarOrientation(XY, false);
+        adjustLayoutToPlanar(XY, false);
     }
     else
         hideOrientationOptions();
@@ -447,15 +447,13 @@ void GeometryWidget::Update(ParamsMgr *paramsMgr,
 	updateBoxCombos(minFullExt, maxFullExt);
 
     if (_geometryFlags & PLANAR) {
-        //int guiOrientation = _planeComboBox->currentIndex();
-        //if ( rParamsOrientation != guiOrientation ) {
         _planeComboBox->blockSignals(true);
 
         int rParamsOrientation = _rParams->GetBox()->GetOrientation();
         _planeComboBox->setCurrentIndex(rParamsOrientation);
 
         bool reinit=false;
-        adjustPlanarOrientation(rParamsOrientation, reinit);
+        adjustLayoutToPlanar(rParamsOrientation, reinit);
 
         _planeComboBox->blockSignals(false);
     }
@@ -485,7 +483,7 @@ void GeometryWidget::connectWidgets() {
 	connect(_zRangeCombo, SIGNAL(valueChanged(double,double)), 
 		this, SLOT(setRange(double, double)));
     connect(_planeComboBox, SIGNAL(currentIndexChanged(int)),
-        this, SLOT(adjustPlanarOrientation(int)));
+        this, SLOT(adjustLayoutToPlanar(int)));
 }	
 
 void GeometryWidget::setPoint(double point) {

--- a/apps/vaporgui/GeometryWidget.cpp
+++ b/apps/vaporgui/GeometryWidget.cpp
@@ -127,17 +127,16 @@ void GeometryWidget::adjustLayoutToPlanarXY(
 
     if (!_rParams) return; 
     
-    std::vector<double> minExt(3,0);
-    std::vector<double> maxExt(3,1);
-    Box* box = _rParams->GetBox();
     if (reinit) {   
-        cout << "reinitXY" << endl;
+        std::vector<double> minExt(3,0);
+        std::vector<double> maxExt(3,1);
         getFullExtents(minExt, maxExt);
         double average = (minExt[Z]+maxExt[Z])/2.f;
         _zSinglePoint->SetValue(average);
         
         minExt[Z] = average;
         maxExt[Z] = average;
+        Box* box = _rParams->GetBox();
         box->SetExtents(minExt, maxExt);
     }
 }
@@ -154,17 +153,17 @@ void GeometryWidget::adjustLayoutToPlanarXZ(
     _zPointFrame->hide();
 
     if (!_rParams) return; 
-	std::vector<double> minExt(3,0);
-    std::vector<double> maxExt(3,1);
-    Box* box = _rParams->GetBox();
+
     if (reinit) {
-        cout << "reinitXZ" << endl;
+        std::vector<double> minExt(3,0);
+        std::vector<double> maxExt(3,1);
         getFullExtents(minExt, maxExt);
         double average = (minExt[Y]+maxExt[Y])/2.f;
         _ySinglePoint->SetValue(average);
         
         minExt[Y] = average;
         maxExt[Y] = average;
+        Box* box = _rParams->GetBox();
         box->SetExtents(minExt, maxExt);
     }
 }
@@ -181,26 +180,22 @@ void GeometryWidget::adjustLayoutToPlanarYZ(
     _zPointFrame->hide();
 
     if (!_rParams) return; 
-	std::vector<double> minExt(3,0);
-    std::vector<double> maxExt(3,1);
-    Box* box = _rParams->GetBox();
     if (reinit) {
-        cout << "reinitYZ" << endl;
+        std::vector<double> minExt(3,0);
+        std::vector<double> maxExt(3,1);
         getFullExtents(minExt, maxExt);
         double average = (minExt[X]+maxExt[X])/2.f;
         _xSinglePoint->SetValue(average);
         
         minExt[X] = average;
         maxExt[X] = average;
+        Box* box = _rParams->GetBox();
         box->SetExtents(minExt, maxExt);
     }
 }
 
 void GeometryWidget::adjustLayoutTo2D() {
 	_zFrame->hide();
-	//_minMaxContainerWidget->adjustSize();
-	//_minMaxTab->adjustSize();
-
 	adjustSize();
 }
 

--- a/apps/vaporgui/GeometryWidget.h
+++ b/apps/vaporgui/GeometryWidget.h
@@ -44,13 +44,13 @@ signals:
 private slots:
     void setPoint(double point);
 	void setRange(double min, double max, int dim=-1);
-    void adjustPlanarOrientation(int plane);
+    void adjustPlanarOrientation(int plane, bool reinit = true);
 
 private:
 	void adjustLayoutTo2D();
-    void adjustLayoutToPlanarXY();
-    void adjustLayoutToPlanarXZ();
-    void adjustLayoutToPlanarYZ();
+    void adjustLayoutToPlanarXY(bool reinit);
+    void adjustLayoutToPlanarXZ(bool reinit);
+    void adjustLayoutToPlanarYZ(bool reinit);
     void showOrientationOptions();
     void hideOrientationOptions();
 	void connectWidgets();

--- a/apps/vaporgui/GeometryWidget.h
+++ b/apps/vaporgui/GeometryWidget.h
@@ -44,7 +44,7 @@ signals:
 private slots:
     void setPoint(double point);
 	void setRange(double min, double max, int dim=-1);
-    void adjustPlanarOrientation(int plane, bool reinit = true);
+    void adjustLayoutToPlanar(int plane, bool reinit = true);
 
 private:
 	void adjustLayoutTo2D();

--- a/apps/vaporgui/GeometryWidget.h
+++ b/apps/vaporgui/GeometryWidget.h
@@ -51,6 +51,10 @@ private:
     void adjustLayoutToPlanarXY(bool reinit);
     void adjustLayoutToPlanarXZ(bool reinit);
     void adjustLayoutToPlanarYZ(bool reinit);
+    void reinitBoxToPlanarAxis(
+        int planarAxis,
+        QSliderEdit *slider
+    );
     void showOrientationOptions();
     void hideOrientationOptions();
 	void connectWidgets();


### PR DESCRIPTION
Fix for #1362 regarding the slice renderer's reinitialization method resetting the extents of the slice.