### PR TITLE
Mac DVR fix

### DIFF
--- a/include/vapor/RayCaster.h
+++ b/include/vapor/RayCaster.h
@@ -207,7 +207,6 @@ protected:
     void _updateColormap( RayCasterParams* params );
     void _updateDataTextures();
     int  _updateVertCoordsTexture( const glm::mat4& MV );
-    void _enableVertexAttribute( const float* buf, size_t length, bool attrib1Enabled ) const;
     void _configure3DTextureNearestInterpolation() const;
     void _configure3DTextureLinearInterpolation() const;
     void _configure2DTextureLinearInterpolation() const;

--- a/lib/render/RayCaster.cpp
+++ b/lib/render/RayCaster.cpp
@@ -1236,6 +1236,8 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     // Each strip will have the same numOfVertices for the first 4 faces
     size_t      numOfVertices = bx * 2;
     unsigned int* indexBuffer = new unsigned int[ numOfVertices ];
+    std::memset( indexBuffer, 0, numOfVertices * sizeof(unsigned int) );
+    // Create buffer object to keep indices
     glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int), 
                   indexBuffer,              GL_DYNAMIC_DRAW );
 
@@ -1247,6 +1249,7 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
         attrib1Buffer  = new  int[ bx * by * 4 ];    // Buffer for front and back face
         std::memset( attrib1Buffer, 0, bx * by * 4 * sizeof(int) );
         glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+        // Create buffer object to keep attributes
         glBufferData( GL_ARRAY_BUFFER,      bx * by * 4 * sizeof(int),
                       attrib1Buffer,        GL_DYNAMIC_DRAW );
     }   
@@ -1254,7 +1257,7 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     //
     // Render front face: 
     //
-    //_enableVertexAttribute( _userCoordinates.frontFace, bx * by * 3, attrib1Enabled );
+    // Attribute 0 keeps all the vertex indices of the entire front face.
     glEnableVertexAttribArray( 0 );
     glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
     glBufferData( GL_ARRAY_BUFFER,              bx * by * 3 * sizeof(float),
@@ -1292,16 +1295,14 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 2 ] = int(bz) - 2;
                 attrib1Buffer[ attribIdx + 3 ] = 0;
             }
+            // Update attribute 1
             glEnableVertexAttribArray( 1 );
-            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
-            //glBufferData( GL_ARRAY_BUFFER,      bx * by * 4 * sizeof(int),
-            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBindBuffer(    GL_ARRAY_BUFFER,   _vertexAttribId );
             glBufferSubData( GL_ARRAY_BUFFER,   y * bx * 4 * sizeof(int), 
                              2 * bx * 4 * sizeof(int), (attrib1Buffer + y * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
         }
-        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int), 
-        //              indexBuffer,              GL_DYNAMIC_DRAW );
+        // Update indices buffer
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
@@ -1310,7 +1311,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     //
     // Render back face: 
     //
-    //_enableVertexAttribute( _userCoordinates.backFace, bx * by * 3, attrib1Enabled );
     glEnableVertexAttribArray( 0 );
     glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
     glBufferData( GL_ARRAY_BUFFER,              bx * by * 3 * sizeof(float),
@@ -1340,15 +1340,11 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 3 ] = 1;
             }
             glEnableVertexAttribArray( 1 );
-            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
-            //glBufferData( GL_ARRAY_BUFFER,      bx * by * 4 * sizeof(int),
-            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBindBuffer(    GL_ARRAY_BUFFER,   _vertexAttribId );
             glBufferSubData( GL_ARRAY_BUFFER,   y * bx * 4 * sizeof(int), 
                              2 * bx * 4 * sizeof(int), (attrib1Buffer + y * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
         }
-        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-        //              indexBuffer,              GL_DYNAMIC_DRAW );
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
@@ -1360,6 +1356,7 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
         attrib1Buffer = new int[ bx * bz * 4 ]; // For top and bottom faces
         std::memset( attrib1Buffer, 0, bx * bz * 4 * sizeof(int) );
         glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+        // Create a new buffer object with the new size.
         glBufferData( GL_ARRAY_BUFFER,      bx * bz * 4 * sizeof(int),
                       attrib1Buffer,        GL_DYNAMIC_DRAW );
     }
