### PR TITLE
change combo display from 0 to <no-variable>

### DIFF
--- a/apps/vaporgui/VariablesWidget.cpp
+++ b/apps/vaporgui/VariablesWidget.cpp
@@ -153,7 +153,7 @@ void VariablesWidget::setVarName(const QString& qname){
 	if (! (_variableFlags & SCALAR)) return;
 
 	string name = qname.toStdString();
-	name = name == "0" ? "" : name;
+	name = name == "<no-variable>" ? "" : name;
 	_rParams->SetVariableName(name);
 
 	if (! (_variableFlags & COLOR))
@@ -169,7 +169,7 @@ void VariablesWidget::setVectorVarName(const QString& qname, int component) {
 	if (! (_variableFlags & VECTOR)) return;
 
 	string name = qname.toStdString();
-	name = name == "0" ? "" : name;
+	name = name == "<no-variable>" ? "" : name;
 
 	vector<string> varnames = _rParams->GetFieldVariableNames();
 	varnames[component] = name;
@@ -209,7 +209,7 @@ void VariablesWidget::setHeightVarName(const QString& qname){
 	if (! (_variableFlags & HEIGHT)) return;
 
 	string name = qname.toStdString();
-	name = name == "0" ? "" : name;
+	name = name == "<no-variable>" ? "" : name;
 	_rParams->SetHeightVariableName(name);
 }
 
@@ -219,7 +219,7 @@ void VariablesWidget::setColorMappedVariable(const QString& qname) {
 	if (! (_variableFlags & COLOR)) return;
 
 	string name = qname.toStdString();
-	name = name == "0" ? "" : name;
+	name = name == "<no-variable>" ? "" : name;
 	_rParams->SetColorMapVariableName(name);
 }
 
@@ -341,10 +341,10 @@ string VariablesWidget::updateVarCombo(
 	vector <string> my_varnames = varnames;
 	
 	if (doZero)
-		my_varnames.insert(my_varnames.begin(), "0");
+		my_varnames.insert(my_varnames.begin(), "<no-variable>");
 	
 	if (currentVar == "") {
-		currentVar = "0";
+		currentVar = "<no-variable>";
 	}
 
 	varCombo->clear();

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -305,7 +305,7 @@ void RenderParams::SetEnabled(bool val){
 
 void RenderParams::SetVariableName(string varname){
 
-	varname = string_replace(varname, "0", "NULL");
+	varname = string_replace(varname, "<no-variable>", "NULL");
 	varname = string_replace(varname, "", "NULL");
 
 	SetValueString(_variableNameTag,"Specify variable name", varname);
@@ -469,7 +469,7 @@ vector<string> RenderParams::GetFieldVariableNames()  const {
 
 void RenderParams::SetFieldVariableNames(vector<string> varnames){
 
-	varnames = string_replace(varnames, "0", "NULL");
+	varnames = string_replace(varnames, "<no-variable>", "NULL");
 	varnames = string_replace(varnames, "", "NULL");
 	for (int i=varnames.size(); i<3; i++) varnames.push_back("NULL");
 
@@ -489,7 +489,7 @@ vector<string> RenderParams::GetAuxVariableNames()  const
 
 void RenderParams::SetAuxVariableNames(std::vector<std::string> varnames)
 {
-    varnames = string_replace(varnames, "0", "NULL");
+    varnames = string_replace(varnames, "<no-variable>", "NULL");
     varnames = string_replace(varnames, "", "NULL");
     SetValueStringVec( _auxVariableNamesTag, "Specify auxiliary varnames", varnames);
 }
@@ -516,7 +516,7 @@ string RenderParams::GetHeightVariableName() const {
 
 void RenderParams::SetHeightVariableName(string varname) {
 
-	varname = string_replace(varname, "0", "NULL");
+	varname = string_replace(varname, "<no-variable>", "NULL");
 	varname = string_replace(varname, "", "NULL");
 
 	SetValueString(
@@ -535,7 +535,7 @@ string RenderParams::GetColorMapVariableName() const {
 
 void RenderParams::SetColorMapVariableName(string varname) {
 
-	varname = string_replace(varname, "0", "NULL");
+	varname = string_replace(varname, "<no-variable>", "NULL");
 	varname = string_replace(varname, "", "NULL");
 
 	SetValueString(

--- a/lib/render/Renderer.cpp
+++ b/lib/render/Renderer.cpp
@@ -292,7 +292,7 @@ bool Renderer::VariableExists(
 ) const {
 
 	for (int i=0; i<varnames.size(); i++) {
-		if (zeroOK && (varnames[i] == "0" || varnames[i] == "")) {
+		if (zeroOK && (varnames[i] == "<no-variable>" || varnames[i] == "")) {
 			continue;
 		}
 


### PR DESCRIPTION
This PR changes the display of no variable being selected from "0" to <no-variable>.

This change has passed test to work with 
1. Barb renderer
2. Save and open sessions. 