### PR TITLE
Python deprecated register

### DIFF
--- a/apps/vaporgui/Manip.cpp
+++ b/apps/vaporgui/Manip.cpp
@@ -569,7 +569,6 @@ bool TranslateStretchManip::pixelToVector(
 		strHandleMid[0],strHandleMid[1], strHandleMid[2], _modelViewMatrix, 
 		_projectionMatrix, viewport,&screenx,&screeny, &screenz
 	);
-    double screen[3] = {screenx, screeny, screenz};
 	//Obtain the coords of a point in view:
 	bool success = (0 != gluUnProject(
 		(GLdouble)winCoords[0],

--- a/apps/vaporgui/Plot.cpp
+++ b/apps/vaporgui/Plot.cpp
@@ -13,7 +13,6 @@
 //  Date:       January 2018
 //
 
-#include <Python.h>
 #include <vapor/MyPython.h>
 #include <vapor/DC.h>
 

--- a/include/vapor/MyPython.h
+++ b/include/vapor/MyPython.h
@@ -7,6 +7,9 @@
 
 #include <vapor/MyBase.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-register"
+
 #ifdef WIN32
 #ifdef _DEBUG
 #undef _DEBUG
@@ -18,6 +21,8 @@
 #else
 #include <Python.h>
 #endif
+
+#pragma clang diagnostic pop
 
 namespace Wasp {
 

--- a/include/vapor/PyEngine.h
+++ b/include/vapor/PyEngine.h
@@ -1,5 +1,5 @@
 #include <vector>
-#include <Python.h>
+#include <vapor/MyPython.h>
 #include <vapor/DataMgr.h>
 #include <vapor/DC.h>
 

--- a/lib/render/PyEngine.cpp
+++ b/lib/render/PyEngine.cpp
@@ -5,7 +5,6 @@
 #include <new>
 #include <vapor/utils.h>
 #include <vapor/DataMgrUtils.h>
-#include <vapor/MyPython.h>
 #include <vapor/PyEngine.h>
 using namespace Wasp;
 using namespace VAPoR;


### PR DESCRIPTION
In a recent update of OSX the `register` keyword was deprecated. Some Python headers use this and were throwing warnings. This silences them.