@@ -1367,7 +1364,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     //
     // Render top face: 
     //
-    //_enableVertexAttribute( _userCoordinates.topFace, bx * bz * 3, attrib1Enabled );
     glEnableVertexAttribArray( 0 );
     glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
     glBufferData( GL_ARRAY_BUFFER,              bx * bz * 3 * sizeof(float),
@@ -1397,15 +1393,11 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 3 ] = 2;
             }
             glEnableVertexAttribArray( 1 );
-            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
-            //glBufferData( GL_ARRAY_BUFFER,      bx * bz * 4 * sizeof(int),
-            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBindBuffer(    GL_ARRAY_BUFFER,   _vertexAttribId );
             glBufferSubData( GL_ARRAY_BUFFER,   z * bx * 4 * sizeof(int), 
                              2 * bx * 4 * sizeof(int), (attrib1Buffer + z * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
         }
-        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-        //              indexBuffer,              GL_DYNAMIC_DRAW );
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
@@ -1414,7 +1406,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     //
     // Render bottom face: 
     //
-    //_enableVertexAttribute( _userCoordinates.bottomFace, bx * bz * 3, attrib1Enabled );
     glEnableVertexAttribArray( 0 );
     glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
     glBufferData( GL_ARRAY_BUFFER,              bx * bz * 3 * sizeof(float),
@@ -1444,15 +1435,11 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 3 ] = 3;
             }
             glEnableVertexAttribArray( 1 );
-            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
-            //glBufferData( GL_ARRAY_BUFFER,      bx * bz * 4 * sizeof(int),
-            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBindBuffer(    GL_ARRAY_BUFFER,   _vertexAttribId );
             glBufferSubData( GL_ARRAY_BUFFER,   z * bx * 4 * sizeof(int), 
                              2 * bx * 4 * sizeof(int), (attrib1Buffer + z * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
         }
-        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-        //              indexBuffer,              GL_DYNAMIC_DRAW );
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
@@ -1462,6 +1449,8 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     numOfVertices = by * 2;
     delete[] indexBuffer;
     indexBuffer = new unsigned int[ numOfVertices ];
+    std::memset( indexBuffer, 0, numOfVertices * sizeof(unsigned int) );
+    // Re-create the index buffer object with the new size.
     glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int), 
                   indexBuffer,              GL_DYNAMIC_DRAW );
     if( attrib1Enabled )
@@ -1477,7 +1466,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     //
     // Render right face: 
     //
-    //_enableVertexAttribute( _userCoordinates.rightFace, by * bz * 3, attrib1Enabled );
     glEnableVertexAttribArray( 0 );
     glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
     glBufferData( GL_ARRAY_BUFFER,              by * bz * 3 * sizeof(float),
@@ -1507,15 +1495,11 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 3 ] = 4;
             }
             glEnableVertexAttribArray( 1 );
-            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
-            //glBufferData( GL_ARRAY_BUFFER,      by * bz * 4 * sizeof(int),
-            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBindBuffer(    GL_ARRAY_BUFFER,   _vertexAttribId );
             glBufferSubData( GL_ARRAY_BUFFER,   z * by * 4 * sizeof(int), 
                              2 * by * 4 * sizeof(int), (attrib1Buffer + z * by * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
         }
-        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-        //              indexBuffer,              GL_DYNAMIC_DRAW );
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
@@ -1524,7 +1508,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     //
     // Render left face
     //
-    //_enableVertexAttribute( _userCoordinates.leftFace, by * bz * 3, attrib1Enabled );
     glEnableVertexAttribArray( 0 );
     glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
     glBufferData( GL_ARRAY_BUFFER,              by * bz * 3 * sizeof(float),
@@ -1554,15 +1537,11 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 3 ] = 5;
             }
             glEnableVertexAttribArray( 1 );
