### PR TITLE
Fix for 1620

### DIFF
--- a/include/vapor/AnnotationRenderer.h
+++ b/include/vapor/AnnotationRenderer.h
@@ -115,14 +115,14 @@ private:
     ) const;
 
     void _applyDataMgrCornerToDomain(
-        std::vector<double> *domainExtents,
-        const glm::vec4 *dataMgrCorner,
+        std::vector<double> &domainExtents,
+        const glm::vec4 &dataMgrCorner,
         const glm::mat4 &transformMatrix
     ) const;
 
     void _getDataMgrCorner(
         const int cornerNumber,
-        glm::vec4 *dataMgrCorner,
+        glm::vec4 &dataMgrCorner,
         const std::vector<double> &minDataMgrExtents,
         const std::vector<double> &maxDataMgrExtents
     ) const;

--- a/lib/render/AnnotationRenderer.cpp
+++ b/lib/render/AnnotationRenderer.cpp
@@ -470,6 +470,10 @@ void AnnotationRenderer::_calculateDomainExtents(
             -1
         );
 
+        if ( dataMgrMinExts.size() < 2 ||
+             dataMgrMaxExts.size() < 2 )
+                continue;
+
         // If the DataMgr has only 2D variables, we still need to define
         // a z coordinate for its domain.  Specify it to 0.f.
         if ( dataMgrMinExts.size() == 2 )

