### PR TITLE
Fix Github tab spacing issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{c,cpp,h,pl,frag,vert}]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
## Before
![old](https://user-images.githubusercontent.com/2772687/59056426-66cfc180-8855-11e9-8511-c6adc81b9969.png)

## After
![new](https://user-images.githubusercontent.com/2772687/59056419-63d4d100-8855-11e9-8abd-fedbf1e535c0.png)