-            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
-            //glBufferData( GL_ARRAY_BUFFER,      by * bz * 4 * sizeof(int),
-            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBindBuffer(    GL_ARRAY_BUFFER,   _vertexAttribId );
             glBufferSubData( GL_ARRAY_BUFFER,   z * by * 4 * sizeof(int), 
                              2 * by * 4 * sizeof(int), (attrib1Buffer + z * by * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
         }
-        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-        //              indexBuffer,              GL_DYNAMIC_DRAW );
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
@@ -1574,22 +1553,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     glDisableVertexAttribArray( 0 );
     glDisableVertexAttribArray( 1 );
     glBindBuffer( GL_ARRAY_BUFFER, 0 );
-}
-
-void RayCaster::_enableVertexAttribute( const float* buf, 
-                                        size_t       length, 
-                                        bool         attrib1Enabled ) const
-{
-    glEnableVertexAttribArray( 0 );
-    glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
-    glBufferData( GL_ARRAY_BUFFER,              length * sizeof(float),
-                  buf,                          GL_STATIC_DRAW );
-    glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
-    //if( attrib1Enabled )
-    //{
-    //    glEnableVertexAttribArray( 1 );
-    //    glBindBuffer( GL_ARRAY_BUFFER, _vertexAttribId );
-    //}
 }
 
 

--- a/lib/render/RayCaster.cpp
+++ b/lib/render/RayCaster.cpp
@@ -1260,7 +1260,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     glBufferData( GL_ARRAY_BUFFER,              bx * by * 3 * sizeof(float),
                   _userCoordinates.frontFace,   GL_STATIC_DRAW );
     glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
