### PR TITLE
Fix 1913: DVR: propagate existing depth buffer to output

### DIFF
--- a/share/shaders/VolumeBase.frag
+++ b/share/shaders/VolumeBase.frag
@@ -81,11 +81,15 @@ bool ShouldRenderSample(const vec3 sampleSTR)
 float GetDepthBuffer()
 {
     if (readDepthBuffer) {
-        float depth = texture(sceneDepth, ST).r;
-        return depth * 2 - 1; // back to NDC
+        return texture(sceneDepth, ST).r;
     } else {
         return 1;
     }
+}
+
+float GetDepthBufferNDC()
+{
+    return GetDepthBuffer() * 2 - 1;
 }
 
 float PhongLighting(vec3 normal, vec3 viewDir)
@@ -146,7 +150,7 @@ void BlendToBack(inout vec4 accum, vec4 color)
 void GetRayParameters(out vec3 eye, out vec3 dir, out vec3 normal, OUT float maxT)
 {
 	vec2 screen = ST*2-1;
-    vec4 world = inverse(MVP) * vec4(screen, GetDepthBuffer(), 1);
+    vec4 world = inverse(MVP) * vec4(screen, GetDepthBufferNDC(), 1);
     if (mapOrthoMode) {
         eye = vec3(world.xy, cameraPos.z);
     } else {

--- a/share/shaders/VolumeCellBase.frag
+++ b/share/shaders/VolumeCellBase.frag
@@ -564,11 +564,11 @@ void main(void)
         if (accum.a < ALPHA_DISCARD) {
             // discard; // There is a bug on in the 2015 15" AMD MBP laptops where this does not work with larger(?) datasets
             fragColor = vec4(0);
-            gl_FragDepth = 1;
+            gl_FragDepth = GetDepthBuffer();
             return;
         }
         fragColor = accum;
         return;
     }
-    discard;
+    gl_FragDepth = GetDepthBuffer();
 }

--- a/share/shaders/VolumeDVR.frag
+++ b/share/shaders/VolumeDVR.frag
@@ -75,5 +75,5 @@ void main(void)
         fragColor = accum;
     }
     if (accum.a < ALPHA_DISCARD)
-        discard;
+        gl_FragDepth = GetDepthBuffer();
 }

--- a/share/shaders/VolumeIso.frag
+++ b/share/shaders/VolumeIso.frag
@@ -76,5 +76,5 @@ void main(void)
     }
         
     if (accum.a < ALPHA_DISCARD)
-        discard;
+        gl_FragDepth = GetDepthBuffer();
 }


### PR DESCRIPTION
Fix #1913 