### PR TITLE
Fixed problem with hidden files

### DIFF
--- a/apps/vaporgui/TFColorWidget.cpp
+++ b/apps/vaporgui/TFColorWidget.cpp
@@ -67,6 +67,9 @@ void TFColorMap::PopulateSettingsMenu(QMenu *menu) const
     std::sort(fileNames.begin(), fileNames.end());
     for (int i = 0; i < fileNames.size(); i++) {
         
+        // Ignore hidden files
+        if (fileNames[i][0] == '.') continue;
+ 
         string path = FileUtils::JoinPaths({builtinPath, fileNames[i]});
         
         QAction *item = new ColorMapMenuItem(path);


### PR DESCRIPTION
TFColorWidget is throwing an error condition into MyBase when it tries to read hidden files in our share/palettes directory.