### PR TITLE
fix for #1378 - Controls too small on high res screens on Windows

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -347,7 +347,6 @@ MainForm::MainForm(
 	_vizWinMgr = new VizWinMgr(this, _mdiArea, _controlExec);
 	
 	_tabMgr = new TabManager(this, _controlExec);
-    _tabMgr->setMaximumWidth(600);
     _tabMgr->setUsesScrollButtons(true);
 
     _tabMgr->setMinimumWidth(460);


### PR DESCRIPTION
Fix for #1378 