-    glEnableVertexAttribArray( 0 );
     for( unsigned int y = 0; y < by - 1; y++ )   // Looping over every TriangleStrip
     {
         idx = 0;
@@ -1300,7 +1299,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glBufferSubData( GL_ARRAY_BUFFER,   y * bx * 4 * sizeof(int), 
                              2 * bx * 4 * sizeof(int), (attrib1Buffer + y * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
-            glEnableVertexAttribArray( 1 );
         }
         //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int), 
         //              indexBuffer,              GL_DYNAMIC_DRAW );
@@ -1318,7 +1316,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     glBufferData( GL_ARRAY_BUFFER,              bx * by * 3 * sizeof(float),
                   _userCoordinates.backFace,    GL_STATIC_DRAW );
     glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
-    glEnableVertexAttribArray( 0 );
     for( unsigned int y = 0; y < by - 1; y++ )   // strip by strip
     {
         idx = 0;
@@ -1349,7 +1346,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glBufferSubData( GL_ARRAY_BUFFER,   y * bx * 4 * sizeof(int), 
                              2 * bx * 4 * sizeof(int), (attrib1Buffer + y * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
-            glEnableVertexAttribArray( 1 );
         }
         //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
         //              indexBuffer,              GL_DYNAMIC_DRAW );
@@ -1377,7 +1373,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     glBufferData( GL_ARRAY_BUFFER,              bx * bz * 3 * sizeof(float),
                   _userCoordinates.topFace,     GL_STATIC_DRAW );
     glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
-    glEnableVertexAttribArray( 0 );
     for( unsigned int z = 0; z < bz - 1; z++ )   
     {
         idx = 0;
@@ -1408,7 +1403,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glBufferSubData( GL_ARRAY_BUFFER,   z * bx * 4 * sizeof(int), 
                              2 * bx * 4 * sizeof(int), (attrib1Buffer + z * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
-            glEnableVertexAttribArray( 1 );
         }
         //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
         //              indexBuffer,              GL_DYNAMIC_DRAW );
@@ -1426,7 +1420,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     glBufferData( GL_ARRAY_BUFFER,              bx * bz * 3 * sizeof(float),
                   _userCoordinates.bottomFace,  GL_STATIC_DRAW );
     glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
-    glEnableVertexAttribArray( 0 );
     for( unsigned int z = 0; z < bz - 1; z++ )   
     {
         idx = 0;
@@ -1457,7 +1450,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glBufferSubData( GL_ARRAY_BUFFER,   z * bx * 4 * sizeof(int), 
                              2 * bx * 4 * sizeof(int), (attrib1Buffer + z * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
-            glEnableVertexAttribArray( 1 );
         }
         //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
         //              indexBuffer,              GL_DYNAMIC_DRAW );
@@ -1491,7 +1483,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     glBufferData( GL_ARRAY_BUFFER,              by * bz * 3 * sizeof(float),
                   _userCoordinates.rightFace,   GL_STATIC_DRAW );
     glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
-    glEnableVertexAttribArray( 0 );
     for( unsigned int z = 0; z < bz - 1; z++ )   
     {
         idx = 0;
@@ -1522,7 +1513,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glBufferSubData( GL_ARRAY_BUFFER,   z * by * 4 * sizeof(int), 
                              2 * by * 4 * sizeof(int), (attrib1Buffer + z * by * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
-            glEnableVertexAttribArray( 1 );
         }
         //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
         //              indexBuffer,              GL_DYNAMIC_DRAW );
@@ -1540,7 +1530,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     glBufferData( GL_ARRAY_BUFFER,              by * bz * 3 * sizeof(float),
                   _userCoordinates.leftFace,    GL_STATIC_DRAW );
     glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
-    glEnableVertexAttribArray( 0 );
     for( unsigned int z = 0; z < bz - 1; z++ )   
     {
         idx = 0;
@@ -1571,7 +1560,6 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glBufferSubData( GL_ARRAY_BUFFER,   z * by * 4 * sizeof(int), 
                              2 * by * 4 * sizeof(int), (attrib1Buffer + z * by * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
-            glEnableVertexAttribArray( 1 );
         }
         //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
         //              indexBuffer,              GL_DYNAMIC_DRAW );

--- a/lib/render/RayCaster.cpp
+++ b/lib/render/RayCaster.cpp
@@ -1098,7 +1098,7 @@ void RayCaster::_drawVolumeFaces( int                         whichPass,
 
             glEnableVertexAttribArray( 0 );  // attribute 0 is vertex coordinates
             glBindBuffer( GL_ARRAY_BUFFER, _vertexBufferId );
-            glBufferData( GL_ARRAY_BUFFER, 12 * sizeof(GLfloat), nearCoords, GL_STREAM_DRAW );
+            glBufferData( GL_ARRAY_BUFFER, 12 * sizeof(GLfloat), nearCoords, GL_DYNAMIC_DRAW );
             glVertexAttribPointer( 0, 3, GL_FLOAT, GL_FALSE, 0, (void*)0 );
             glDrawArrays( GL_TRIANGLE_STRIP, 0, 4 );
             glBindBuffer( GL_ARRAY_BUFFER, 0 );
@@ -1241,30 +1241,37 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     int*    attrib1Buffer  = nullptr;
     if( castingMode == CellTraversal && whichPass == 3 )
     {
-            attrib1Enabled = true;
-        unsigned int big1  = bx > by ? bx : by;
-        unsigned int small = bx < by ? bx : by;
-        unsigned int big2  = bz > small ? bz : small;
-            attrib1Buffer  = new int[ big1 * big2 * 4 ];    // Enough length for all faces
+        attrib1Enabled = true;
+        attrib1Buffer  = new  int[ bx * by * 4 ];    // Buffer for front and back face
+        std::memset( attrib1Buffer, 0, bx * by * 4 * sizeof(int) );
+        glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+        glBufferData( GL_ARRAY_BUFFER,      bx * by * 4 * sizeof(int),
+                      attrib1Buffer,        GL_DYNAMIC_DRAW );
     }   
 
     //
     // Render front face: 
     //
-    _enableVertexAttribute( _userCoordinates.frontFace, bx * by * 3, attrib1Enabled );
+    //_enableVertexAttribute( _userCoordinates.frontFace, bx * by * 3, attrib1Enabled );
+    glEnableVertexAttribArray( 0 );
+    glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
+    glBufferData( GL_ARRAY_BUFFER,              bx * by * 3 * sizeof(float),
+                  _userCoordinates.frontFace,   GL_STATIC_DRAW );
+    glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
+    glEnableVertexAttribArray( 0 );
     for( unsigned int y = 0; y < by - 1; y++ )   // Looping over every TriangleStrip
     {
         idx = 0;
+        //
         // This loop controls rendering order of the triangle strip. It 
-        // provides the indices for each vertex in a strip. Strips are
-        // created one row at a time.
+        // provides the indices for each vertex in the current strip.
         //
         for( unsigned int x = 0; x < bx; x++ )   // Filling indices for vertices of this TriangleStrip
         {
             indexBuffer[ idx++ ] = (y + 1) * bx + x;
             indexBuffer[ idx++ ] = y * bx + x;
         }
-
+        //
         // In cell-traverse ray casting mode we need a cell index for the
         // two triangles forming the face of a cell. Use the OpenGL "provoking"
         // vertex to provide this information.
@@ -1284,12 +1291,17 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 2 ] = int(bz) - 2;
                 attrib1Buffer[ attribIdx + 3 ] = 0;
             }
-            glBufferData( GL_ARRAY_BUFFER,      bx * by * 4 * sizeof(int),
-                          attrib1Buffer,        GL_STREAM_DRAW );
+            glEnableVertexAttribArray( 1 );
+            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+            //glBufferData( GL_ARRAY_BUFFER,      bx * by * 4 * sizeof(int),
+            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBufferSubData( GL_ARRAY_BUFFER,   y * bx * 4 * sizeof(int), 
+                             2 * bx * 4 * sizeof(int), (attrib1Buffer + y * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
+            glEnableVertexAttribArray( 1 );
         }
         glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int), 
-                      indexBuffer,              GL_STREAM_DRAW );
+                      indexBuffer,              GL_DYNAMIC_DRAW );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }
@@ -1297,7 +1309,13 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     //
     // Render back face: 
     //
-    _enableVertexAttribute( _userCoordinates.backFace, bx * by * 3, attrib1Enabled );
+    //_enableVertexAttribute( _userCoordinates.backFace, bx * by * 3, attrib1Enabled );
+    glEnableVertexAttribArray( 0 );
+    glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
+    glBufferData( GL_ARRAY_BUFFER,              bx * by * 3 * sizeof(float),
+                  _userCoordinates.backFace,    GL_STATIC_DRAW );
+    glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
+    glEnableVertexAttribArray( 0 );
     for( unsigned int y = 0; y < by - 1; y++ )   // strip by strip
     {
         idx = 0;
@@ -1321,20 +1339,41 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 2 ] = 0;
                 attrib1Buffer[ attribIdx + 3 ] = 1;
             }
-            glBufferData( GL_ARRAY_BUFFER,      bx * by * 4 * sizeof(int),
-                          attrib1Buffer,        GL_STREAM_DRAW );
+            glEnableVertexAttribArray( 1 );
+            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+            //glBufferData( GL_ARRAY_BUFFER,      bx * by * 4 * sizeof(int),
+            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBufferSubData( GL_ARRAY_BUFFER,   y * bx * 4 * sizeof(int), 
+                             2 * bx * 4 * sizeof(int), (attrib1Buffer + y * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
+            glEnableVertexAttribArray( 1 );
         }
         glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-                      indexBuffer,              GL_STREAM_DRAW );
+                      indexBuffer,              GL_DYNAMIC_DRAW );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
+    }
+
+    if( attrib1Enabled )
+    {
+        delete[] attrib1Buffer;
+        attrib1Buffer = new int[ bx * bz * 4 ]; // For top and bottom faces
+        std::memset( attrib1Buffer, 0, bx * bz * 4 * sizeof(int) );
+        glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+        glBufferData( GL_ARRAY_BUFFER,      bx * bz * 4 * sizeof(int),
+                      attrib1Buffer,        GL_DYNAMIC_DRAW );
     }
 
     //
     // Render top face: 
     //
-    _enableVertexAttribute( _userCoordinates.topFace, bx * bz * 3, attrib1Enabled );
+    //_enableVertexAttribute( _userCoordinates.topFace, bx * bz * 3, attrib1Enabled );
+    glEnableVertexAttribArray( 0 );
+    glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
+    glBufferData( GL_ARRAY_BUFFER,              bx * bz * 3 * sizeof(float),
+                  _userCoordinates.topFace,     GL_STATIC_DRAW );
+    glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
+    glEnableVertexAttribArray( 0 );
     for( unsigned int z = 0; z < bz - 1; z++ )   
     {
         idx = 0;
@@ -1358,12 +1397,17 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 2 ] = int(z);
                 attrib1Buffer[ attribIdx + 3 ] = 2;
             }
-            glBufferData( GL_ARRAY_BUFFER,      bx * bz * 4 * sizeof(int),
-                          attrib1Buffer,        GL_STREAM_DRAW );
+            glEnableVertexAttribArray( 1 );
+            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+            //glBufferData( GL_ARRAY_BUFFER,      bx * bz * 4 * sizeof(int),
+            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBufferSubData( GL_ARRAY_BUFFER,   z * bx * 4 * sizeof(int), 
+                             2 * bx * 4 * sizeof(int), (attrib1Buffer + z * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
+            glEnableVertexAttribArray( 1 );
         }
         glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-                      indexBuffer,              GL_STREAM_DRAW );
+                      indexBuffer,              GL_DYNAMIC_DRAW );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }
@@ -1371,7 +1415,13 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     //
     // Render bottom face: 
     //
-    _enableVertexAttribute( _userCoordinates.bottomFace, bx * bz * 3, attrib1Enabled );
+    //_enableVertexAttribute( _userCoordinates.bottomFace, bx * bz * 3, attrib1Enabled );
+    glEnableVertexAttribArray( 0 );
+    glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
+    glBufferData( GL_ARRAY_BUFFER,              bx * bz * 3 * sizeof(float),
+                  _userCoordinates.bottomFace,  GL_STATIC_DRAW );
+    glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
+    glEnableVertexAttribArray( 0 );
     for( unsigned int z = 0; z < bz - 1; z++ )   
     {
         idx = 0;
@@ -1395,12 +1445,17 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 2 ] = int(z);
                 attrib1Buffer[ attribIdx + 3 ] = 3;
             }
-            glBufferData( GL_ARRAY_BUFFER,      bx * bz * 4 * sizeof(int),
-                          attrib1Buffer,        GL_STREAM_DRAW );
+            glEnableVertexAttribArray( 1 );
+            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+            //glBufferData( GL_ARRAY_BUFFER,      bx * bz * 4 * sizeof(int),
+            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBufferSubData( GL_ARRAY_BUFFER,   z * bx * 4 * sizeof(int), 
+                             2 * bx * 4 * sizeof(int), (attrib1Buffer + z * bx * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
+            glEnableVertexAttribArray( 1 );
         }
         glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-                      indexBuffer,              GL_STREAM_DRAW );
+                      indexBuffer,              GL_DYNAMIC_DRAW );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }
@@ -1409,11 +1464,26 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     numOfVertices = by * 2;
     delete[] indexBuffer;
     indexBuffer = new unsigned int[ numOfVertices ];
