### PR TITLE
Fixed #1847 - Flow: Unsteady Flow Crash

### DIFF
--- a/include/vapor/CurvilinearGrid.h
+++ b/include/vapor/CurvilinearGrid.h
@@ -77,7 +77,7 @@ public:
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const std::vector <double> &zcoords,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr<const QuadTreeRectangle<float, size_t> > qtr
  );
 
  //! \copydoc StructuredGrid::StructuredGrid()
@@ -123,7 +123,7 @@ public:
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
  );
 
  //! \copydoc StructuredGrid::StructuredGrid()
@@ -163,15 +163,17 @@ public:
 	const std::vector <float *> &blks,
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
  );
 
  CurvilinearGrid() = default;
  virtual ~CurvilinearGrid() {
-	if (_qtrOwner && _qtr) delete _qtr;
+	if (_qtr) {
+		_qtr = nullptr;	// qtr is a C++ shared pointer
+	}
  }
 
- const QuadTreeRectangle<float, size_t> *GetQuadTreeRectangle() const {
+ std::shared_ptr <const QuadTreeRectangle<float, size_t> > GetQuadTreeRectangle() const {
     return(_qtr);
  }
 
@@ -331,15 +333,14 @@ private:
  RegularGrid _yrg;
  RegularGrid _zrg;
  bool _terrainFollowing;
- const QuadTreeRectangle<float, size_t> *_qtr;
- bool _qtrOwner;
+ std::shared_ptr <const QuadTreeRectangle<float, size_t> > _qtr;
 
  void _curvilinearGrid(
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
 	const std::vector <double> &zcoords,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
  );
 
  void _GetUserExtents(
@@ -377,7 +378,7 @@ private:
 	double zwgt[2]
  ) const;
 
- QuadTreeRectangle<float, size_t> *_makeQuadTreeRectangle() const;
+ std::shared_ptr <QuadTreeRectangle<float, size_t> >_makeQuadTreeRectangle() const;
 
 };
 };

