### PR TITLE
Issue #1379 - Removed user access to Jpeg captures

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -982,12 +982,12 @@ void MainForm::_createCaptureMenu() {
 	//
     _captureMenu = menuBar()->addMenu(tr("Capture"));
     _singleImageMenu = _captureMenu->addMenu(tr("Single image"));
-    _singleImageMenu->addAction(_captureSingleJpegAction);
+    //_singleImageMenu->addAction(_captureSingleJpegAction);
     _singleImageMenu->addAction(_captureSinglePngAction);
     _singleImageMenu->addAction(_captureSingleTiffAction);
     //_captureMenu->addMenu("Single image");
     _imageSequenceMenu = _captureMenu->addMenu(tr("Image sequence"));
-    _imageSequenceMenu->addAction(_captureJpegSequenceAction);
+    //_imageSequenceMenu->addAction(_captureJpegSequenceAction);
     _imageSequenceMenu->addAction(_capturePngSequenceAction);
     _imageSequenceMenu->addAction(_captureTiffSequenceAction);
 	//_captureMenu->addAction(_captureStartJpegAction);


### PR DESCRIPTION
All of the functionality that we had for capturing Jpeg images still exists.  The menu items to access these functions are now removed so that the user cannot access them.