### PR TITLE
Fixed #1842 - vapor unnecessarily reads full data domain when an ROI is selected

### DIFF
--- a/apps/vaporgui/ContourSubtabs.cpp
+++ b/apps/vaporgui/ContourSubtabs.cpp
@@ -135,7 +135,10 @@ void ContourAppearanceSubtab::GetContourBounds(double &min, double &max) {
 	int lod = _cParams->GetCompressionLevel();
 	vector<double> minMax(2,0);
 
-	_dataMgr->GetDataRange(ts, varname, level, lod, 1, minMax);
+    vector<double> minExt, maxExt;
+    _cParams->GetBox()->GetExtents(minExt, maxExt);
+
+	_dataMgr->GetDataRange(ts, varname, level, lod, minExt, maxExt, minMax);
 	min = minMax[0];
 	max = minMax[1];
 }

--- a/apps/vaporgui/TFWidget.cpp
+++ b/apps/vaporgui/TFWidget.cpp
@@ -307,13 +307,16 @@ void TFWidget::getVariableRange(
 
 	if (! _dataMgr->VariableExists(ts, varName, ref, cmp)) return;
 
+	vector<double> minExt, maxExt;
+	_rParams->GetBox()->GetExtents(minExt, maxExt);
+
 	vector <double> rangev;
 	int rc = _dataMgr->GetDataRange(
         ts, 
         varName, 
         ref, 
         cmp,
-        _stride, 
+		minExt, maxExt,
         rangev
     );
 

--- a/apps/vaporgui/VolumeIsoSubtabs.cpp
+++ b/apps/vaporgui/VolumeIsoSubtabs.cpp
@@ -117,13 +117,17 @@ void VolumeIsoAppearanceSubtab::Update( VAPoR::DataMgr      *dataMgr,
     _specularWidget->SetValue (_params->GetPhongSpecular());
     _shininessWidget->SetValue(_params->GetPhongShininess());
 
+	vector<double> minExt, maxExt;
+	_params->GetBox()->GetExtents(minExt, maxExt);
+
     // Get the value range
     std::vector<double> valueRanged;
 	bool errEnabled = MyBase::EnableErrMsg(false);
     int rc = dataMgr->GetDataRange( params->GetCurrentTimestep(),
                            params->GetVariableName(),
                            params->GetRefinementLevel(),
-                           params->GetCompressionLevel(), 1,
+                           params->GetCompressionLevel(), 
+                           minExt, maxExt,
                            valueRanged );
 	MyBase::EnableErrMsg(errEnabled);
 

--- a/include/vapor/DataMgr.h
+++ b/include/vapor/DataMgr.h
@@ -447,19 +447,27 @@ std::vector <size_t> GetCRatios(string varname) const;
  //!
  //! This method finds the minimum and maximum value of a variable
  //!
- //! \param[in] stride Stride between successive grid points. If set to 
- //! one every grid point the variable is sampled on will be used to compute
- //! the range. If greater than one specifies stride between successive 
- //! grid points used in calculation.
- //! 
  //! \param[out] range A two element vector containing the minimum and maximum
  //! value, respectively, for the variable \p varname at the specified
  //! time step, lod, etc.
  //
  int GetDataRange(
     size_t ts, string varname, int level,
-    int lod, size_t stride, std::vector <double> &range
+    int lod, std::vector <double> &range
  ) ;
+
+ //! Compute min and max value of a variable within a specified ROI
+ //!
+ //! This method finds the minimum and maximum value of a variable within
+ //! the region of interest (ROI) specified by \p min and \p max. Note, the
+ //! results returned by this method are equivalent to calling the 
+ //! Grid::GetRange() method on a grid returned by DataMgr::GetVariable
+ //! using the same arguments provided here.
+ //
+ int GetDataRange(
+    size_t ts, string varname, int level, int lod, 
+	vector <double> min, vector <double> max, std::vector <double> &range
+ );
 
  
  //! \copydoc DC::GetDimLensAtLevel()

--- a/include/vapor/VolumeRenderer.h
+++ b/include/vapor/VolumeRenderer.h
@@ -74,6 +74,8 @@ protected:
     int _framebufferSize[2];
     float _framebufferRatio;
     float _previousFramebufferRatio;
+    std::vector<double> _dataMinExt;
+    std::vector<double> _dataMaxExt;
     
     struct Cache {
         std::string var = "";
@@ -89,6 +91,9 @@ protected:
         std::vector<float> constantColor;
         
         std::string algorithmName = "";
+
+        std::vector<double> minExt;
+        std::vector<double> maxExt;
         
         bool needsUpdate;
     } _cache;

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -405,6 +405,8 @@ MapperFunction* RenderParams::GetMapperFunc(string varname) {
 	int level = 0;
 	int lod = 0;
 	if (_dataMgr->VariableExists(ts,varname, level, lod)) {
+		vector<double> minExt, maxExt;
+		_Box->GetExtents(minExt, maxExt);
 
 		vector <double> range;
 		bool prev = EnableErrMsg(false);	// no error handling
@@ -413,7 +415,7 @@ MapperFunction* RenderParams::GetMapperFunc(string varname) {
             varname, 
             level,
             lod,
-            _stride,
+			minExt, maxExt,
             range
         );
 		if (rc<0) {

--- a/lib/render/VolumeIsoRenderer.cpp
+++ b/lib/render/VolumeIsoRenderer.cpp
@@ -37,7 +37,10 @@ VolumeIsoRenderer::VolumeIsoRenderer( const ParamsMgr*    pm,
     // An ugly fix but I don't think we have a mechanism for this
     if (_needToSetDefaultAlgorithm()) {
         VolumeParams *vp = (VolumeParams*)GetActiveParams();
-        Grid *grid = _dataMgr->GetVariable(vp->GetCurrentTimestep(), vp->GetVariableName(), vp->GetRefinementLevel(), vp->GetCompressionLevel());
+		vector <double> minExt, maxExt;
+		vp->GetBox()->GetExtents(minExt, maxExt);
+
+        Grid *grid = _dataMgr->GetVariable(vp->GetCurrentTimestep(), vp->GetVariableName(), vp->GetRefinementLevel(), vp->GetCompressionLevel(), minExt, maxExt);
         if (grid) {
             string algorithmName = _getDefaultAlgorithmForGrid(grid);
             vp->SetAlgorithm(algorithmName);

--- a/lib/render/VolumeRenderer.cpp
+++ b/lib/render/VolumeRenderer.cpp
@@ -67,7 +67,10 @@ VolumeRenderer::VolumeRenderer(
     
     if (_needToSetDefaultAlgorithm()) {
         VolumeParams *vp = (VolumeParams*)GetActiveParams();
-        Grid *grid = _dataMgr->GetVariable(vp->GetCurrentTimestep(), vp->GetVariableName(), vp->GetRefinementLevel(), vp->GetCompressionLevel());
+        vector <double> minExt, maxExt;
+        vp->GetBox()->GetExtents(minExt, maxExt);
+
+        Grid *grid = _dataMgr->GetVariable(vp->GetCurrentTimestep(), vp->GetVariableName(), vp->GetRefinementLevel(), vp->GetCompressionLevel(), minExt, maxExt);
         if (grid) {
             string algorithmName = _getDefaultAlgorithmForGrid(grid);
             vp->SetAlgorithm(algorithmName);
@@ -391,14 +394,19 @@ int VolumeRenderer::_initializeAlgorithm()
 int VolumeRenderer::_loadData()
 {
     VolumeParams *RP = (VolumeParams *)GetActiveParams();
+    vector <double> minExt, maxExt;
+    RP->GetBox()->GetExtents(minExt, maxExt);
+
     CheckCache(_cache.var, RP->GetVariableName());
     CheckCache(_cache.ts, RP->GetCurrentTimestep());
     CheckCache(_cache.refinement, RP->GetRefinementLevel());
     CheckCache(_cache.compression, RP->GetCompressionLevel());
+    CheckCache(_cache.minExt, minExt);
+    CheckCache(_cache.maxExt, maxExt);
     if (!_cache.needsUpdate)
         return 0;
     
-    Grid *grid = _dataMgr->GetVariable(_cache.ts, _cache.var, _cache.refinement, _cache.compression);
+    Grid *grid = _dataMgr->GetVariable(_cache.ts, _cache.var, _cache.refinement, _cache.compression, _cache.minExt, _cache.maxExt);
     if (!grid)
         return -1;
     
@@ -406,6 +414,11 @@ int VolumeRenderer::_loadData()
         MyBase::SetErrMsg("Unstructured grids are not supported by this renderer");
         return -1;
     }
+
+	// Actual min and max extents of returned grid, which are in general 
+	// larger than requested extents.
+	//
+	grid->GetUserExtents(_dataMinExt, _dataMaxExt);
     
     if (_needToSetDefaultAlgorithm()) {
         RP->SetAlgorithm(_getDefaultAlgorithmForGrid(grid));
@@ -430,7 +443,7 @@ int VolumeRenderer::_loadSecondaryData()
         return 0;
     
     if (_cache.useColorMapVar) {
-        Grid *grid = _dataMgr->GetVariable(_cache.ts, _cache.colorMapVar, _cache.refinement, _cache.compression);
+        Grid *grid = _dataMgr->GetVariable(_cache.ts, _cache.colorMapVar, _cache.refinement, _cache.compression, _cache.minExt, _cache.maxExt);
         if (!grid)
             return -1;
         int ret = _algorithm->LoadSecondaryData(grid);
@@ -506,14 +519,10 @@ glm::vec3 VolumeRenderer::_getVolumeScales() const
 
 void VolumeRenderer::_getExtents(glm::vec3 *dataMin, glm::vec3 *dataMax, glm::vec3 *userMin, glm::vec3 *userMax) const
 {
-    VolumeParams *vp = (VolumeParams *)GetActiveParams();
-    vector<double> dMinExts, dMaxExts;
-    vp->GetBox()->GetExtents(dMinExts, dMaxExts);
-    *userMin = vec3(dMinExts[0], dMinExts[1], dMinExts[2]);
-    *userMax = vec3(dMaxExts[0], dMaxExts[1], dMaxExts[2]);
-    _dataMgr->GetVariableExtents(_cache.ts, _cache.var, _cache.refinement, dMinExts, dMaxExts);
-    *dataMin = vec3(dMinExts[0], dMinExts[1], dMinExts[2]);
-    *dataMax = vec3(dMaxExts[0], dMaxExts[1], dMaxExts[2]);
+    *userMin = vec3(_cache.minExt[0], _cache.minExt[1], _cache.minExt[2]);
+    *userMax = vec3(_cache.maxExt[0], _cache.maxExt[1], _cache.maxExt[2]);
+    *dataMin = vec3(_dataMinExt[0], _dataMinExt[1], _dataMinExt[2]);
+    *dataMax = vec3(_dataMaxExt[0], _dataMaxExt[1], _dataMaxExt[2]);
     
     // Moving domain allows area outside of data to be selected
     *userMin = glm::max(*userMin, *dataMin);

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -1032,22 +1032,6 @@ Grid *DataMgr::GetVariable (
 	rc = _lod_correction(varname, lod);
 	if (rc<0) return(NULL);
 
-	// Make sure variable dimensions match extents specification
-	//
-	vector <string> coord_vars;
-	bool ok = GetVarCoordVars(varname, true, coord_vars);
-	if (! ok) {
-		SetErrMsg(
-			"Failed to get coordinate variables for variable \"%s\"", 
-			varname.c_str()
-		);
-		return(NULL);
-	}
-
-	while (min.size() > coord_vars.size()) {
-		min.pop_back();
-		max.pop_back();
-	}
 
 	//
 	// Find the coordinates in voxels of the grid that contains
@@ -1620,18 +1604,34 @@ int DataMgr::GetVariableExtents(
 	return(0);
 }
 
+int DataMgr::GetDataRange(
+	size_t ts,
+	string varname,
+	int level,
+	int lod,
+	vector <double> &range
+) {
+	SetDiagMsg("DataMgr::GetDataRange(%d,%s)", ts, varname.c_str());
+
+    vector <double> min, max;
+	int rc = GetVariableExtents(ts, varname, level, min, max);
+	if (rc<0) return(-1);
+
+	return(GetDataRange(ts, varname, level, lod, min, max, range));
+}
+
 
 int DataMgr::GetDataRange(
 	size_t ts,
 	string varname,
 	int level,
 	int lod,
-	size_t stride,
+	vector <double> min, vector <double> max,
 	vector <double> &range
 ) {
 	SetDiagMsg("DataMgr::GetDataRange(%d,%s)", ts, varname.c_str());
 
-	range.clear();
+	range = {0.0, 0.0};
 
 	int rc = _level_correction(varname, level);
 	if (rc<0) return(-1);
@@ -1639,14 +1639,23 @@ int DataMgr::GetDataRange(
 	rc = _lod_correction(varname, lod);
 	if (rc<0) return(-1);
 
+	//
+	// Find the coordinates in voxels of the grid that contains
+	// the axis aligned bounding box specified in user coordinates
+	// by min and max
+	//
+	vector <size_t> min_ui, max_ui;
+	rc = _find_bounding_grid(
+		ts, varname, level, lod, min, max, min_ui, max_ui
+	);
+	if (rc<0) return(-1);
 
 	// See if we've already cache'd it.
 	//
 	ostringstream oss;
 	oss << "VariableRange";
-	if (stride > 1) {
-		oss << stride;
-	}
+	oss << vector_to_string(min_ui);
+	oss << vector_to_string(max_ui);
 	string key = oss.str();
 
 	if (_varInfoCacheDouble.Get(ts, varname, level, lod, key, range)) {
@@ -1655,44 +1664,14 @@ int DataMgr::GetDataRange(
 	}
 
 	const Grid *sg = DataMgr::GetVariable(
-		ts, varname, level, lod, false
+		ts, varname, level, lod, min_ui, max_ui, false
 	);
 	if (! sg) return(-1);
 
-	//
-	// Have to calculate range 
-	//
+	float range_f[2];
+	sg->GetRange(range_f);
+	range = {range_f[0], range_f[1]};
 
-	range.clear(); range.push_back(0.0); range.push_back(0.0);
-	float mv = sg->GetMissingValue();
-	Grid::ConstIterator itr = sg->cbegin();
-	Grid::ConstIterator enditr = sg->cend();
-
-	while (*itr == mv) ++itr;
-	if (itr != enditr) {
-		range[0] = range[1] = *itr;
-		++itr;
-	}
-
-	if (stride > 1) {
-		for (; itr!=enditr;) {
-			float v = *itr;
-			if (v != mv) {
-				if (v < range[0]) range[0] = v;
-				if (v > range[1]) range[1] = v;
-			}
-			itr += stride;
-		}
-	}
-	else {
-		for (; itr!=enditr; ++itr) {
-			float v = *itr;
-			if (v != mv) {
-				if (v < range[0]) range[0] = v;
-				if (v > range[1]) range[1] = v;
-			}
-		}
-	}
 	delete sg;
 
 	_varInfoCacheDouble.Set(ts, varname, level, lod, key, range);
@@ -3044,6 +3023,13 @@ int DataMgr::_find_bounding_grid(
 
 	bool ok = _get_coord_vars(varname, scvars, tcvar);
 	if (! ok) return(-1);
+
+	// Make sure variable dimensions match extents specification
+	//
+	while (min.size() > scvars.size()) {
+		min.pop_back();
+		max.pop_back();
+	}
 
 	size_t hash_ts = 0;
 	for (int i=0; i<scvars.size(); i++) {


### PR DESCRIPTION
Vapor was unnecessarily reading the entire data domain in two instances, despite a region of interest (ROI) having been selected. The first instance was whenever DataMgr::GetDataRange() was invoked to get a variable's minimum and maximum value. GetDataRange() is used in a number of places throughout the application, e.g. computing histograms.  The second instance was inside the DVR and isosurface volume renderer. Both were calling the overloaded DataMgr::GetVariable() method *without* specifying an ROI. 

The fix for the first instance was to overload DataMgr::GetDataRangeI() method with a version that accepts an ROI (min and max extents) as an argument. The volume rendering problem simply required call the correct version of DataMgr::GetVariable() 