### PR TITLE
Fix for 1453

### DIFF
--- a/lib/render/TwoDRenderer.cpp
+++ b/lib/render/TwoDRenderer.cpp
@@ -182,6 +182,7 @@ void TwoDRenderer::_openGLInit() {
 //
 void TwoDRenderer::_openGLRestore()
 {
+    glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glDisable(GL_BLEND);
 	glDisable(GL_DEPTH_TEST);


### PR DESCRIPTION
Fix for #1453: Image Renderer Corrupt on Windows with Intel Graphics.

![](https://user-images.githubusercontent.com/9522770/52354634-02f3d400-29ee-11e9-88b2-a8383f90bce1.gif)
