### PR TITLE
Fix #1917: Enable depth testing for the Flow renderer

### DIFF
--- a/lib/render/FlowRenderer.cpp
+++ b/lib/render/FlowRenderer.cpp
@@ -285,6 +285,9 @@ FlowRenderer::_paintGL( bool fast )
             rv = _2ndAdvection->CalculateParticleValues( &_colorField, true );
         _coloringComplete = true;
     }
+    
+    glEnable(GL_DEPTH_TEST);
+    glDepthMask(true);
 
     _prepareColormap( params );
     _renderFromAnAdvection( &_advection, params, fast );


### PR DESCRIPTION
Fix #1917