--- a/include/vapor/GridHelper.h
+++ b/include/vapor/GridHelper.h
@@ -89,7 +89,7 @@ private:
  template<typename key_t, typename value_t>
  class lru_cache {
  public:
-  typedef typename std::pair<key_t, value_t *> key_value_pair_t;
+  typedef typename std::pair<key_t, value_t > key_value_pair_t;
   typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
 
   lru_cache() : 
@@ -100,8 +100,8 @@ private:
 	_max_size(max_size) 
   {}
 	
-  value_t *put(const key_t& key, value_t *value) {
-	value_t *rvalue = NULL;
+  value_t put(const key_t& key, value_t value) {
+	value_t rvalue = NULL;
 	auto it = _cache_items_map.find(key);
 	_cache_items_list.push_front(key_value_pair_t(key, value));
 	if (it != _cache_items_map.end()) {
@@ -121,7 +121,7 @@ private:
 	return(rvalue);
   }
 
-  value_t *get(const key_t& key) {
+  value_t get(const key_t& key) {
 	auto it = _cache_items_map.find(key);
 	if (it == _cache_items_map.end()) return(NULL);
 
@@ -131,12 +131,13 @@ private:
 	return it->second->second;
   }
 
-  value_t *remove_lru() {
+  value_t remove_lru() {
 	if (! _cache_items_map.size()) return(NULL);
 
 	auto last = _cache_items_list.end();
 	last--;
-	value_t *rvalue = last->second;
+	value_t rvalue = last->second;
+	last->second = nullptr;	// necessary for delete?
 	_cache_items_map.erase(last->first);
 	_cache_items_list.pop_back();
 	return(rvalue);
@@ -157,7 +158,7 @@ private:
   size_t _max_size;
  };
 
- lru_cache<string, QuadTreeRectangle<float, size_t> > _qtrCache;
+ lru_cache<string, std::shared_ptr<const QuadTreeRectangle<float, size_t> > > _qtrCache;
 
 
  RegularGrid *_make_grid_regular(

--- a/include/vapor/UnstructuredGrid2D.h
+++ b/include/vapor/UnstructuredGrid2D.h
@@ -45,15 +45,15 @@ public:
 	const UnstructuredGridCoordless &xug,
 	const UnstructuredGridCoordless &yug,
 	const UnstructuredGridCoordless &zug,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr<const QuadTreeRectangle<float, size_t> > qtr
  );
 
  UnstructuredGrid2D() = default;
  virtual ~UnstructuredGrid2D() {
-	if (_qtrOwner && _qtr) delete _qtr;
+	if (_qtr) _qtr = nullptr;
  }
 
- const QuadTreeRectangle<float, size_t> *GetQuadTreeRectangle() const {
+ std::shared_ptr <const QuadTreeRectangle<float, size_t> >GetQuadTreeRectangle() const {
 	return(_qtr);
  }
 
@@ -189,8 +189,7 @@ private:
  UnstructuredGridCoordless _xug;
  UnstructuredGridCoordless _yug;
  UnstructuredGridCoordless _zug;
- const QuadTreeRectangle<float, size_t> *_qtr;
- bool _qtrOwner;
+ std::shared_ptr<const QuadTreeRectangle<float, size_t> > _qtr;
 
  bool _insideGrid(
 	const std::vector <double> &coords,
@@ -220,7 +219,7 @@ private:
 	double *lambda, int &nlambda
  ) const;
 
- QuadTreeRectangle<float, size_t> *_makeQuadTreeRectangle() const;
+ std::shared_ptr<QuadTreeRectangle<float, size_t> >_makeQuadTreeRectangle() const;
 
 
 };

--- a/include/vapor/UnstructuredGridLayered.h
+++ b/include/vapor/UnstructuredGridLayered.h
@@ -44,13 +44,13 @@ public:
 	const UnstructuredGridCoordless &xug,
 	const UnstructuredGridCoordless &yug,
 	const UnstructuredGridCoordless &zug,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr<const QuadTreeRectangle<float, size_t> >qtr
  );
 
  UnstructuredGridLayered() = default;
  virtual ~UnstructuredGridLayered() = default;
 
- const QuadTreeRectangle<float, size_t> *GetQuadTreeRectangle() const {
+ std::shared_ptr<const QuadTreeRectangle<float, size_t> >GetQuadTreeRectangle() const {
 	return(_ug2d.GetQuadTreeRectangle());
  }
 

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -17,7 +17,7 @@ void CurvilinearGrid::_curvilinearGrid(
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
 	const vector <double> &zcoords,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
 ) {
 	_zcoords.clear();
 	_minu.clear();
@@ -29,10 +29,8 @@ void CurvilinearGrid::_curvilinearGrid(
 	_zcoords = zcoords;
 
 	_qtr = qtr;
-	_qtrOwner = false;
 	if (! _qtr) {
 		_qtr = _makeQuadTreeRectangle();
-		_qtrOwner = true;
 	}
 
 }
@@ -44,7 +42,7 @@ CurvilinearGrid::CurvilinearGrid(
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const vector <double> &zcoords,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
  ) : StructuredGrid(dims, bs, blks) {
 
 	VAssert(dims.size() == 2 || dims.size() == 3);
@@ -68,7 +66,7 @@ CurvilinearGrid::CurvilinearGrid(
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
 	const RegularGrid &zrg,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
  ) : StructuredGrid(dims, bs, blks) {
 
 	VAssert(dims.size() == 3);
@@ -92,7 +90,7 @@ CurvilinearGrid::CurvilinearGrid(
 	const vector <float *> &blks,
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
  ) : StructuredGrid(dims, bs, blks) {
 
 	VAssert(dims.size() == 2);
@@ -1019,7 +1017,7 @@ bool CurvilinearGrid::_insideGrid(
 	}
 }
 
-QuadTreeRectangle<float, size_t> *CurvilinearGrid::_makeQuadTreeRectangle() const {
+std::shared_ptr <QuadTreeRectangle<float, size_t> >CurvilinearGrid::_makeQuadTreeRectangle() const {
 
 	vector <double> minu, maxu;
 	GetUserExtents(minu, maxu);
@@ -1028,8 +1026,8 @@ QuadTreeRectangle<float, size_t> *CurvilinearGrid::_makeQuadTreeRectangle() cons
 	const vector <size_t> dims2d = {dims[0], dims[1]};
 	size_t reserve_size = dims2d[0] * dims2d[1];
 
-	QuadTreeRectangle<float, size_t> *qtr = 
-		new QuadTreeRectangle<float, size_t>(
+	std::shared_ptr <QuadTreeRectangle<float, size_t> >qtr = 
+		std::make_shared <QuadTreeRectangle<float, size_t> >(
 			(float) minu[0], (float) minu[1], (float) maxu[0], (float) maxu[1], 
 			16, reserve_size
 		);

--- a/lib/vdc/UnstructuredGrid2D.cpp
+++ b/lib/vdc/UnstructuredGrid2D.cpp
@@ -36,7 +36,7 @@ UnstructuredGrid2D::UnstructuredGrid2D(
     const UnstructuredGridCoordless &xug,
     const UnstructuredGridCoordless &yug,
     const UnstructuredGridCoordless &zug,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> > qtr
 ) : UnstructuredGrid(
 		vertexDims, faceDims, edgeDims, bs, blks, 2,
 		vertexOnFace, faceOnVertex, faceOnFace, location, 
@@ -53,10 +53,8 @@ UnstructuredGrid2D::UnstructuredGrid2D(
 
 	VAssert(location == NODE);
 
-	_qtrOwner = false;
 	if (! _qtr) {
 		_qtr = _makeQuadTreeRectangle();
-		_qtrOwner = true;
 	}
 
 }
@@ -558,7 +556,7 @@ bool UnstructuredGrid2D::_insideFace(
 	return ret;
 }
 
-QuadTreeRectangle<float, size_t> *UnstructuredGrid2D::_makeQuadTreeRectangle() const {
+std::shared_ptr <QuadTreeRectangle<float, size_t> >UnstructuredGrid2D::_makeQuadTreeRectangle() const {
 
 	size_t maxNodes = GetMaxVertexPerCell();
 	size_t nodeDim = GetNodeDimensions().size();
@@ -573,8 +571,8 @@ QuadTreeRectangle<float, size_t> *UnstructuredGrid2D::_makeQuadTreeRectangle() c
 	const vector <size_t> &dims = GetDimensions();
 	size_t reserve_size = dims[0];
 
-	QuadTreeRectangle<float, size_t> *qtr = 
-		new QuadTreeRectangle<float, size_t>(
+	std::shared_ptr <QuadTreeRectangle<float, size_t> >qtr = 
+		std::make_shared <QuadTreeRectangle<float, size_t>>(
 			(float) minu[0], (float) minu[1], (float) maxu[0], (float) maxu[1], 
 			16, reserve_size
 		);

--- a/lib/vdc/UnstructuredGridLayered.cpp
+++ b/lib/vdc/UnstructuredGridLayered.cpp
@@ -36,7 +36,7 @@ UnstructuredGridLayered::UnstructuredGridLayered(
     const UnstructuredGridCoordless &xug,
     const UnstructuredGridCoordless &yug,
     const UnstructuredGridCoordless &zug,
-	const QuadTreeRectangle<float, size_t> *qtr
+	std::shared_ptr <const QuadTreeRectangle<float, size_t> >qtr
 ) : UnstructuredGrid(
         vertexDims, faceDims, edgeDims, bs, blks, 3,
         vertexOnFace, faceOnVertex, faceOnFace, location,


### PR DESCRIPTION
This bug was caused by an attempt to use an instance of a QuadTreeRectangle
that had previously been freed. QuadTreeRectangles are now allocated as shared
pointers to make chaching them for re-use by multiple Grid objects
easier. Populating a QuadTreeRectangle instance is an expensive operation
and it is desireable to re-use the tree as much as possible.