### PR TITLE
Revert "Fixed problem with hidden files"

### DIFF
--- a/apps/vaporgui/TFColorWidget.cpp
+++ b/apps/vaporgui/TFColorWidget.cpp
@@ -67,9 +67,6 @@ void TFColorMap::PopulateSettingsMenu(QMenu *menu) const
     std::sort(fileNames.begin(), fileNames.end());
     for (int i = 0; i < fileNames.size(); i++) {
         
-        // Ignore hidden files
-        if (fileNames[i][0] == '.') continue;
- 
         string path = FileUtils::JoinPaths({builtinPath, fileNames[i]});
         
         QAction *item = new ColorMapMenuItem(path);


### PR DESCRIPTION
Reverts NCAR/VAPOR#1898

I left a comment on the original PR:

> I think the error being logged is caused by a non-.tf3 file being read, for example a .DS_Store, not by a hidden file per se.