### PR TITLE
Issue1886 - Session files do not work if dataset path has spaces

### DIFF
--- a/include/vapor/STLUtils.h
+++ b/include/vapor/STLUtils.h
@@ -23,5 +23,6 @@ namespace STLUtils {
 	COMMON_API std::string ToLower(std::string str);
 	COMMON_API std::vector<std::string> Split(std::string str, const std::string &delimeter);
 	COMMON_API std::string Join(const std::vector<std::string> &parts, const std::string &delimeter);
+    COMMON_API std::string ReplaceAll(std::string source, const std::string &oldSegment, const std::string &newSegment);
 
 }

--- a/lib/common/MyBase.cpp
+++ b/lib/common/MyBase.cpp
@@ -251,7 +251,12 @@ void Wasp::StrToWordVec(const string &s, vector <string> &v)
 		while (! tmp.empty() && isspace(tmp[0])) tmp.erase(0, 1);
 
 		int index = 0;
-		while (index < tmp.length() && ! isspace(tmp[index])) index++;
+        while (index < tmp.length()) {
+            if (isspace(tmp[index]))
+                if (index == 0 || tmp[index-1] != '\\')
+                    break;
+            index++;
+        }
 
 		if (index) {
 			string word = tmp.substr(0, index);

--- a/lib/common/STLUtils.cpp
+++ b/lib/common/STLUtils.cpp
@@ -46,3 +46,15 @@ std::string STLUtils::Join(const std::vector<std::string> &parts, const std::str
         whole += delimeter + *itr;
     return whole;
 }
+
+std::string STLUtils::ReplaceAll(std::string source, const std::string &oldSegment, const std::string &newSegment)
+{
+    size_t start = 0;
+    
+    size_t index;
+    while ((index = source.find(oldSegment, start)) != string::npos) {
+        source.replace(index, oldSegment.length(), newSegment);
+        start = index + newSegment.length();
+    }
+    return source;
+}

--- a/lib/params/XmlNode.cpp
+++ b/lib/params/XmlNode.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <expat.h>
 #include <vapor/XmlNode.h>
+#include <vapor/STLUtils.h>
 
 using namespace VAPoR;
 using namespace Wasp;
@@ -361,7 +362,7 @@ void XmlNode::SetElementStringVec(
 
 	string s;
 	for (int i=0; i<strvec.size(); i++) {
-		s.append(strvec[i]);
+		s.append(STLUtils::ReplaceAll(strvec[i], " ", "\\ "));
 		if (i<strvec.size()-1) s.append(" ");
 	}
 
@@ -412,8 +413,9 @@ const string &XmlNode::GetElementString(const string &tag) const {
 void XmlNode::GetElementStringVec(const string &tag, vector <string> &vec) const {
 	
 	string s = XmlNode::GetElementString(tag);
-
 	StrToWordVec(s, vec);
+    for (string &e : vec)
+        e = STLUtils::ReplaceAll(e, "\\ ", " ");
 }
 
 


### PR DESCRIPTION
The problem is that string vectors are space delimited in the params database/xml files. Since I'm guessing this is not something we can change due to backwards compatibility and potentially breaking things, I added escaping for spaces for string vectors in the params database.

Fix #1886 