### PR TITLE
Fix Creating a contour renderer for a dataset without a 2D variable breaks the update trigger

### DIFF
--- a/apps/vaporgui/ContourSubtabs.cpp
+++ b/apps/vaporgui/ContourSubtabs.cpp
@@ -58,7 +58,10 @@ void ContourAppearanceSubtab::Initialize(VAPoR::ContourParams* cParams) {
 
 	_cParams = cParams;
 	string varname = _cParams->GetVariableName();
-	if (varname.empty()) return;
+    if (varname.empty()) {
+        _paramsMgr->EndSaveStateGroup();
+        return;
+    }
 
 	double minBound, maxBound;
 	GetContourBounds(minBound, maxBound);


### PR DESCRIPTION
Fix #1638