+    if( attrib1Enabled )
+    {
+        delete[] attrib1Buffer;
+        attrib1Buffer  = new  int[ by * bz * 4 ];    // For right and left faces
+        std::memset( attrib1Buffer, 0, by * bz * 4 * sizeof(int) );
+        glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+        glBufferData( GL_ARRAY_BUFFER,      by * bz * 4 * sizeof(int),
+                      attrib1Buffer,        GL_DYNAMIC_DRAW );
+    }
 
     //
     // Render right face: 
     //
-    _enableVertexAttribute( _userCoordinates.rightFace, by * bz * 3, attrib1Enabled );
+    //_enableVertexAttribute( _userCoordinates.rightFace, by * bz * 3, attrib1Enabled );
+    glEnableVertexAttribArray( 0 );
+    glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
+    glBufferData( GL_ARRAY_BUFFER,              by * bz * 3 * sizeof(float),
+                  _userCoordinates.rightFace,   GL_STATIC_DRAW );
+    glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
+    glEnableVertexAttribArray( 0 );
     for( unsigned int z = 0; z < bz - 1; z++ )   
     {
         idx = 0;
@@ -1437,12 +1507,17 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 2 ] = int(z);
                 attrib1Buffer[ attribIdx + 3 ] = 4;
             }