--- a/lib/render/AnnotationRenderer.cpp
+++ b/lib/render/AnnotationRenderer.cpp
@@ -78,6 +78,7 @@ void AnnotationRenderer::InitializeGL(GLManager *glManager) {
 void AnnotationRenderer::drawDomainFrame(
     std::vector<double> corners
 ) const {
+    assert( corners.size() == 6 );
 
 	AnnotationParams *vfParams = m_paramsMgr->GetAnnotationParams(m_winName);
 
@@ -349,31 +350,33 @@ void AnnotationRenderer::_makeTransformMatrix(
 }
 
 void AnnotationRenderer::_applyDataMgrCornerToDomain(
-    std::vector<double> *domainExtents,
-    const glm::vec4 *dataMgrCorner,
+    std::vector<double> &domainExtents,
+    const glm::vec4 &dataMgrCorner,
     const glm::mat4 &transformMatrix
 ) const {
+    assert( domainExtents.size() == 6 );
+
     // transform our corner
     glm::vec4 transformedCorner;
-    transformedCorner = transformMatrix * *dataMgrCorner;
+    transformedCorner = transformMatrix * dataMgrCorner;
 
     // See if the minimum and maximum extents of our corner exceed the
     // the currently defined domain. 
     for (int i=0; i<6; i++) {
         int transformedCornerIndex = i%3;
         // use this corner to define all domain corners that are uninitialized
-        if ( std::isnan( (*domainExtents)[i]) )
-            (*domainExtents)[i] = transformedCorner[ transformedCornerIndex ];
+        if ( std::isnan( domainExtents[i]) )
+            domainExtents[i] = transformedCorner[ transformedCornerIndex ];
         // otherwise see if the corner exceeds our currently defined domain minima
         else if ( i<3 ){
-            if (transformedCorner[transformedCornerIndex] < (*domainExtents)[i]) {
-                (*domainExtents)[i] = transformedCorner[transformedCornerIndex];
+            if (transformedCorner[transformedCornerIndex] < domainExtents[i]) {
+                domainExtents[i] = transformedCorner[transformedCornerIndex];
             }
         }
         // otherwise see if the corner exceeds our currently defined domain maxima
         else {
-            if (transformedCorner[transformedCornerIndex] > (*domainExtents)[i]) {
-                (*domainExtents)[i] = transformedCorner[transformedCornerIndex];
+            if (transformedCorner[transformedCornerIndex] > domainExtents[i]) {
+                domainExtents[i] = transformedCorner[transformedCornerIndex];
             }
         }
     }
@@ -396,10 +399,14 @@ void AnnotationRenderer::_applyDataMgrCornerToDomain(
 //  1 1 1       7
 void AnnotationRenderer::_getDataMgrCorner(
     const int cornerNumber,
-    glm::vec4 *dataMgrCorner,
+    glm::vec4 &dataMgrCorner,
     const std::vector<double> &minDataMgrExtents,
     const std::vector<double> &maxDataMgrExtents
 ) const {
+    assert( minDataMgrExtents.size() == 3 );
+    assert( maxDataMgrExtents.size() == 3 );
+    assert( cornerNumber >= 0 && cornerNumber <= 7 );
+
     double xCoord, yCoord, zCoord;
     if (cornerNumber & 0b100)
         xCoord = maxDataMgrExtents[X];
@@ -416,7 +423,7 @@ void AnnotationRenderer::_getDataMgrCorner(
     else
         zCoord = minDataMgrExtents[Z];
   
-    *dataMgrCorner = glm::vec4( xCoord, yCoord, zCoord, 1.f ); 
+    dataMgrCorner = glm::vec4( xCoord, yCoord, zCoord, 1.f ); 
 }
 
 void AnnotationRenderer::_applyDataMgrToDomainExtents(
@@ -425,6 +432,10 @@ void AnnotationRenderer::_applyDataMgrToDomainExtents(
     const std::vector<double> &dataMgrMaxExts,
     const Transform* transform
 ) const {
+
+    assert( domainExtents.size() == 6 );
+    assert( dataMgrMinExts.size() == 3 );
+    assert( dataMgrMaxExts.size() == 3 );
 
     glm::mat4 transformMatrix;
     _makeTransformMatrix(
@@ -436,14 +447,14 @@ void AnnotationRenderer::_applyDataMgrToDomainExtents(
     for (int i=0; i<8; i++) {
         _getDataMgrCorner(
             i, 
-            &dataMgrCorner, 
+            dataMgrCorner, 
             dataMgrMinExts, 
             dataMgrMaxExts
         );
     
         _applyDataMgrCornerToDomain(
-            &domainExtents,
-            &dataMgrCorner,
+            domainExtents,
+            dataMgrCorner,
             transformMatrix
         );
     }
@@ -452,6 +463,8 @@ void AnnotationRenderer::_applyDataMgrToDomainExtents(
 void AnnotationRenderer::_calculateDomainExtents(
     std::vector<double> &domainExtents
 ) const {
+    domainExtents = { NAN, NAN, NAN, NAN, NAN, NAN };
+
     vector<string> names = m_paramsMgr->GetDataMgrNames();
     for (int i=0; i<names.size(); i++ ) {
         std::vector<double> dataMgrMinExts, dataMgrMaxExts;
@@ -490,6 +503,11 @@ void AnnotationRenderer::_calculateDomainExtents(
             transform
         );
     }
+
+    for (int i=0; i<6; i++) {
+        if ( std::isnan( domainExtents[i]) )
+            domainExtents[i] = 0.f;
+    }
 }
 
 void AnnotationRenderer::InScenePaint(size_t ts)
@@ -501,7 +519,7 @@ void AnnotationRenderer::InScenePaint(size_t ts)
 
 	ViewpointParams *vpParams = m_paramsMgr->GetViewpointParams(m_winName);
 
-    std::vector<double> domainExtents(6, NAN);
+    std::vector<double> domainExtents;
     _calculateDomainExtents(domainExtents);
 
     _currentTimestep = ts;
@@ -519,7 +537,7 @@ void AnnotationRenderer::InScenePaint(size_t ts)
         for (int i=0; i<names.size(); i++) {
             tmp = vpParams->GetTransform(names[i]);
             if ( tmp->GetScales()[Z] < t->GetScales()[Z] )
-                t = tmp;
+                *t = *tmp;
         }
     }
 	applyTransform(t);


### PR DESCRIPTION
Fix for #1620 which crashed during the importation of ROMS data without grid files.  Specifically, crashes would occur when the dimensionality of a dataset was less than 2.