### PR TITLE
Added tooltips for our raycaster options

### DIFF
--- a/apps/vaporgui/DVRVariablesGUI.ui
+++ b/apps/vaporgui/DVRVariablesGUI.ui
@@ -152,14 +152,17 @@
               <height>16777215</height>
              </size>
             </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The &amp;quot;Fixed-Stepsize&amp;quot; method is fast because it assumes the underlying grid is regular. That means, every cell in the volume has the same height, width, and depth. When this assumption does not hold true, renderings from the &amp;quot;Fixed-Stepsize&amp;quot; method will start to become misleading.&lt;/p&gt;&lt;p&gt;The &amp;quot;Cell-Traversal&amp;quot; method is slow because it takes into consideration different cell sizes and shapes. Renderings will always be accurate using this method, but it could be two orders of magnitude slower than &amp;quot;Fixed-Stepsize&amp;quot; rendering.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
             <item>
              <property name="text">
-              <string>Fixed Stepsize Casting </string>
+              <string>Fixed Stepsize Casting (Fast)</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Cell Traverse Casting</string>
+              <string>Cell Traverse Casting (Slow)</string>
              </property>
             </item>
            </widget>

--- a/apps/vaporgui/IsoSurfaceVariablesGUI.ui
+++ b/apps/vaporgui/IsoSurfaceVariablesGUI.ui
@@ -143,14 +143,17 @@
               <height>16777215</height>
              </size>
             </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The &amp;quot;Fixed-Stepsize&amp;quot; method is fast because it assumes the underlying grid is regular. That means, every cell in the volume has the same height, width, and depth. When this assumption does not hold true, renderings from the &amp;quot;Fixed-Stepsize&amp;quot; method will start to become misleading.&lt;/p&gt;&lt;p&gt;The &amp;quot;Cell-Traversal&amp;quot; method is slow because it takes into consideration different cell sizes and shapes. Renderings will always be accurate using this method, but it could be two orders of magnitude slower than &amp;quot;Fixed-Stepsize&amp;quot; rendering.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
             <item>
              <property name="text">
-              <string>Fixed Stepsize Casting </string>
+              <string>Fixed Stepsize Casting (Fast)</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Cell Traverse Casting</string>
+              <string>Cell Traverse Casting (Slow)</string>
              </property>
             </item>
            </widget>


### PR DESCRIPTION
Added text to indicate fast vs slow ray casting methods, along with a tooltip shown below:

The "Fixed-Stepsize" method is fast because it assumes the underlying grid is regular. That means, every cell in the volume has the same height, width, and depth. When this assumption does not hold true, renderings from the "Fixed-Stepsize" method will start to become misleading.

The "Cell-Traversal" method is slow because it takes into consideration different cell sizes and shapes. Renderings will always be accurate using this method, but it could be two orders of magnitude slower than "Fixed-Stepsize" rendering.
