### PR TITLE
Reset locale to C

### DIFF
--- a/apps/vaporgui/main.cpp
+++ b/apps/vaporgui/main.cpp
@@ -99,6 +99,8 @@ if (getenv("VAPOR_DEBUG"))
 	    QApplication::setColorSpec( QApplication::ManyColor );
 #endif
     	QApplication a( argc, argv,true );
+    
+    setlocale(LC_ALL, "C");
 	
 	// Set path for Qt to look for its plugins. 
 	//

--- a/apps/vaporgui/main.cpp
+++ b/apps/vaporgui/main.cpp
@@ -104,6 +104,8 @@ if (getenv("VAPOR_DEBUG"))
     // Initalizing QApplication changes the locale to the system configuration
     // which can cause problems if it is not supported.
     // Udunits does not support it and vapor potentially does not either.
+    //
+    // https://www.gnu.org/software/libc/manual/html_node/Setting-the-Locale.html
     // https://doc.qt.io/qt-5/qcoreapplication.html#locale-settings
     //
     setlocale(LC_ALL, "C");

--- a/apps/vaporgui/main.cpp
+++ b/apps/vaporgui/main.cpp
@@ -100,6 +100,12 @@ if (getenv("VAPOR_DEBUG"))
 #endif
     	QApplication a( argc, argv,true );
     
+    // All C programs are run with the locale set to "C"
+    // Initalizing QApplication changes the locale to the system configuration
+    // which can cause problems if it is not supported.
+    // Udunits does not support it and vapor potentially does not either.
+    // https://doc.qt.io/qt-5/qcoreapplication.html#locale-settings
+    //
     setlocale(LC_ALL, "C");
 	
 	// Set path for Qt to look for its plugins. 


### PR DESCRIPTION
I found some documentation referencing this issue:

https://doc.qt.io/qt-5/qcoreapplication.html#locale-settings

I reset the LC_ALL to "C" which is different from what the documentation states because we do not support any localization.