### PR TITLE
fix memory leak in Plot.cpp

### DIFF
--- a/apps/vaporgui/Plot.cpp
+++ b/apps/vaporgui/Plot.cpp
@@ -579,6 +579,8 @@ void Plot::_spaceTabPlotClicked()
             }
             sequences.push_back( seq );
         }
+
+        delete grid;
     }
     
     // Decide X label and values
@@ -655,6 +657,8 @@ void Plot::_timeTabPlotClicked()
                 else
                     seq.push_back( std::nanf("1") );
             }
+
+            delete grid;
         }
         sequences.push_back( seq );
     }


### PR DESCRIPTION
This PR fixes a memory leak by not deleting a grid. 