### PR TITLE
Fixed #1847 - Flow: Unsteady Flow Crash

### DIFF
--- a/include/vapor/CurvilinearGrid.h
+++ b/include/vapor/CurvilinearGrid.h
@@ -77,7 +77,7 @@ public:
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const std::vector <double> &zcoords,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr<const QuadTreeRectangle<float, size_t> > qtr
  );
 
  //! \copydoc StructuredGrid::StructuredGrid()
@@ -123,7 +123,7 @@ public:
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
  );
 
  //! \copydoc StructuredGrid::StructuredGrid()
@@ -163,15 +163,17 @@ public:
 	const std::vector <float *> &blks,
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
  );
 
  CurvilinearGrid() = default;
  virtual ~CurvilinearGrid() {
-	if (_qtrOwner && _qtr) delete _qtr;
+	if (_qtr) {
+		_qtr = nullptr;	// qtr is a C++ shared pointer
+	}
  }
 
- const QuadTreeRectangle<float, size_t> *GetQuadTreeRectangle() const {
+ std::shared_ptr <const QuadTreeRectangle<float, size_t> > GetQuadTreeRectangle() const {
     return(_qtr);
  }
 
@@ -331,15 +333,14 @@ private:
  RegularGrid _yrg;
  RegularGrid _zrg;
  bool _terrainFollowing;
- const QuadTreeRectangle<float, size_t> *_qtr;
- bool _qtrOwner;
+ std::shared_ptr <const QuadTreeRectangle<float, size_t> > _qtr;
 
  void _curvilinearGrid(
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
 	const std::vector <double> &zcoords,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
  );
 
  void _GetUserExtents(
@@ -377,7 +378,7 @@ private:
 	double zwgt[2]
  ) const;
 
- QuadTreeRectangle<float, size_t> *_makeQuadTreeRectangle() const;
+ std::shared_ptr <QuadTreeRectangle<float, size_t> >_makeQuadTreeRectangle() const;
 
 };
 };

--- a/include/vapor/CurvilinearGrid.h
+++ b/include/vapor/CurvilinearGrid.h
@@ -167,11 +167,8 @@ public:
  );
 
  CurvilinearGrid() = default;
- virtual ~CurvilinearGrid() {
-	if (_qtr) {
-		_qtr = nullptr;	// qtr is a C++ shared pointer
-	}
- }
+ 
+ virtual ~CurvilinearGrid() { } 
 
  const QuadTreeRectangle<float, size_t> * GetQuadTreeRectangle() const {
     return(_qtr);

--- a/include/vapor/CurvilinearGrid.h
+++ b/include/vapor/CurvilinearGrid.h
@@ -77,7 +77,7 @@ public:
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const std::vector <double> &zcoords,
-	std::shared_ptr<const QuadTreeRectangle<float, size_t> > qtr
+	const QuadTreeRectangle<float, size_t> * qtr
  );
 
  //! \copydoc StructuredGrid::StructuredGrid()
@@ -123,7 +123,7 @@ public:
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
-	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
+	const QuadTreeRectangle<float, size_t> * qtr
  );
 
  //! \copydoc StructuredGrid::StructuredGrid()
@@ -163,7 +163,7 @@ public:
 	const std::vector <float *> &blks,
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
-	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
+	const QuadTreeRectangle<float, size_t> * qtr
  );
 
  CurvilinearGrid() = default;
@@ -173,7 +173,7 @@ public:
 	}
  }
 
- std::shared_ptr <const QuadTreeRectangle<float, size_t> > GetQuadTreeRectangle() const {
+ const QuadTreeRectangle<float, size_t> * GetQuadTreeRectangle() const {
     return(_qtr);
  }
 
@@ -333,14 +333,14 @@ private:
  RegularGrid _yrg;
  RegularGrid _zrg;
  bool _terrainFollowing;
- std::shared_ptr <const QuadTreeRectangle<float, size_t> > _qtr;
+ const QuadTreeRectangle<float, size_t> * _qtr;
 
  void _curvilinearGrid(
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
 	const std::vector <double> &zcoords,
-	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
+	const QuadTreeRectangle<float, size_t> * qtr
  );
 
  void _GetUserExtents(
@@ -378,7 +378,7 @@ private:
 	double zwgt[2]
  ) const;
 
- std::shared_ptr <QuadTreeRectangle<float, size_t> >_makeQuadTreeRectangle() const;
+ const QuadTreeRectangle<float, size_t> * _makeQuadTreeRectangle() const;
 
 };
 };

