### PR TITLE
Fixed #1731 - Crash on reading 3D variable from MPAS

### DIFF
--- a/lib/vdc/DCMPAS.cpp
+++ b/lib/vdc/DCMPAS.cpp
@@ -901,8 +901,8 @@ int DCMPAS::_readRegionEdgeVariable(
 		return(-1);
 	}
 
-	size_t j0 = min.size() == 2 ? min[0] : 0;
-	size_t j1 = max.size() == 2 ? max[0] : 0;
+	size_t j0 = min.size() == 2 ? min[1] : 0;
+	size_t j1 = max.size() == 2 ? max[1] : 0;
 
 
 	float wgt = 1.0 / (float) vertexDegree;


### PR DESCRIPTION
Fixed #1731 - Crash on reading 3D variable from MPAS