### PR TITLE
Fixed #1755 - Vapor crashes with large MPAS wireframe renderer

### DIFF
--- a/include/vapor/WireFrameRenderer.h
+++ b/include/vapor/WireFrameRenderer.h
@@ -81,8 +81,19 @@ private:
 
 	} _cacheParams;
 
+	// Helper class to keep track of which cell edges have been drawn so
+	// we can avoid duplicate draws.
+	//
 	class DrawList {
 	public:
+
+		// maxEntries is the maximum number of unique cell nodes. 
+		// maxLinesPerVertex is the *expected* max valence (degree) of any
+		// node (vertex). If a node has more than maxLinesPerVertex edges
+		// only the first maxLinesPerVertex edges will be recorded in
+		// DrawList. Hence, queries to edges with DrawList::InList will
+		// return false once maxLinesPerVertex has been exceeded
+		//
 		DrawList(size_t maxEntries, size_t maxLinesPerVertex) :
 			_drawList(
 				maxEntries*maxLinesPerVertex, std::numeric_limits<size_t>::max()
@@ -117,6 +128,14 @@ private:
 		size_t _maxEntries;
 		size_t _maxLinesPerVertex;
 	};
+
+	void  _buildCacheVertices(
+		const Grid *grid, const Grid *heightGrid, vector <size_t> &nodeMap
+	) const;
+
+	size_t _buildCacheConnectivity(
+		const Grid *grid, const vector <size_t> &nodeMap
+	) const;
 
 	int  _buildCache();
 	bool _isCacheDirty() const;

--- a/include/vapor/WireFrameRenderer.h
+++ b/include/vapor/WireFrameRenderer.h
@@ -95,15 +95,15 @@ private:
 		// DrawList. Hence, queries to edges with DrawList::InList will
 		// return false once maxLinesPerVertex has been exceeded
 		//
-		DrawList(size_t maxEntries, size_t maxLinesPerVertex) :
+		DrawList(GLuint maxEntries, size_t maxLinesPerVertex) :
 			_drawList(
-				maxEntries*maxLinesPerVertex, std::numeric_limits<size_t>::max()
+				maxEntries*maxLinesPerVertex, std::numeric_limits<GLuint>::max()
 			),
 			_maxEntries(maxEntries),
 			_maxLinesPerVertex(maxLinesPerVertex)
 		 {}	
 
-		bool InList(size_t idx0, size_t idx1) {
+		bool InList(GLuint idx0, GLuint idx1) {
 			VAssert(idx0 < _maxEntries);
 			VAssert(idx1 < _maxEntries);
 
@@ -115,7 +115,7 @@ private:
 				if (_drawList[idx0*_maxLinesPerVertex+i] == idx1) {
 					return(true);
 				}
-				if (_drawList[idx0*_maxLinesPerVertex+i] == std::numeric_limits<size_t>::max()) {
+				if (_drawList[idx0*_maxLinesPerVertex+i] == std::numeric_limits<GLuint>::max()) {
 					_drawList[idx0*_maxLinesPerVertex+i] = idx1;
 					return(false);
 				}
@@ -123,28 +123,28 @@ private:
 			return(false);
 		}
 	private:
-		vector<size_t> _drawList;
+		vector<GLuint> _drawList;
 		size_t _maxEntries;
 		size_t _maxLinesPerVertex;
 	};
 
 	void  _buildCacheVertices(
-		const Grid *grid, const Grid *heightGrid, vector <size_t> &nodeMap
+		const Grid *grid, const Grid *heightGrid, vector <GLuint> &nodeMap
 	) const;
 
 	size_t _buildCacheConnectivity(
-		const Grid *grid, const vector <size_t> &nodeMap
+		const Grid *grid, const vector <GLuint> &nodeMap
 	) const;
 
 	int  _buildCache();
 	bool _isCacheDirty() const;
 	void _saveCacheParams();
 	void _drawCell(
-		const size_t *cellNodeIndices,
+		const GLuint *cellNodeIndices,
 		int n,
 		bool layered,
-		const std::vector <size_t> &nodeMap,
-		size_t invalidIndex,
+		const std::vector <GLuint> &nodeMap,
+		GLuint invalidIndex,
 		std::vector<unsigned int> &indices,
 		DrawList &drawList
 	) const;

--- a/include/vapor/WireFrameRenderer.h
+++ b/include/vapor/WireFrameRenderer.h
@@ -81,17 +81,55 @@ private:
 
 	} _cacheParams;
 
+	class DrawList {
+	public:
+		DrawList(size_t maxEntries, size_t maxLinesPerVertex) :
+			_drawList(
+				maxEntries*maxLinesPerVertex, std::numeric_limits<size_t>::max()
+			),
+			_maxEntries(maxEntries),
+			_maxLinesPerVertex(maxLinesPerVertex)
+		 {}	
+
+		bool InList(size_t idx0, size_t idx1) {
+			VAssert(idx0 < _maxEntries);
+			VAssert(idx1 < _maxEntries);
+
+			if (idx1 < idx0) {
+				size_t tmp = idx0;
+				idx0 = idx1;
+				idx1 = tmp;
+			}
+
+			for (int i = 0; i<_maxLinesPerVertex; i++) {
+				if (_drawList[idx0*_maxLinesPerVertex+i] == idx1) {
+					return(true);
+				}
+				if (_drawList[idx0*_maxLinesPerVertex+i] == std::numeric_limits<size_t>::max()) {
+					_drawList[idx0*_maxLinesPerVertex+i] = idx1;
+					return(false);
+				}
+			}
+			return(false);
+		}
+	private:
+		vector<size_t> _drawList;
+		size_t _maxEntries;
+		size_t _maxLinesPerVertex;
+	};
+
 	int  _buildCache();
 	bool _isCacheDirty() const;
 	void _saveCacheParams();
 	void _drawCell(
-            vector<VertexData> &vertices,
-            vector<unsigned int> &indices,
-			const float *verts,
-			const float *colors,
-			int n,
-			bool layered
-			);
+		const size_t *cellNodeIndices,
+		int n,
+		bool layered,
+		const std::vector <size_t> &nodeMap,
+		size_t invalidIndex,
+		std::vector<unsigned int> &indices,
+		DrawList &drawList
+	) const;
 
   void _clearCache() {
 	_cacheParams.varName.clear();

--- a/include/vapor/WireFrameRenderer.h
+++ b/include/vapor/WireFrameRenderer.h
@@ -17,6 +17,7 @@
 #include <GL/gl.h>
 #endif
 
+#include <utility>
 #include <vapor/DataMgr.h>
 #include <vapor/utils.h>
 #include <vapor/Renderer.h>
@@ -107,9 +108,7 @@ private:
 			VAssert(idx1 < _maxEntries);
 
 			if (idx1 < idx0) {
-				size_t tmp = idx0;
-				idx0 = idx1;
-				idx1 = tmp;
+				std::swap( idx1, idx0 );
 			}
 
 			for (int i = 0; i<_maxLinesPerVertex; i++) {

--- a/include/vapor/WireFrameRenderer.h
+++ b/include/vapor/WireFrameRenderer.h
@@ -125,7 +125,8 @@ private:
 	private:
 		vector<GLuint> _drawList;
 		size_t _maxEntries;
-		size_t _maxLinesPerVertex;
+        const size_t _maxEntries;
+		const size_t _maxLinesPerVertex;
 	};
 
 	void  _buildCacheVertices(

--- a/lib/render/WireFrameRenderer.cpp
+++ b/lib/render/WireFrameRenderer.cpp
@@ -278,7 +278,7 @@ void WireFrameRenderer::_buildCacheVertices(
 
 		vertices.push_back({
 			(float) coord[0], (float) coord[1], (float) coord[2],
-			color[1], color[1], color[2], color[3]
+			color[0], color[1], color[2], color[3]
 		});
 	}
 

--- a/lib/render/WireFrameRenderer.cpp
+++ b/lib/render/WireFrameRenderer.cpp
@@ -203,6 +203,8 @@ int WireFrameRenderer::_buildCache()
     
     Grid::ConstNodeIterator nitr = grid->ConstNodeBegin();
     Grid::ConstNodeIterator nend = grid->ConstNodeEnd();
+    Grid::ConstCoordItr coordItr = grid->ConstCoordBegin();
+    Grid::ConstCoordItr coordEnd = grid->ConstCoordEnd();
 
 	double mv = grid->GetMissingValue();
 	float defaultZ = _getDefaultZ(_dataMgr, _cacheParams.ts);
@@ -214,14 +216,18 @@ int WireFrameRenderer::_buildCache()
 	vertices.reserve(numNodes);
 
 	size_t count = 0;
-	for (; nitr != nend; ++nitr) {
+	for (; nitr != nend; ++nitr, ++coordItr) {
 		size_t index = Wasp::LinearizeCoords(*nitr, grid->GetDimensions());
 		nodeMap[index] = vertices.size();
 	
 		double coord[3];
-		grid->GetUserCoordinates((*nitr).data(), coord);
-			
-		if (grid->GetGeometryDim() < 3) {
+		coord[0] = (*coordItr)[0];
+		coord[1] = (*coordItr)[1];
+
+		if (grid->GetGeometryDim() > 2) {
+			coord[2] = (*coordItr)[2];
+		}
+		else {
 			if (heightGrid) {
 				coord[2] = heightGrid->GetValueAtIndex(*nitr);
 			}

--- a/lib/render/WireFrameRenderer.cpp
+++ b/lib/render/WireFrameRenderer.cpp
@@ -141,8 +141,11 @@ void WireFrameRenderer::_drawCell(
 		//
 		if (drawList.InList(idx0,idx1)) continue;
 
-        indices.push_back(idx0);
-        indices.push_back(idx1);
+		// check for overflow
+		//
+		if ((unsigned int) idx0 < 0 || (unsigned int) idx1 < 0) continue;
+        indices.push_back((unsigned int) idx0);
+        indices.push_back((unsigned int) idx1);
 	}
 
 	if (! layered) return;
@@ -158,8 +161,11 @@ void WireFrameRenderer::_drawCell(
 
 		if (drawList.InList(idx0,idx1)) continue;
 
-        indices.push_back(idx0);
-        indices.push_back(idx1);
+		// check for overflow
+		//
+		if ((unsigned int) idx0 < 0 || (unsigned int) idx1 < 0) continue;
+        indices.push_back((unsigned int) idx0);
+        indices.push_back((unsigned int) idx1);
 	}
     
 	// Now draw edges between top and bottom face
@@ -173,8 +179,11 @@ void WireFrameRenderer::_drawCell(
 
 		if (drawList.InList(idx0,idx1)) continue;
 
-        indices.push_back(idx0);
-        indices.push_back(idx1);
+		// check for overflow
+		//
+		if ((unsigned int) idx0 < 0 || (unsigned int) idx1 < 0) continue;
+        indices.push_back((unsigned int) idx0);
+        indices.push_back((unsigned int) idx1);
 	}
 }
 


### PR DESCRIPTION
VAPOR was crashing inside of the WireFrameRenderer with large data sets. The code (prior to this PR) was allocating more memory than necessary. This was mostly due to the brute force rendering approach taken: each edge, for each cell in the grid was drawn as a line segment. Edges shared by multiple cells (the general case) were drawn multiple times. Thus, the connectivity list could easily be 10's of GigaBytes in size. 

In addition to reducing the memory requirements by avoiding redrawing the same lines over and over, this PR takes further steps to improve performance. Namely, memory is pre-allocated for std::vector. 