### PR TITLE
Fix #1928: Loading a colormap resets the mapping range

### DIFF
--- a/lib/params/MapperFunction.cpp
+++ b/lib/params/MapperFunction.cpp
@@ -214,6 +214,11 @@ int MapperFunction::LoadColormapFromFile(string path)
     *m_colorMap = *temp.GetColorMap();
     m_colorMap->SetParent(this);
     
+    // Apparently the colormap stores its own copy of the mapping range.
+    // This could be solved differently but the fact that this
+    // is a valid solution is amusing.
+    setMinMaxMapValue(getMinMapValue(), getMaxMapValue());
+    
     return rc;
 }
 


### PR DESCRIPTION
Fix #1928 