### PR TITLE
Sleep

### DIFF
--- a/include/vapor/RayCaster.h
+++ b/include/vapor/RayCaster.h
@@ -210,6 +210,7 @@ protected:
     void _configure3DTextureNearestInterpolation() const;
     void _configure3DTextureLinearInterpolation() const;
     void _configure2DTextureLinearInterpolation() const;
+    void _sleepAWhile() const;
 
     double _getElapsedSeconds( const struct timeval* begin, const struct timeval* end ) const;
 

--- a/include/vapor/RayCaster.h
+++ b/include/vapor/RayCaster.h
@@ -212,7 +212,9 @@ protected:
     void _configure2DTextureLinearInterpolation() const;
     void _sleepAWhile() const;
 
+#ifndef WIN32
     double _getElapsedSeconds( const struct timeval* begin, const struct timeval* end ) const;
+#endif
 
 };  // End of class RayCaster
 

--- a/lib/render/RayCaster.cpp
+++ b/lib/render/RayCaster.cpp
@@ -1783,14 +1783,15 @@ int RayCaster::_selectDefaultCastingMethod() const
 
 void RayCaster::_sleepAWhile() const
 {
-glFinish();
 #ifdef WIN32
-    Sleep( 3 ); // 3 milliseconds
+    glFinish();
+    Sleep( 1 ); // 1 milliseconds
 #else
     #ifdef Darwin
         struct timespec req, rem;
         req.tv_sec  = 0;
-        req.tv_nsec = 3000000L; // 3 milliseconds
+        req.tv_nsec = 1000000L; // 1 milliseconds
+        glFinish();
         nanosleep( &req, &rem );
     #endif
 #endif

--- a/lib/render/RayCaster.cpp
+++ b/lib/render/RayCaster.cpp
@@ -1093,15 +1093,15 @@ void RayCaster::_drawVolumeFaces( int                         whichPass,
             glm::vec4 bottomLeftNDC ( -1.0f, -1.0f, -0.999f, 1.0f );
             glm::vec4 topRightNDC   (  1.0f,  1.0f, -0.999f, 1.0f );
             glm::vec4 bottomRightNDC(  1.0f, -1.0f, -0.999f, 1.0f );
-            glm::vec4 near[4];
-            near[0] = InversedMVP * topLeftNDC;
-            near[1] = InversedMVP * bottomLeftNDC;
-            near[2] = InversedMVP * topRightNDC;
-            near[3] = InversedMVP * bottomRightNDC;
+            glm::vec4 nearP[4];
+            nearP[0] = InversedMVP * topLeftNDC;
+            nearP[1] = InversedMVP * bottomLeftNDC;
+            nearP[2] = InversedMVP * topRightNDC;
+            nearP[3] = InversedMVP * bottomRightNDC;
             for( int i = 0; i < 4; i++ )
             {
-                near[i] /= near[i].w;
-                std::memcpy( nearCoords + i * 3, glm::value_ptr(near[i]), 3 * sizeof(GLfloat) );
+                nearP[i] /= nearP[i].w;
+                std::memcpy( nearCoords + i * 3, glm::value_ptr(nearP[i]), 3 * sizeof(GLfloat) );
             }
 
             glEnableVertexAttribArray( 0 );  // attribute 0 is vertex coordinates
@@ -1570,15 +1570,13 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
 }
 
 
+#ifndef WIN32
 double RayCaster::_getElapsedSeconds( const struct timeval* begin, 
                                       const struct timeval* end ) const
 {
-#ifdef WIN32
-	return -1.0;
-#else
     return (end->tv_sec - begin->tv_sec) + ((end->tv_usec - begin->tv_usec)/1000000.0);
-#endif
 }
+#endif
 
 void RayCaster::_updateViewportWhenNecessary( const GLint* viewport )
 {

--- a/lib/render/RayCaster.cpp
+++ b/lib/render/RayCaster.cpp
@@ -7,6 +7,14 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/ext/matrix_relational.hpp>
 
+#ifdef WIN32
+    #include <Windows.h>
+#else
+    #ifdef Darwin
+        #include <time.h>
+    #endif
+#endif
+
 #define OUTOFDATE    1
 #define GLNOTREADY   2
 #define GRIDERROR   -1
@@ -1306,6 +1314,7 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
+        _sleepAWhile();
     }
 
     //
@@ -1348,6 +1357,7 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
+        _sleepAWhile();
     }
 
     if( attrib1Enabled )
@@ -1401,6 +1411,7 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
+        _sleepAWhile();
     }
 
     //
@@ -1443,6 +1454,7 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
+        _sleepAWhile();
     }
 
     // Each strip will have the same numOfVertices for the rest 2 faces.
@@ -1503,6 +1515,7 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
+        _sleepAWhile();
     }
 
     //
@@ -1545,6 +1558,7 @@ void RayCaster::_renderTriangleStrips( int whichPass, int  castingMode ) const
         glBufferSubData( GL_ELEMENT_ARRAY_BUFFER, 0,  numOfVertices * sizeof(unsigned int), indexBuffer );
         glDrawElements( GL_TRIANGLE_STRIP,      numOfVertices,
                         GL_UNSIGNED_INT,        (void*)0 );
+        _sleepAWhile();
     }
 
     if( attrib1Enabled )
@@ -1767,4 +1781,19 @@ int RayCaster::_selectDefaultCastingMethod() const
     delete grid;
 
     return 0;
+}
+
+void RayCaster::_sleepAWhile() const
+{
+glFinish();
+#ifdef WIN32
+    Sleep( 3 ); // 3 milliseconds
+#else
+    #ifdef Darwin
+        struct timespec req, rem;
+        req.tv_sec  = 0;
+        req.tv_nsec = 3000000L; // 3 milliseconds
+        nanosleep( &req, &rem );
+    #endif
+#endif
 }


### PR DESCRIPTION
This PR implements a sleep function that requires the raycasting process to sleep 1 millisecond after rendering each triangle strip. 
Note: this function only applies to Macos and Windows. 