### PR TITLE
Fix for overlooked mistake in in statement

### DIFF
--- a/apps/vaporgui/NavigationEventRouter.cpp
+++ b/apps/vaporgui/NavigationEventRouter.cpp
@@ -289,11 +289,9 @@ void NavigationEventRouter::_performAutoStretching(string dataSetName) {
 
         // If a dimension's scale is not 1.f, the user has saved a session with
         // a non-default value.  Don't modify it.
-        if ( scales[ xDimension ] != 1.f )
-            continue;
-        if ( scales[ yDimension ] != 1.f )
-            continue;
-        if ( scales[ zDimension ] != 1.f )
+        if ( scales[ xDimension ] != 1.f &&
+             scales[ yDimension ] != 1.f &&
+             scales[ zDimension ] != 1.f )
             continue;
 
 		DataMgr* dm = ds->GetDataMgr(dataSetName);


### PR DESCRIPTION
The previous fix for #1476 had a mistake in a condition for performing auto scaling.  This is a fix for that error.