### PR TITLE
Fix #1428: Disable the opacity map for the wireframe renderer

### DIFF
--- a/apps/vaporgui/TFEditor.cpp
+++ b/apps/vaporgui/TFEditor.cpp
@@ -43,3 +43,11 @@ void TFEditor::Update(VAPoR::DataMgr *dataMgr, VAPoR::ParamsMgr *paramsMgr, VAPo
     _mapsInfo->Update(rParams);
     range->Update(dataMgr, paramsMgr, rParams);
 }
+
+void TFEditor::SetShowOpacityMap(bool b)
+{
+    if (b)
+        _opacityMap->show();
+    else
+        _opacityMap->hide();
+}

--- a/apps/vaporgui/TFEditor.h
+++ b/apps/vaporgui/TFEditor.h
@@ -23,6 +23,7 @@ public:
     TFEditor();
     
     virtual void Update(VAPoR::DataMgr *dataMgr, VAPoR::ParamsMgr *paramsMgr, VAPoR::RenderParams *rParams);
+    void SetShowOpacityMap(bool b);
     
 protected:
     TFMapGroupWidget *_maps;

--- a/apps/vaporgui/TFMapWidget.cpp
+++ b/apps/vaporgui/TFMapWidget.cpp
@@ -68,14 +68,16 @@ void TFMap::update()
 
 void TFMap::show()
 {
+    _hidden = false;
     if (_parent)
-        _parent->show();
+        _parent->showMap(this);
 }
 
 void TFMap::hide()
 {
+    _hidden = true;
     if (_parent)
-        _parent->hide();
+        _parent->hideMap(this);
 }
 
 VAPoR::MapperFunction *TFMap::getMapperFunction() const
@@ -275,6 +277,22 @@ QSize TFMapWidget::minimumSizeHint() const
     return max;
 }
 
+void TFMapWidget::showMap(TFMap *map)
+{
+    map->_hidden = false;
+    show();
+}
+
+void TFMapWidget::hideMap(TFMap *map)
+{
+    map->_hidden = true;
+    int nHidden = 0;
+    for (TFMap *m : _maps)
+        if (m->_hidden) nHidden++;
+    if (nHidden == _maps.size())
+        hide();
+}
+
 void TFMapWidget::_mapActivated(TFMap *who)
 {
     for (auto map : _maps)
@@ -310,7 +328,7 @@ void TFMapWidget::paintEvent(QPaintEvent* event)
     
 //    void *s = VAPoR::GLManager::BeginTimer();
     for (int i = _maps.size() - 1; i >= 0; i--) {
-        if (!_maps[i]->HasValidParams() || !_maps[i]->isLargeEnoughToPaint())
+        if (!_maps[i]->HasValidParams() || !_maps[i]->isLargeEnoughToPaint() || _maps[i]->_hidden)
             continue;
         p.save();
         _maps[i]->paintEvent(p);

--- a/apps/vaporgui/TFMapWidget.h
+++ b/apps/vaporgui/TFMapWidget.h
@@ -29,6 +29,7 @@ class TFMap : public QObject {
     int _width = 0;
     int _height = 0;
     bool _insideSaveStateGroup = false;
+    bool _hidden = false;
     
     VAPoR::DataMgr *_dataMgr = nullptr;
     VAPoR::ParamsMgr *_paramsMgr = nullptr;
@@ -121,6 +122,8 @@ public:
     void Update(VAPoR::DataMgr *dataMgr, VAPoR::ParamsMgr *paramsMgr, VAPoR::RenderParams *rParams);
     void Deactivate();
     QSize minimumSizeHint() const override;
+    void showMap(TFMap *map);
+    void hideMap(TFMap *map);
     
 signals:
     void Activated(TFMapWidget *who);

--- a/apps/vaporgui/WireFrameSubtabs.h
+++ b/apps/vaporgui/WireFrameSubtabs.h
@@ -47,6 +47,7 @@ public:
 	WireFrameAppearanceSubtab(QWidget* parent) {
 		setupUi(this);
         verticalLayout->insertWidget(0, _tfe = new TFEditor);
+        _tfe->SetShowOpacityMap(false);
 	}
 
 	void Update(


### PR DESCRIPTION
Fix #1428