-            glBufferData( GL_ARRAY_BUFFER,      by * bz * 4 * sizeof(int),
-                          attrib1Buffer,        GL_STREAM_DRAW );
+            glEnableVertexAttribArray( 1 );
+            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+            //glBufferData( GL_ARRAY_BUFFER,      by * bz * 4 * sizeof(int),
+            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBufferSubData( GL_ARRAY_BUFFER,   z * by * 4 * sizeof(int), 
+                             2 * by * 4 * sizeof(int), (attrib1Buffer + z * by * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
+            glEnableVertexAttribArray( 1 );
         }
         glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-                      indexBuffer,              GL_STREAM_DRAW );
+                      indexBuffer,              GL_DYNAMIC_DRAW );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }
@@ -1450,7 +1525,13 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     //
     // Render left face
     //
-    _enableVertexAttribute( _userCoordinates.leftFace, by * bz * 3, attrib1Enabled );
+    //_enableVertexAttribute( _userCoordinates.leftFace, by * bz * 3, attrib1Enabled );
+    glEnableVertexAttribArray( 0 );
+    glBindBuffer( GL_ARRAY_BUFFER,              _vertexBufferId );
+    glBufferData( GL_ARRAY_BUFFER,              by * bz * 3 * sizeof(float),
+                  _userCoordinates.leftFace,    GL_STATIC_DRAW );
+    glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
+    glEnableVertexAttribArray( 0 );
     for( unsigned int z = 0; z < bz - 1; z++ )   
     {
         idx = 0;
@@ -1474,12 +1555,17 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
                 attrib1Buffer[ attribIdx + 2 ] = int(z);
                 attrib1Buffer[ attribIdx + 3 ] = 5;
             }
