### PR TITLE
Fix to reduce windows 3rd party file size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,10 +212,10 @@ if (WIN32)
 	set (PRE_UNINSTALL_LOCAL_PATH "buildutils/NSIS.preUnInstall.ini")
 	set (PRE_UNINSTALL_PATH "${CMAKE_CURRENT_BINARY_DIR}/${PRE_UNINSTALL_LOCAL_PATH}")
 	configure_file ("${PRE_UNINSTALL_LOCAL_PATH}.in" "${PRE_UNINSTALL_PATH}" @ONLY)
-
+	
 	if (GENERATE_FULL_INSTALLER)
-		set (DLL_DIR ${THIRD_PARTY_DIR}/dll)
-		file (GLOB WIN_INSTALL_DLLS ${DLL_DIR}/*.dll ${QTDIR}/bin/*.dll)
+		set (LIB_DIR ${THIRD_PARTY_DIR}/lib)
+		file (GLOB WIN_INSTALL_DLLS ${LIB_DIR}/*.dll ${QTDIR}/bin/*.dll)
 
 		install (
 			FILES ${WIN_INSTALL_DLLS}


### PR DESCRIPTION
My 3rd party library archive contained redundant .dll files.  This just points CMake to a new location for .dll's.