### PR TITLE
Changes to VWidgets

### DIFF
--- a/apps/vaporgui/VaporWidgets.cpp
+++ b/apps/vaporgui/VaporWidgets.cpp
@@ -145,13 +145,16 @@ double VDoubleSpinBox::GetValue() const {
     return _value;
 }
 
+//
+// ====================================
+//
+
 VLineEdit::VLineEdit(
         QWidget *parent,
         const std::string& labelText,
         const std::string& editText
     ) :
     VaporWidget(parent, labelText)
-    //_validator( nullptr )
 {
     _text = editText;
 
@@ -164,50 +167,7 @@ VLineEdit::VLineEdit(
         this, SLOT( _relaySignal() ) );
 }
 
-VLineEdit::~VLineEdit() {
-//    if (_validator != nullptr) {
-//        delete _validator;
-//        _validator = nullptr;
-//    }
-}
-
-void VLineEdit::SetExtents( int min, int max ) {
-//    assert( _validator );
-
-//    QIntValidator* val = qobject_cast<QIntValidator*>(_validator);
-//    assert( val );
-
-//    val->setRange( min, max );
-}
-
-void VLineEdit::SetExtents( double min, double max ) {
-//    assert( _validator );
-
-//    QDoubleValidator* val = qobject_cast<QDoubleValidator*>(_validator);
-//    assert( val );
-
-//    val->setRange( min, max );
-}
-
-void VLineEdit::SetIntType() {
-//    if (_validator != nullptr)
-//        delete _validator;
-//
-//    _validator = new QIntValidator( this );
-//    _edit->setValidator( _validator );
-}
-
-void VLineEdit::SetDoubleType() {
-//    if (_validator != nullptr)
-//        delete _validator;
-//
-//    _validator = new QDoubleValidator( this );
-//    _edit->setValidator( _validator );
-}
-
-//void VLineEdit::SetValidator( QValidator* v ) {
-//    _validator = v;
-//}
+VLineEdit::~VLineEdit() { }
 
 void VLineEdit::SetEditText( const std::string& text )
 {
@@ -217,8 +177,6 @@ void VLineEdit::SetEditText( const std::string& text )
 void VLineEdit::SetEditText( const QString& text )
 {
     _edit->setText( text );
-   
-    // set local copy after line edit runs validation
     _text = _edit->text().toStdString();
 }
 
@@ -228,22 +186,15 @@ std::string VLineEdit::GetEditText() const {
 
 void VLineEdit::_relaySignal() {
     QString text = _edit->text();
-//    if ( _validator != nullptr ) {
-//        int i=0;
-//        const QValidator::State state = _validator->validate( text, i );
-//
-//        if ( state == QValidator::Acceptable )
-//            _text = _edit->text().toStdString();
-//
-//        _edit->setText( QString::fromStdString( _text ) );
-//    }
-//    else {
-        _edit->setText( text );
-        _text = text.toStdString();    
-//    }
+    _edit->setText( text );
+    _text = text.toStdString();    
 
     emit _editingFinished();
 }
+
+//
+// ====================================
+//
 
 VPushButton::VPushButton(
         QWidget *parent,

--- a/apps/vaporgui/VaporWidgets.cpp
+++ b/apps/vaporgui/VaporWidgets.cpp
@@ -160,8 +160,8 @@ VLineEdit::VLineEdit(
 
     SetEditText( QString::fromStdString( editText ) );
 
-    connect( _edit, SIGNAL( returnPressed() ),
-        this, SLOT( _returnPressed() ) );
+    connect( _edit, SIGNAL( editingFinished() ),
+        this, SLOT( _relaySignal() ) );
 }
 
 VLineEdit::~VLineEdit() {
@@ -226,7 +226,7 @@ std::string VLineEdit::GetEditText() const {
     return _text;
 }
 
-void VLineEdit::_returnPressed() {
+void VLineEdit::_relaySignal() {
     QString text = _edit->text();
     if ( _validator != nullptr ) {
         int i=0;

--- a/apps/vaporgui/VaporWidgets.cpp
+++ b/apps/vaporgui/VaporWidgets.cpp
@@ -177,7 +177,7 @@ void VLineEdit::SetExtents( int min, int max ) {
 //    QIntValidator* val = qobject_cast<QIntValidator*>(_validator);
 //    assert( val );
 
-    val->setRange( min, max );
+//    val->setRange( min, max );
 }
 
 void VLineEdit::SetExtents( double min, double max ) {
@@ -186,7 +186,7 @@ void VLineEdit::SetExtents( double min, double max ) {
 //    QDoubleValidator* val = qobject_cast<QDoubleValidator*>(_validator);
 //    assert( val );
 
-    val->setRange( min, max );
+//    val->setRange( min, max );
 }
 
 void VLineEdit::SetIntType() {

--- a/apps/vaporgui/VaporWidgets.cpp
+++ b/apps/vaporgui/VaporWidgets.cpp
@@ -150,8 +150,8 @@ VLineEdit::VLineEdit(
         const std::string& labelText,
         const std::string& editText
     ) :
-    VaporWidget(parent, labelText),
-    _validator( nullptr )
+    VaporWidget(parent, labelText)
+    //_validator( nullptr )
 {
     _text = editText;
 
@@ -165,49 +165,49 @@ VLineEdit::VLineEdit(
 }
 
 VLineEdit::~VLineEdit() {
-    if (_validator != nullptr) {
-        delete _validator;
-        _validator = nullptr;
-    }
+//    if (_validator != nullptr) {
+//        delete _validator;
+//        _validator = nullptr;
+//    }
 }
 
 void VLineEdit::SetExtents( int min, int max ) {
-    assert( _validator );
+//    assert( _validator );
 
-    QIntValidator* val = qobject_cast<QIntValidator*>(_validator);
-    assert( val );
+//    QIntValidator* val = qobject_cast<QIntValidator*>(_validator);
+//    assert( val );
 
     val->setRange( min, max );
 }
 
 void VLineEdit::SetExtents( double min, double max ) {
-    assert( _validator );
+//    assert( _validator );
 
-    QDoubleValidator* val = qobject_cast<QDoubleValidator*>(_validator);
-    assert( val );
+//    QDoubleValidator* val = qobject_cast<QDoubleValidator*>(_validator);
+//    assert( val );
 
     val->setRange( min, max );
 }
 
 void VLineEdit::SetIntType() {
-    if (_validator != nullptr)
-        delete _validator;
-
-    _validator = new QIntValidator( this );
-    _edit->setValidator( _validator );
+//    if (_validator != nullptr)
+//        delete _validator;
+//
+//    _validator = new QIntValidator( this );
+//    _edit->setValidator( _validator );
 }
 
 void VLineEdit::SetDoubleType() {
-    if (_validator != nullptr)
-        delete _validator;
-
-    _validator = new QDoubleValidator( this );
-    _edit->setValidator( _validator );
+//    if (_validator != nullptr)
+//        delete _validator;
+//
+//    _validator = new QDoubleValidator( this );
+//    _edit->setValidator( _validator );
 }
 
-void VLineEdit::SetValidator( QValidator* v ) {
-    _validator = v;
-}
+//void VLineEdit::SetValidator( QValidator* v ) {
+//    _validator = v;
+//}
 
 void VLineEdit::SetEditText( const std::string& text )
 {
@@ -228,19 +228,19 @@ std::string VLineEdit::GetEditText() const {
 
 void VLineEdit::_relaySignal() {
     QString text = _edit->text();
-    if ( _validator != nullptr ) {
-        int i=0;
-        const QValidator::State state = _validator->validate( text, i );
-
-        if ( state == QValidator::Acceptable )
-            _text = _edit->text().toStdString();
-
-        _edit->setText( QString::fromStdString( _text ) );
-    }
-    else {
+//    if ( _validator != nullptr ) {
+//        int i=0;
+//        const QValidator::State state = _validator->validate( text, i );
+//
+//        if ( state == QValidator::Acceptable )
+//            _text = _edit->text().toStdString();
+//
+//        _edit->setText( QString::fromStdString( _text ) );
+//    }
+//    else {
         _edit->setText( text );
         _text = text.toStdString();    
-    }
+//    }
 
     emit _editingFinished();
 }

--- a/apps/vaporgui/VaporWidgets.h
+++ b/apps/vaporgui/VaporWidgets.h
@@ -145,7 +145,7 @@ protected:
     QValidator* _validator;
 
 private slots:
-    void _returnPressed();
+    void _relaySignal();
 
 private:
     std::string _text;

--- a/apps/vaporgui/VaporWidgets.h
+++ b/apps/vaporgui/VaporWidgets.h
@@ -123,11 +123,6 @@ public:
 
     void SetEditText( const std::string& text );
     void SetEditText( const QString& text );
-    void SetExtents( int min, int max );
-    void SetExtents( double min, double max );
-    void SetIntType();
-    void SetDoubleType();
-    //void SetValidator( QValidator* v );
     std::string GetEditText() const;
 
 signals:
@@ -135,13 +130,6 @@ signals:
 
 protected:
     QLineEdit* _edit;
-
-    // If we assign a validator to the QLineEdit, the QLineEdit will not emit
-    // the returnPressed() signal with invalid input.  However we do want this
-    // signal to be emitted with invalid input, so we can change it to the
-    // previous value.  Therefore, we perform validation within the VLineEdit,
-    // not the QLineEdit.
-    //QValidator* _validator;
 
 private slots:
     void _relaySignal();

--- a/apps/vaporgui/VaporWidgets.h
+++ b/apps/vaporgui/VaporWidgets.h
@@ -7,7 +7,6 @@ class QComboBox;
 class QCheckBox;
 class QPushButton;
 class QLineEdit;
-class QValidator;
 class QSpacerItem;
 class QHBoxLayout;
 class QSpinBox;
@@ -128,7 +127,7 @@ public:
     void SetExtents( double min, double max );
     void SetIntType();
     void SetDoubleType();
-    void SetValidator( QValidator* v );
+    //void SetValidator( QValidator* v );
     std::string GetEditText() const;
 
 signals:
@@ -142,7 +141,7 @@ protected:
     // signal to be emitted with invalid input, so we can change it to the
     // previous value.  Therefore, we perform validation within the VLineEdit,
     // not the QLineEdit.
-    QValidator* _validator;
+    //QValidator* _validator;
 
 private slots:
     void _relaySignal();


### PR DESCRIPTION
@sgpearse  as we discussed, this PR 
1) comment out a dangerous practice which could lead to dangling pointers
2) catch a proper signal and rename the functions.

As I mentioned, I think it's actually acceptable to offload the validation work to whoever owns a VLineEdit widget, so VLineEdit is cleaner. 