### PR TITLE
Fixed #1481

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -723,6 +723,10 @@ void MainForm::hookupSignals() {
 		_tabMgr, SIGNAL(Proj4StringChanged(string)), 
 		this, SLOT( _setProj4String(string))
 	);
+	connect (
+		_vizWinMgr, SIGNAL(removeViz(const QString &)),
+		_tabMgr, SLOT(SetActiveViz(const QString &))
+	);
 }
 
 void MainForm::_createFileMenu() {

--- a/apps/vaporgui/RenderHolder.cpp
+++ b/apps/vaporgui/RenderHolder.cpp
@@ -303,7 +303,7 @@ void RenderHolder::_deleteRenderer() {
 	assert(rc == 0);
 
 	_controlExec->RemoveRenderer(
-		activeViz, dataSetName, rendererType, rendererName
+		activeViz, dataSetName, rendererType, rendererName, false
 	);
 	
 	// Update will rebuild the TableWidget with the updated state

--- a/apps/vaporgui/TabManager.cpp
+++ b/apps/vaporgui/TabManager.cpp
@@ -640,6 +640,7 @@ void TabManager::_updateRouters() {
 
 	if (activeViz.size() && renderClass.size() && instName.size()) {
         
+		SetActiveRenderer(activeViz, renderClass, instName);
 
 		EventRouter* eRouter = _getRenderEventRouter(
 			activeViz, renderClass, instName

--- a/apps/vaporgui/VizWinMgr.cpp
+++ b/apps/vaporgui/VizWinMgr.cpp
@@ -308,6 +308,7 @@ void VizWinMgr::_vizAboutToDisappear(string vizName)  {
 	string activeViz = p->GetActiveVizName();
 
     itr->second->makeCurrent();
+    _controlExec->RemoveAllRenderers(vizName, true);
     _controlExec->RemoveVisualizer(vizName);
 
 

--- a/include/vapor/ControlExecutive.h
+++ b/include/vapor/ControlExecutive.h
@@ -222,9 +222,27 @@ public:
 	const RenderParams *rp, string renderName, bool on
  );
 
+ //! Remove (destroy) the indicated renderer
+ //!
+ //! \param[in] hasOpenGLContext If true it is the callers job to ensure that the
+ //! OpenGL Context for the window \p winName is active. In this case the renderer
+ //! is destroyed immediately. If false the renderer is queue'd for later destruction
+ //! when \p winName has an active OpenGL context.
+ //! 
  void RemoveRenderer(
 	string winName, string dataSetName,
-	string renderType, string renderName
+	string renderType, string renderName, bool hasOpenGLContext
+ );
+
+ //! Remove (destroy) all renderers on this window
+ //!
+ //! \param[in] hasOpenGLContext If true it is the callers job to ensure that the
+ //! OpenGL Context for the window \p winName is active. In this case the renderer
+ //! is destroyed immediately. If false the renderer is queue'd for later destruction
+ //! when \p winName has an active OpenGL context.
+ //! 
+ void RemoveAllRenderers(
+	string winName, bool hasOpenGLContext
  );
  
 
@@ -715,7 +733,7 @@ private:
 
  void _removeRendererHelper(
 	string winName, string dataSetName, string renderType, string renderName,
-	bool removeFromParamsFlag
+	bool removeFromParamsFlag, bool hasOpenGLContext
  );
 
 

--- a/include/vapor/Visualizer.h
+++ b/include/vapor/Visualizer.h
@@ -86,16 +86,35 @@ public:
 	//! \return number of renderers
 	int GetNumRenderers() const {return _renderers.size();}
 
-	//! Get a renderer
-	//! \param[in] RenderParams to be checked for renderer
-	//! \return associated RenderParams instance
-	Renderer* GetRenderer(string type, string instance) const;
 	
-    void InsertRenderer(Renderer* ren);
+	//! \note A render params instance must have been previously created for
+	//! this renderer.
+	//
+	int CreateRenderer(string dataSetName, string renderType, string renderName);
+
+	//! Flag a renderer for destruction.
+	//!
+	//! \param[in] hasOpenGLContext If true it is the callers job to ensure that the
+	//! OpenGL Context for the window \p winName is active. In this case the renderer
+	//! is destroyed immediately. If false the renderer is queue'd for later destruction
+	//! when \p winName has an active OpenGL context.
+	//
+	void DestroyRenderer(string renderType, string renderName, bool hasOpenGLContext);
+
+	//! Flag all rendereres for destruction.
+	//!
+	//! \param[in] hasOpenGLContext If true it is the callers job to ensure that the
+	//! OpenGL Context for the window \p winName is active. In this case the renderer
+	//! is destroyed immediately. If false the renderer is queue'd for later destruction
+	//! when \p winName has an active OpenGL context.
+	//
+	void DestroyAllRenderers(bool hasOpenGLContext);
+
+	bool HasRenderer(string renderType, string renderName) const;
     
     //! Move the renderer to the front of the render queue
     //! \param[out] Renderer instance that is moved to front
-    void MoveRendererToFront(Renderer* ren);
+    void MoveRendererToFront(string renderType, string renderName);
     void MoveRenderersOfTypeToFront(const std::string &type);
 
 	//! Determine the approximate size of a pixel in terms of user coordinates,
@@ -196,6 +215,8 @@ private:
 
 	static void _incrementPath(string& s);
 
+	Renderer* _getRenderer(string type, string instance) const;
+
 	const ParamsMgr* _paramsMgr;
 	const DataStatus* _dataStatus;
 	string _winName;
@@ -208,6 +229,7 @@ private:
 	string _captureImageFile;
 	
 	vector<Renderer*> _renderers;
+	vector<Renderer*> _renderersToDestroy;
 };
 
 };

--- a/lib/render/ControlExecutive.cpp
+++ b/lib/render/ControlExecutive.cpp
@@ -167,15 +167,15 @@ int ControlExec::ActivateRender(
 		return -1;
 	}
 
-
-	Renderer *ren = v->GetRenderer(renderType, renderName);
-
 	_paramsMgr->BeginSaveStateGroup("ActivateRender");
 
-	if (! ren) { 
-
-		string paramsType = RendererFactory::Instance()->
+	// Create new renderer if one does not exist
+	//
+	string paramsType = RendererFactory::Instance()->
 			GetParamsClassFromRenderClass(renderType);
+
+	if (! v->HasRenderer(renderType, renderName)) { 
+
 
 		assert(! paramsType.empty());
 
@@ -190,24 +190,24 @@ int ControlExec::ActivateRender(
 			return -1;
 		}
 
-		ren = RendererFactory::Instance()->CreateInstance(
-			_paramsMgr, winName, dataSetName, renderType, renderName,
-			_dataStatus->GetDataMgr(dataSetName)
-		);
-		if (! ren) {
+		int rc = v->CreateRenderer(dataSetName, renderType, renderName);
+		if (rc<0) {
 			SetErrMsg("Invalid renderer of type \"%s\"",renderType.c_str());
 			_paramsMgr->EndSaveStateGroup();
 			return(-1);
 		}
-		v->InsertRenderer(ren);
 	}
 
 
-	RenderParams *rp = ren->GetActiveParams();
+	// Get newly created (or existing) render params for this renderer
+	//
+	RenderParams *rp = _paramsMgr->GetRenderParams(
+		winName, dataSetName, paramsType, renderName
+	);
 	assert(rp);
 
 	rp->SetEnabled(on);
-	v->MoveRendererToFront(ren);
+	v->MoveRendererToFront(renderType, renderName);
     v->MoveRenderersOfTypeToFront(IsoSurfaceRenderer::GetClassType());
     v->MoveRenderersOfTypeToFront(DVRenderer::GetClassType());
 
@@ -236,11 +236,13 @@ int ControlExec::ActivateRender(
 	string renderType = RendererFactory::Instance()->
 		GetRenderClassFromParamsClass(rp->GetName());
 
-	Renderer *ren = v->GetRenderer(renderType, renderName);
+	string paramsType = rp->GetName();
 
 	_paramsMgr->BeginSaveStateGroup("ActivateRender");
 
-	if (! ren) { 
+	// Create new renderer if one does not exist
+	//
+	if (! v->HasRenderer(renderType, renderName)) { 
 
 		// Need to create a params instance for this renderer
 		//
@@ -253,23 +255,23 @@ int ControlExec::ActivateRender(
 			return -1;
 		}
 
-		ren = RendererFactory::Instance()->CreateInstance(
-			_paramsMgr, winName, dataSetName, renderType, renderName,
-			_dataStatus->GetDataMgr(dataSetName)
-		);
-		if (! ren) {
+		int rc = v->CreateRenderer(dataSetName, renderType, renderName);
+		if (rc<0) {
 			SetErrMsg("Invalid renderer of type \"%s\"",renderType.c_str());
 			_paramsMgr->EndSaveStateGroup();
 			return(-1);
 		}
-		v->InsertRenderer(ren);
 	}
 
-
-	RenderParams *newRP = ren->GetActiveParams();
+	RenderParams *newRP = _paramsMgr->GetRenderParams(
+		winName, dataSetName, paramsType, renderName
+	);
 	assert(newRP);
 
 	newRP->SetEnabled(on);
+	v->MoveRendererToFront(renderType, renderName);
+    v->MoveRenderersOfTypeToFront(IsoSurfaceRenderer::GetClassType());
+    v->MoveRenderersOfTypeToFront(DVRenderer::GetClassType());
 
 	_paramsMgr->EndSaveStateGroup();
 
@@ -278,7 +280,7 @@ int ControlExec::ActivateRender(
 
 void ControlExec::_removeRendererHelper(
 	string winName, string dataSetName, string renderType, string renderName,
-	bool removeFromParamsFlag
+	bool removeFromParamsFlag, bool hasOpenGLContext
 ) {
 
 	// No-op if tuple of winName, dataSetName, renderType, and
@@ -295,10 +297,7 @@ void ControlExec::_removeRendererHelper(
 	Visualizer* v = getVisualizer(winName);
 	if (! v)  return;
 
-	Renderer *ren = v->GetRenderer(renderType, renderName);
-	if (! ren) return;
-    
-    ren->FlagForDeletion();
+	v->DestroyRenderer(renderType, renderName, hasOpenGLContext);
 
 	if (removeFromParamsFlag) {
 		_paramsMgr->RemoveRenderParamsInstance(
@@ -308,9 +307,42 @@ void ControlExec::_removeRendererHelper(
 }
 
 void ControlExec::RemoveRenderer(
-	string winName, string dataSetName, string renderType, string renderName
+	string winName, string dataSetName, string renderType, string renderName,
+	bool hasOpenGLContext
 ) {
-	_removeRendererHelper(winName, dataSetName, renderType, renderName, true);
+	_removeRendererHelper(
+		winName, dataSetName, renderType, renderName, true, hasOpenGLContext
+	);
+}
+
+void ControlExec::RemoveAllRenderers(
+	string winName, bool hasOpenGLContext
+) {
+	vector <string> dataSetNames = _paramsMgr->GetDataMgrNames();
+	for (int k=0; k<dataSetNames.size(); k++) {
+
+		vector <string> pClassNames = _paramsMgr->
+			GetRenderParamsClassNames(winName, dataSetNames[k]);
+
+		for (int j=0; j<pClassNames.size(); j++) {
+			vector <string> instNames = _paramsMgr->GetRenderParamInstances(
+				winName, dataSetNames[k], pClassNames[j]
+			);
+
+			string rClassName =
+				RendererFactory::Instance()->GetRenderClassFromParamsClass(
+					pClassNames[j]
+				);
+
+			for (int i=0; i<instNames.size(); i++) {
+
+				_removeRendererHelper(
+					winName, dataSetNames[k], rClassName,
+					instNames[i], true, hasOpenGLContext
+				);
+			}
+		}
+	}
 }
 
 void ControlExec::LoadState() {
@@ -486,7 +518,7 @@ int ControlExec::OpenData(
 
 					_removeRendererHelper(
 						vizNames[k], dataSetName, rClassName,
-						instNames[i], false
+						instNames[i], false, false
 					);
 				}
 			}
@@ -532,7 +564,7 @@ void ControlExec::CloseData(string dataSetName) {
 				// render type, and render instance does not exist
 				//
 				RemoveRenderer(
-					winNames[i], dataSetName, renderTypes[j], renderNames[k]
+					winNames[i], dataSetName, renderTypes[j], renderNames[k], false
 				);
 			}
 		}


### PR DESCRIPTION
Fixed #1481 

Moved ownership of Renderers from ControlExec to inside Visualizer class.
Added methods to delete renderers immediately or delayed, when Visualizer is
guaranteed to have active OpenGL context. If the former method is used it is
the caller's responsibility to ensure the correct OpenGL context is loaded
prior to requesting the destruction of a renderer.