-            glBufferData( GL_ARRAY_BUFFER,      by * bz * 4 * sizeof(int),
-                          attrib1Buffer,        GL_STREAM_DRAW );
+            glEnableVertexAttribArray( 1 );
+            glBindBuffer( GL_ARRAY_BUFFER,      _vertexAttribId );
+            //glBufferData( GL_ARRAY_BUFFER,      by * bz * 4 * sizeof(int),
+            //              attrib1Buffer,        GL_DYNAMIC_DRAW );
+            glBufferSubData( GL_ARRAY_BUFFER,   z * by * 4 * sizeof(int), 
+                             2 * by * 4 * sizeof(int), (attrib1Buffer + z * by * 4) );
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
+            glEnableVertexAttribArray( 1 );
         }
         glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-                      indexBuffer,              GL_STREAM_DRAW );
+                      indexBuffer,              GL_DYNAMIC_DRAW );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }
@@ -1501,11 +1587,11 @@ void RayCaster::_enableVertexAttribute( const float* buf,
     glBufferData( GL_ARRAY_BUFFER,              length * sizeof(float),
                   buf,                          GL_STATIC_DRAW );
     glVertexAttribPointer( 0, 3, GL_FLOAT,      GL_FALSE, 0, (void*)0 );
-    if( attrib1Enabled )
-    {
-        glEnableVertexAttribArray( 1 );
-        glBindBuffer( GL_ARRAY_BUFFER, _vertexAttribId );
-    }
+    //if( attrib1Enabled )
+    //{
+    //    glEnableVertexAttribArray( 1 );
+    //    glBindBuffer( GL_ARRAY_BUFFER, _vertexAttribId );
+    //}
 }
 
 

--- a/lib/render/RayCaster.cpp
+++ b/lib/render/RayCaster.cpp
@@ -1236,6 +1236,8 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     // Each strip will have the same numOfVertices for the first 4 faces
     size_t      numOfVertices = bx * 2;
     unsigned int* indexBuffer = new unsigned int[ numOfVertices ];
+    glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int), 
+                  indexBuffer,              GL_DYNAMIC_DRAW );
 
     bool    attrib1Enabled = false;      // Attribute to hold provoking index of each triangle.
     int*    attrib1Buffer  = nullptr;
@@ -1300,8 +1302,9 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
             glEnableVertexAttribArray( 1 );
         }
-        glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int), 
-                      indexBuffer,              GL_DYNAMIC_DRAW );
+        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int), 
+        //              indexBuffer,              GL_DYNAMIC_DRAW );
+        glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }
@@ -1348,8 +1351,9 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
             glEnableVertexAttribArray( 1 );
         }
-        glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-                      indexBuffer,              GL_DYNAMIC_DRAW );
+        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
+        //              indexBuffer,              GL_DYNAMIC_DRAW );
+        glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }
@@ -1406,8 +1410,9 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
             glEnableVertexAttribArray( 1 );
         }
-        glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-                      indexBuffer,              GL_DYNAMIC_DRAW );
+        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
+        //              indexBuffer,              GL_DYNAMIC_DRAW );
+        glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }
@@ -1454,8 +1459,9 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
             glEnableVertexAttribArray( 1 );
         }