--- a/include/vapor/GridHelper.h
+++ b/include/vapor/GridHelper.h
@@ -89,7 +89,7 @@ private:
  template<typename key_t, typename value_t>
  class lru_cache {
  public:
-  typedef typename std::pair<key_t, value_t *> key_value_pair_t;
+  typedef typename std::pair<key_t, value_t > key_value_pair_t;
   typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
 
   lru_cache() : 
@@ -100,8 +100,8 @@ private:
 	_max_size(max_size) 
   {}
 	
-  value_t *put(const key_t& key, value_t *value) {
-	value_t *rvalue = NULL;
+  value_t put(const key_t& key, value_t value) {
+	value_t rvalue = NULL;
 	auto it = _cache_items_map.find(key);
 	_cache_items_list.push_front(key_value_pair_t(key, value));
 	if (it != _cache_items_map.end()) {
@@ -121,7 +121,7 @@ private:
 	return(rvalue);
   }
 
-  value_t *get(const key_t& key) {
+  value_t get(const key_t& key) {
 	auto it = _cache_items_map.find(key);
 	if (it == _cache_items_map.end()) return(NULL);
 
@@ -131,12 +131,13 @@ private:
 	return it->second->second;
   }
 
-  value_t *remove_lru() {
+  value_t remove_lru() {
 	if (! _cache_items_map.size()) return(NULL);
 
 	auto last = _cache_items_list.end();
 	last--;
-	value_t *rvalue = last->second;
+	value_t rvalue = last->second;
+	last->second = nullptr;	// necessary for delete?
 	_cache_items_map.erase(last->first);
 	_cache_items_list.pop_back();
 	return(rvalue);
@@ -157,7 +158,7 @@ private:
   size_t _max_size;
  };
 
- lru_cache<string, QuadTreeRectangle<float, size_t> > _qtrCache;
+ lru_cache<string, std::shared_ptr<const QuadTreeRectangle<float, size_t> > > _qtrCache;
 
 
  RegularGrid *_make_grid_regular(

--- a/include/vapor/GridHelper.h
+++ b/include/vapor/GridHelper.h
@@ -87,83 +87,8 @@ public:
 
 private:
 
-#if 0
- template<typename key_t, typename value_t>
- class lru_cache {
- public:
-  typedef typename std::pair<key_t, value_t > key_value_pair_t;
-  typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
-
-  lru_cache() : 
-	_max_size(10)
-  {}
-
-  lru_cache(size_t max_size) :
-	_max_size(max_size) 
-  {}
-	
-  value_t put(const key_t& key, value_t value) {
-	value_t rvalue = NULL;
-	auto it = _cache_items_map.find(key);
-	_cache_items_list.push_front(key_value_pair_t(key, value));
-	if (it != _cache_items_map.end()) {
-		rvalue = it->second->second;
-		_cache_items_list.erase(it->second);
-		_cache_items_map.erase(it);
-	}
-	_cache_items_map[key] = _cache_items_list.begin();
-
-	if (_cache_items_map.size() > _max_size) {
-		auto last = _cache_items_list.end();
-		last--;
-			rvalue = last->second;
-		_cache_items_map.erase(last->first);
-		_cache_items_list.pop_back();
-	}
-	return(rvalue);
-  }
-
-  value_t get(const key_t& key) {
-	auto it = _cache_items_map.find(key);
-	if (it == _cache_items_map.end()) return(NULL);
-
-	_cache_items_list.splice(
-		_cache_items_list.begin(), _cache_items_list, it->second
-	);
-	return it->second->second;
-  }
-
-  value_t remove_lru() {
-	if (! _cache_items_map.size()) return(NULL);
-
-	auto last = _cache_items_list.end();
-	last--;
-	value_t rvalue = last->second;
-	last->second = nullptr;	// necessary for delete?
-	_cache_items_map.erase(last->first);
-	_cache_items_list.pop_back();
-	return(rvalue);
-  }
-
-	
-  bool exists(const key_t& key) const;
-	
-  size_t size() const {
-	return _cache_items_map.size();
-  }
-
-  
-	
- private:
-  std::list<key_value_pair_t> _cache_items_list;
-  std::unordered_map<key_t, list_iterator_t> _cache_items_map;
-  size_t _max_size;
- };
-#endif
-
     using cacheType = unique_ptr_cache< std::string, QuadTreeRectangle<float, size_t> >;
     cacheType   _qtrCache;
- //lru_cache<string, std::shared_ptr<const QuadTreeRectangle<float, size_t> > > _qtrCache;
 
 
  RegularGrid *_make_grid_regular(

--- a/include/vapor/GridHelper.h
+++ b/include/vapor/GridHelper.h
@@ -11,6 +11,7 @@
 #include <vapor/StretchedGrid.h>
 #include <vapor/UnstructuredGrid2D.h>
 #include <vapor/UnstructuredGridLayered.h>
+#include "vapor/unique_ptr_cache.hpp"
 
 #ifndef	GRIDMGR_H
 #define GRIDMGR_H
@@ -86,6 +87,7 @@ public:
 
 private:
 
+#if 0
  template<typename key_t, typename value_t>
  class lru_cache {
  public:
@@ -157,8 +159,11 @@ private:
   std::unordered_map<key_t, list_iterator_t> _cache_items_map;
   size_t _max_size;
  };
+#endif
 
- lru_cache<string, std::shared_ptr<const QuadTreeRectangle<float, size_t> > > _qtrCache;
+    using cacheType = unique_ptr_cache< std::string, QuadTreeRectangle<float, size_t> >;
+    cacheType   _qtrCache;
+ //lru_cache<string, std::shared_ptr<const QuadTreeRectangle<float, size_t> > > _qtrCache;
 
 
  RegularGrid *_make_grid_regular(

--- a/include/vapor/UnstructuredGrid2D.h
+++ b/include/vapor/UnstructuredGrid2D.h
@@ -45,15 +45,15 @@ public:
 	const UnstructuredGridCoordless &xug,
 	const UnstructuredGridCoordless &yug,
 	const UnstructuredGridCoordless &zug,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr<const QuadTreeRectangle<float, size_t> > qtr
  );
 
  UnstructuredGrid2D() = default;
  virtual ~UnstructuredGrid2D() {
-	if (_qtrOwner && _qtr) delete _qtr;
+	if (_qtr) _qtr = nullptr;
  }
 
- const QuadTreeRectangle<float, size_t> *GetQuadTreeRectangle() const {
+ std::shared_ptr <const QuadTreeRectangle<float, size_t> >GetQuadTreeRectangle() const {
 	return(_qtr);
  }
 
@@ -189,8 +189,7 @@ private:
  UnstructuredGridCoordless _xug;
  UnstructuredGridCoordless _yug;
  UnstructuredGridCoordless _zug;
- const QuadTreeRectangle<float, size_t> *_qtr;
- bool _qtrOwner;
+ std::shared_ptr<const QuadTreeRectangle<float, size_t> > _qtr;
 
  bool _insideGrid(
 	const std::vector <double> &coords,
@@ -220,7 +219,7 @@ private:
 	double *lambda, int &nlambda
  ) const;
 
- QuadTreeRectangle<float, size_t> *_makeQuadTreeRectangle() const;
+ std::shared_ptr<QuadTreeRectangle<float, size_t> >_makeQuadTreeRectangle() const;
 
 
 };

--- a/include/vapor/UnstructuredGrid2D.h
+++ b/include/vapor/UnstructuredGrid2D.h
@@ -45,7 +45,7 @@ public:
 	const UnstructuredGridCoordless &xug,
 	const UnstructuredGridCoordless &yug,
 	const UnstructuredGridCoordless &zug,
-	std::shared_ptr<const QuadTreeRectangle<float, size_t> > qtr
+	const QuadTreeRectangle<float, size_t> * qtr
  );
 
  UnstructuredGrid2D() = default;
@@ -53,7 +53,7 @@ public:
 	if (_qtr) _qtr = nullptr;
  }
 
- std::shared_ptr <const QuadTreeRectangle<float, size_t> >GetQuadTreeRectangle() const {
+ const QuadTreeRectangle<float, size_t> * GetQuadTreeRectangle() const {
 	return(_qtr);
  }
 
@@ -189,7 +189,7 @@ private:
  UnstructuredGridCoordless _xug;
  UnstructuredGridCoordless _yug;
  UnstructuredGridCoordless _zug;
- std::shared_ptr<const QuadTreeRectangle<float, size_t> > _qtr;
+ const QuadTreeRectangle<float, size_t> * _qtr;
 
  bool _insideGrid(
 	const std::vector <double> &coords,
@@ -219,7 +219,7 @@ private:
 	double *lambda, int &nlambda
  ) const;
 
- std::shared_ptr<QuadTreeRectangle<float, size_t> >_makeQuadTreeRectangle() const;
+ const QuadTreeRectangle<float, size_t> * _makeQuadTreeRectangle() const;
 
 
 };

--- a/include/vapor/UnstructuredGrid2D.h
+++ b/include/vapor/UnstructuredGrid2D.h
@@ -49,9 +49,7 @@ public:
  );
 
  UnstructuredGrid2D() = default;
- virtual ~UnstructuredGrid2D() {
-	if (_qtr) _qtr = nullptr;
- }
+ virtual ~UnstructuredGrid2D() { }
 
  const QuadTreeRectangle<float, size_t> * GetQuadTreeRectangle() const {
 	return(_qtr);

--- a/include/vapor/UnstructuredGridLayered.h
+++ b/include/vapor/UnstructuredGridLayered.h
@@ -44,13 +44,13 @@ public:
 	const UnstructuredGridCoordless &xug,
 	const UnstructuredGridCoordless &yug,
 	const UnstructuredGridCoordless &zug,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr<const QuadTreeRectangle<float, size_t> >qtr
  );
 
  UnstructuredGridLayered() = default;
  virtual ~UnstructuredGridLayered() = default;
 
- const QuadTreeRectangle<float, size_t> *GetQuadTreeRectangle() const {
+ std::shared_ptr<const QuadTreeRectangle<float, size_t> >GetQuadTreeRectangle() const {
 	return(_ug2d.GetQuadTreeRectangle());
  }
 

--- a/include/vapor/UnstructuredGridLayered.h
+++ b/include/vapor/UnstructuredGridLayered.h
@@ -44,13 +44,13 @@ public:
 	const UnstructuredGridCoordless &xug,
 	const UnstructuredGridCoordless &yug,
 	const UnstructuredGridCoordless &zug,
-	std::shared_ptr<const QuadTreeRectangle<float, size_t> >qtr
+	const QuadTreeRectangle<float, size_t> * qtr
  );
 
  UnstructuredGridLayered() = default;
  virtual ~UnstructuredGridLayered() = default;
 
- std::shared_ptr<const QuadTreeRectangle<float, size_t> >GetQuadTreeRectangle() const {
+ const QuadTreeRectangle<float, size_t> * GetQuadTreeRectangle() const {
 	return(_ug2d.GetQuadTreeRectangle());
  }
 

--- a/include/vapor/unique_ptr_cache.hpp
+++ b/include/vapor/unique_ptr_cache.hpp
@@ -7,9 +7,9 @@
 // need to manage these structures.
 //
 // All structures stored in this cache are const qualified, so once a
-// structures is in, there is no more modifications.
+// structure is put in this cache, there is no more modification to this structure.
 //
-// This implementation follows std container conventions in terms of naming.
+// This implementation follows std container naming conventions.
 //
 // Author: Samuel Li
 // Date  : 9/26/2019
@@ -99,14 +99,14 @@ public:
     //
     void insert( Key key, const BigObj* ptr )
     {
-        // Remove the old BigObj if it exists.
+        // Remove the old BigObj if the same key already exists.
         for( auto it = m_list.cbegin(); it != m_list.cend(); ++it )
         { 
             if( it->first == key )
                 m_list.erase( it );
         }
 
-        // Should use make_unique<> in c++14. CentOS7 prevents it as of 2019.
+        // Should have used make_unique<> in C++14. GCC-4.8 in CentOS7 prevents it as of 2019.
         std::unique_ptr<const BigObj> tmp( ptr );
 
         // Create a new pair at the front of the list

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -1028,9 +1028,8 @@ bool CurvilinearGrid::_insideGrid(
 
     // This structure will be handed to and owned by a unique_ptr_cache,
     // thus nobody needs to manually do the cleanup after this creation. 
-	QuadTreeRectangle<float, size_t> * qtr = new QuadTreeRectangle<float, size_t> (
-			(float) minu[0], (float) minu[1], (float) maxu[0], (float) maxu[1], 
-			16, reserve_size );
+	auto * qtr = new QuadTreeRectangle<float, size_t> ( (float) minu[0], (float) minu[1], 
+                     (float) maxu[0], (float) maxu[1], 16, reserve_size );
 
 
 	// Loop over horizontal dimensions only - the grid, if 3D, is layered.

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -17,7 +17,7 @@ void CurvilinearGrid::_curvilinearGrid(
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
 	const vector <double> &zcoords,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
 ) {
 	_zcoords.clear();
 	_minu.clear();
@@ -29,10 +29,8 @@ void CurvilinearGrid::_curvilinearGrid(
 	_zcoords = zcoords;
 
 	_qtr = qtr;
-	_qtrOwner = false;
 	if (! _qtr) {
 		_qtr = _makeQuadTreeRectangle();
-		_qtrOwner = true;
 	}
 
 }
@@ -44,7 +42,7 @@ CurvilinearGrid::CurvilinearGrid(
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const vector <double> &zcoords,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
  ) : StructuredGrid(dims, bs, blks) {
 
 	VAssert(dims.size() == 2 || dims.size() == 3);
@@ -68,7 +66,7 @@ CurvilinearGrid::CurvilinearGrid(
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
  ) : StructuredGrid(dims, bs, blks) {
 
 	VAssert(dims.size() == 3);
@@ -92,7 +90,7 @@ CurvilinearGrid::CurvilinearGrid(
 	const vector <float *> &blks,
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
  ) : StructuredGrid(dims, bs, blks) {
 
 	VAssert(dims.size() == 2);
@@ -1019,7 +1017,7 @@ bool CurvilinearGrid::_insideGrid(
 	}
 }
 
-QuadTreeRectangle<float, size_t> *CurvilinearGrid::_makeQuadTreeRectangle() const {
+std::shared_ptr <QuadTreeRectangle<float, size_t> >CurvilinearGrid::_makeQuadTreeRectangle() const {
 
 	vector <double> minu, maxu;
 	GetUserExtents(minu, maxu);
@@ -1028,8 +1026,8 @@ QuadTreeRectangle<float, size_t> *CurvilinearGrid::_makeQuadTreeRectangle() cons
 	const vector <size_t> dims2d = {dims[0], dims[1]};
 	size_t reserve_size = dims2d[0] * dims2d[1];
 
-	QuadTreeRectangle<float, size_t> *qtr = 
-		new QuadTreeRectangle<float, size_t>(
+	std::shared_ptr <QuadTreeRectangle<float, size_t> >qtr = 
+		std::make_shared <QuadTreeRectangle<float, size_t> >(
 			(float) minu[0], (float) minu[1], (float) maxu[0], (float) maxu[1], 
 			16, reserve_size
 		);

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -17,7 +17,7 @@ void CurvilinearGrid::_curvilinearGrid(
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
 	const vector <double> &zcoords,
-	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
+	const QuadTreeRectangle<float, size_t> * qtr
 ) {
 	_zcoords.clear();
 	_minu.clear();
@@ -42,7 +42,7 @@ CurvilinearGrid::CurvilinearGrid(
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const vector <double> &zcoords,
-	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
+	const QuadTreeRectangle<float, size_t> * qtr
  ) : StructuredGrid(dims, bs, blks) {
 
 	VAssert(dims.size() == 2 || dims.size() == 3);
@@ -66,7 +66,7 @@ CurvilinearGrid::CurvilinearGrid(
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
-	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
+	const QuadTreeRectangle<float, size_t> * qtr
  ) : StructuredGrid(dims, bs, blks) {
 
 	VAssert(dims.size() == 3);
@@ -90,7 +90,7 @@ CurvilinearGrid::CurvilinearGrid(
 	const vector <float *> &blks,
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
-	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
+	const QuadTreeRectangle<float, size_t> * qtr
  ) : StructuredGrid(dims, bs, blks) {
 
 	VAssert(dims.size() == 2);
@@ -1017,7 +1017,7 @@ bool CurvilinearGrid::_insideGrid(
 	}
 }
 
-std::shared_ptr <QuadTreeRectangle<float, size_t> >CurvilinearGrid::_makeQuadTreeRectangle() const {
+ const QuadTreeRectangle<float, size_t> * CurvilinearGrid::_makeQuadTreeRectangle() const {
 
 	vector <double> minu, maxu;
 	GetUserExtents(minu, maxu);
@@ -1026,11 +1026,11 @@ std::shared_ptr <QuadTreeRectangle<float, size_t> >CurvilinearGrid::_makeQuadTre
 	const vector <size_t> dims2d = {dims[0], dims[1]};
 	size_t reserve_size = dims2d[0] * dims2d[1];
 
-	std::shared_ptr <QuadTreeRectangle<float, size_t> >qtr = 
-		std::make_shared <QuadTreeRectangle<float, size_t> >(
+    // This structure will be handed to and owned by a unique_ptr_cache,
+    // thus nobody needs to manually do the cleanup after this creation. 
+	QuadTreeRectangle<float, size_t> * qtr = new QuadTreeRectangle<float, size_t> (
 			(float) minu[0], (float) minu[1], (float) maxu[0], (float) maxu[1], 
-			16, reserve_size
-		);
+			16, reserve_size );
 
 
 	// Loop over horizontal dimensions only - the grid, if 3D, is layered.

--- a/lib/vdc/GridHelper.cpp
+++ b/lib/vdc/GridHelper.cpp
@@ -393,13 +393,12 @@ CurvilinearGrid *GridHelper::_make_grid_curvilinear(
 		ts, level, lod, cvarsinfo, bmin, bmax
 	);
 
-	// Try to get a shared pointer to the QuadTreeRectangle from the 
-	// cache. If one does not exist the Grid class will make one. We use
-	// a shared pointer so that we can cache it for use by other Grid
-	// classes. This a peformance optimization, necessary be creating
-	// a QuadTreeRectangle is expensive.
+	// Try to get a read-only (const) pointer to the QuadTreeRectangle from the 
+	// cache. If one does not exist the Grid class will make one. 
 	//
-	std::shared_ptr<const QuadTreeRectangle<float, size_t> > qtr = _qtrCache.get(qtr_key);
+    const QuadTreeRectangle<float, size_t> * qtr = nullptr;
+    if( _qtrCache.contains( qtr_key ) )
+        qtr = _qtrCache.find( qtr_key );
 
 	CurvilinearGrid *g;
 	if (dims.size() == 3 && cvarsinfo[2].GetDimNames().size() == 3) {
@@ -437,13 +436,13 @@ CurvilinearGrid *GridHelper::_make_grid_curvilinear(
 		);
 	}
 
-	// No QuadTreeRectangle in cache. So get shared pointer for one created
+	// No QuadTreeRectangle in cache. So get a pointer for one created
 	// by UnstructuredGrid2D() and cache it for later use. The memory
-	// will be garbage collected when all pointers to it go out of scope
+	// will be freed when _qtrCache reaches its end of life.
 	//
 	if (! qtr) {
 		qtr = g->GetQuadTreeRectangle();
-		(void) _qtrCache.put(qtr_key, qtr);
+		_qtrCache.insert(qtr_key, qtr);
 	}
 
 	return(g);
@@ -552,13 +551,12 @@ UnstructuredGrid2D *GridHelper::_make_grid_unstructured2d(
 		ts, level, lod, cvarsinfo, bmin, bmax
 	);
 
-	// Try to get a shared pointer to the QuadTreeRectangle from the 
-	// cache. If one does not exist the Grid class will make one. We use
-	// a shared pointer so that we can cache it for use by other Grid
-	// classes. This a peformance optimization, necessary be creating
-	// a QuadTreeRectangle is expensive.
+	// Try to get a read-only (const) pointer to the QuadTreeRectangle from the 
+	// cache. If one does not exist the Grid class will make one.
 	//
-	std::shared_ptr<const QuadTreeRectangle<float, size_t> > qtr = _qtrCache.get(qtr_key);
+	const QuadTreeRectangle<float, size_t> * qtr = nullptr;
+    if( _qtrCache.contains(qtr_key) )
+        qtr = _qtrCache.find( qtr_key );
 
 	UnstructuredGrid2D *g = new UnstructuredGrid2D(
 		vertexDims, faceDims, edgeDims, bs, blkptrs, 
@@ -568,13 +566,13 @@ UnstructuredGrid2D *GridHelper::_make_grid_unstructured2d(
 		xug, yug, zug, qtr
 	);
 
-	// No QuadTreeRectangle in cache. So get shared pointer for one created
+	// No QuadTreeRectangle in cache. So get a pointer for one created
 	// by UnstructuredGrid2D() and cache it for later use. The memory
-	// will be garbage collected when all pointers to it go out of scope
+	// will be freed when _qtrCache reaches its end of life.
 	//
 	if (! qtr) {
 		qtr = g->GetQuadTreeRectangle();
-		(void) _qtrCache.put(qtr_key, qtr);
+		_qtrCache.insert(qtr_key, qtr);
 	}
 
 
@@ -708,13 +706,12 @@ UnstructuredGridLayered *GridHelper::_make_grid_unstructured_layered(
 		ts, level, lod, cvarsinfo, bmin, bmax
 	);
 
-	// Try to get a shared pointer to the QuadTreeRectangle from the 
-	// cache. If one does not exist the Grid class will make one. We use
-	// a shared pointer so that we can cache it for use by other Grid
-	// classes. This a peformance optimization, necessary be creating
-	// a QuadTreeRectangle is expensive.
+	// Try to get a read-only (const) pointer to the QuadTreeRectangle from the 
+	// cache. If one does not exist the Grid class will make one. 
 	//
-	std::shared_ptr<const QuadTreeRectangle<float, size_t> > qtr = _qtrCache.get(qtr_key);
+	const QuadTreeRectangle<float, size_t> * qtr = nullptr;
+    if( _qtrCache.contains( qtr_key ) )
+        qtr = _qtrCache.find( qtr_key );
 
 	UnstructuredGridLayered *g = new UnstructuredGridLayered(
 		vertexDims, faceDims, edgeDims, bs, blkptrs, 
@@ -723,13 +720,13 @@ UnstructuredGridLayered *GridHelper::_make_grid_unstructured_layered(
 		xug, yug, zug, qtr
 	);
 
-	// No QuadTreeRectangle in cache. So get shared pointer for one created
+	// No QuadTreeRectangle in cache. So get a pointer for one created
 	// by UnstructuredGrid2D() and cache it for later use. The memory
-	// will be garbage collected when all pointers to it go out of scope
+	// will be freed when _qtrCache reaches its end of life.
 	//
 	if (! qtr) {
 		qtr = g->GetQuadTreeRectangle();
-		(void) _qtrCache.put(qtr_key, qtr);
+		_qtrCache.insert(qtr_key, qtr);
 	}
 
 	return(g);
@@ -887,11 +884,7 @@ UnstructuredGrid *GridHelper::MakeGridUnstructured(
 
 
 
-GridHelper::~GridHelper() {
-
-	while ((_qtrCache.remove_lru()) != NULL) {
-	}
-}
+GridHelper::~GridHelper() { }
 
 
 string GridHelper::GetGridType(

--- a/lib/vdc/UnstructuredGrid2D.cpp
+++ b/lib/vdc/UnstructuredGrid2D.cpp
@@ -36,7 +36,7 @@ UnstructuredGrid2D::UnstructuredGrid2D(
     const UnstructuredGridCoordless &xug,
     const UnstructuredGridCoordless &yug,
     const UnstructuredGridCoordless &zug,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
 ) : UnstructuredGrid(
 		vertexDims, faceDims, edgeDims, bs, blks, 2,
 		vertexOnFace, faceOnVertex, faceOnFace, location, 
@@ -53,10 +53,8 @@ UnstructuredGrid2D::UnstructuredGrid2D(
 
 	VAssert(location == NODE);
 
-	_qtrOwner = false;
 	if (! _qtr) {
 		_qtr = _makeQuadTreeRectangle();
-		_qtrOwner = true;
 	}
 
 }
@@ -558,7 +556,7 @@ bool UnstructuredGrid2D::_insideFace(
 	return ret;
 }
 
-QuadTreeRectangle<float, size_t> *UnstructuredGrid2D::_makeQuadTreeRectangle() const {
+std::shared_ptr <QuadTreeRectangle<float, size_t> >UnstructuredGrid2D::_makeQuadTreeRectangle() const {
 
 	size_t maxNodes = GetMaxVertexPerCell();
 	size_t nodeDim = GetNodeDimensions().size();
@@ -573,8 +571,8 @@ QuadTreeRectangle<float, size_t> *UnstructuredGrid2D::_makeQuadTreeRectangle() c
 	const vector <size_t> &dims = GetDimensions();
 	size_t reserve_size = dims[0];
 
-	QuadTreeRectangle<float, size_t> *qtr = 
-		new QuadTreeRectangle<float, size_t>(
+	std::shared_ptr <QuadTreeRectangle<float, size_t> >qtr = 
+		std::make_shared <QuadTreeRectangle<float, size_t>>(
 			(float) minu[0], (float) minu[1], (float) maxu[0], (float) maxu[1], 
 			16, reserve_size
 		);

--- a/lib/vdc/UnstructuredGrid2D.cpp
+++ b/lib/vdc/UnstructuredGrid2D.cpp
@@ -573,9 +573,8 @@ bool UnstructuredGrid2D::_insideFace(
 
     // This structure will be handed to and owned by a unique_ptr_cache,
     // thus nobody needs to manually do the cleanup after this creation. 
-	QuadTreeRectangle<float, size_t> * qtr = new QuadTreeRectangle<float, size_t>(
-			(float) minu[0], (float) minu[1], (float) maxu[0], (float) maxu[1], 
-			16, reserve_size );
+	auto * qtr = new QuadTreeRectangle<float, size_t>( (float) minu[0], (float) minu[1], 
+                     (float) maxu[0], (float) maxu[1], 16, reserve_size );
 
 	double coords[2];
 	Grid::ConstCellIterator it = ConstCellBegin();

--- a/lib/vdc/UnstructuredGrid2D.cpp
+++ b/lib/vdc/UnstructuredGrid2D.cpp
@@ -36,7 +36,7 @@ UnstructuredGrid2D::UnstructuredGrid2D(
     const UnstructuredGridCoordless &xug,
     const UnstructuredGridCoordless &yug,
     const UnstructuredGridCoordless &zug,
-	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
+	const QuadTreeRectangle<float, size_t> * qtr
 ) : UnstructuredGrid(
 		vertexDims, faceDims, edgeDims, bs, blks, 2,
 		vertexOnFace, faceOnVertex, faceOnFace, location, 
@@ -556,7 +556,7 @@ bool UnstructuredGrid2D::_insideFace(
 	return ret;
 }
 
-std::shared_ptr <QuadTreeRectangle<float, size_t> >UnstructuredGrid2D::_makeQuadTreeRectangle() const {
+ const QuadTreeRectangle<float, size_t> * UnstructuredGrid2D::_makeQuadTreeRectangle() const {
 
 	size_t maxNodes = GetMaxVertexPerCell();
 	size_t nodeDim = GetNodeDimensions().size();
@@ -571,11 +571,11 @@ std::shared_ptr <QuadTreeRectangle<float, size_t> >UnstructuredGrid2D::_makeQuad
 	const vector <size_t> &dims = GetDimensions();
 	size_t reserve_size = dims[0];
 
-	std::shared_ptr <QuadTreeRectangle<float, size_t> >qtr = 
-		std::make_shared <QuadTreeRectangle<float, size_t>>(
+    // This structure will be handed to and owned by a unique_ptr_cache,
+    // thus nobody needs to manually do the cleanup after this creation. 
+	QuadTreeRectangle<float, size_t> * qtr = new QuadTreeRectangle<float, size_t>(
 			(float) minu[0], (float) minu[1], (float) maxu[0], (float) maxu[1], 
-			16, reserve_size
-		);
+			16, reserve_size );
 
 	double coords[2];
 	Grid::ConstCellIterator it = ConstCellBegin();

--- a/lib/vdc/UnstructuredGridLayered.cpp
+++ b/lib/vdc/UnstructuredGridLayered.cpp
@@ -36,7 +36,7 @@ UnstructuredGridLayered::UnstructuredGridLayered(
     const UnstructuredGridCoordless &xug,
     const UnstructuredGridCoordless &yug,
     const UnstructuredGridCoordless &zug,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
 ) : UnstructuredGrid(
         vertexDims, faceDims, edgeDims, bs, blks, 3,
         vertexOnFace, faceOnVertex, faceOnFace, location,

--- a/lib/vdc/UnstructuredGridLayered.cpp
+++ b/lib/vdc/UnstructuredGridLayered.cpp
@@ -36,7 +36,7 @@ UnstructuredGridLayered::UnstructuredGridLayered(
     const UnstructuredGridCoordless &xug,
     const UnstructuredGridCoordless &yug,
     const UnstructuredGridCoordless &zug,
-	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
+	const QuadTreeRectangle<float, size_t> * qtr
 ) : UnstructuredGrid(
         vertexDims, faceDims, edgeDims, bs, blks, 3,
         vertexOnFace, faceOnVertex, faceOnFace, location,


### PR DESCRIPTION
This bug was caused by an attempt to use an instance of a QuadTreeRectangle
that had previously been freed. QuadTreeRectangles are now allocated as shared
pointers to make chaching them for re-use by multiple Grid objects
easier. Populating a QuadTreeRectangle instance is an expensive operation
and it is desireable to re-use the tree as much as possible.