-        glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-                      indexBuffer,              GL_DYNAMIC_DRAW );
+        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
+        //              indexBuffer,              GL_DYNAMIC_DRAW );
+        glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }
@@ -1464,6 +1470,8 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
     numOfVertices = by * 2;
     delete[] indexBuffer;
     indexBuffer = new unsigned int[ numOfVertices ];
+    glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int), 
+                  indexBuffer,              GL_DYNAMIC_DRAW );
     if( attrib1Enabled )
     {
         delete[] attrib1Buffer;
@@ -1516,8 +1524,9 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
             glEnableVertexAttribArray( 1 );
         }
-        glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-                      indexBuffer,              GL_DYNAMIC_DRAW );
+        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
+        //              indexBuffer,              GL_DYNAMIC_DRAW );
+        glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }
@@ -1564,8 +1573,9 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
             glVertexAttribIPointer( 1, 4,       GL_INT, 0, (void*)0 );
             glEnableVertexAttribArray( 1 );
         }
-        glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
-                      indexBuffer,              GL_DYNAMIC_DRAW );
+        //glBufferData( GL_ELEMENT_ARRAY_BUFFER,  numOfVertices * sizeof(unsigned int),
+        //              indexBuffer,              GL_DYNAMIC_DRAW );
+        glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
     }

--- a/share/shaders/DVR3rdPassMode1.frag
+++ b/share/shaders/DVR3rdPassMode1.frag
@@ -138,7 +138,10 @@ void main(void)
     vec3 rayDirEye      = stopEye - startEye ;
     float rayDirLength  = length( rayDirEye );
     if( rayDirLength    < ULP10 )
+    {
         discard;
+        return;
+    }
 
     float nStepsf       = rayDirLength / stepSize1D;
     vec3  stepSize3D    = rayDirEye / nStepsf;

--- a/share/shaders/DVR3rdPassMode2.frag
+++ b/share/shaders/DVR3rdPassMode2.frag
@@ -340,7 +340,10 @@ void main(void)
     vec3 rayDirEye      = stopEye - startEye;
     float rayDirLength  = length( rayDirEye );
     if(   rayDirLength  < ULP10 )
+    {
         discard;
+        return;
+    }
 
     // The incoming stepSize1D results in approximate 2 samples per cell.
     float nStepsf       = rayDirLength / stepSize1D;
@@ -359,7 +362,10 @@ void main(void)
         if( LocateNextCell( step1CellIdx, step1Eye, correctIdx ) )
             step1CellIdx = correctIdx;
         else 
+        {
             discard;    // This case always happens on the boundary.
+            return;
+        }
     }
 
     // Set depth value at the backface 

--- a/share/shaders/IsoSurface3rdPassMode1.frag
+++ b/share/shaders/IsoSurface3rdPassMode1.frag
@@ -145,7 +145,10 @@ void main(void)
     vec3 rayDirEye      = stopEye - startEye;
     float rayDirLength  = length( rayDirEye );
     if( rayDirLength    < ULP10 )
+    {
         discard;
+        return;
+    }
 
     float nStepsf       = rayDirLength  / stepSize1D;
     vec3  stepSize3D    = rayDirEye   / nStepsf;

--- a/share/shaders/IsoSurface3rdPassMode2.frag
+++ b/share/shaders/IsoSurface3rdPassMode2.frag
@@ -346,7 +346,10 @@ void main(void)
     vec3 rayDirEye      = stopEye - startEye;
     float rayDirLength  = length( rayDirEye );
     if(   rayDirLength  < ULP10 )
+    {
         discard;
+        return;
+    }
 
     // The incoming stepSize1D results in approximate 2 samples per cell.
     float nStepsf       = rayDirLength / stepSize1D;
@@ -364,8 +367,11 @@ void main(void)
         ivec3 correctIdx;
         if( LocateNextCell( step1CellIdx, step1Eye, correctIdx ) )
             step1CellIdx = correctIdx;
-        else 
-            discard;    // This case always happens on the boundary.
+        else     // This case always happens on the boundary.
+        {
+            discard;
+            return;
+        }
     }
 
     // Set depth value at the backface 


### PR DESCRIPTION
This PR replaces a few uses of `glBufferData` with `glBufferSubData`.

The benefits are:
1) it improves performance (by a small amount)
2) it behaves more friendly with mac. In fact, it stop crashing on Sam's mac. However, it still crashes on John's mac. 
