### PR TITLE
Fix #1748: Transforms: First loaded dataset gets ignored

### DIFF
--- a/lib/params/CMakeLists.txt
+++ b/lib/params/CMakeLists.txt
@@ -61,6 +61,7 @@ set (HEADERS
 	${PROJECT_SOURCE_DIR}/include/vapor/VolumeParams.h
 	${PROJECT_SOURCE_DIR}/include/vapor/VolumeIsoParams.h
 	${PROJECT_SOURCE_DIR}/include/vapor/ModelParams.h
+	${PROJECT_SOURCE_DIR}/include/vapor/Transform.h
 )
 
 add_library (params SHARED ${SRC} ${HEADERS})

--- a/lib/render/AnnotationRenderer.cpp
+++ b/lib/render/AnnotationRenderer.cpp
@@ -514,14 +514,6 @@ void AnnotationRenderer::InScenePaint(size_t ts)
 
 	vector<string> names = m_paramsMgr->GetDataMgrNames();
     Transform* t = vpParams->GetTransform(names[0]);
-    if (names.size()) {
-        Transform* tmp;
-        for (int i=0; i<names.size(); i++) {
-            tmp = vpParams->GetTransform(names[i]);
-            if ( tmp->GetScales()[Z] < t->GetScales()[Z] )
-                *t = *tmp;
-        }
-    }
 	applyTransform(t);
 
 	double mvMatrix[16];


### PR DESCRIPTION
Fix #1748 

There was some code in the annotation renderer that was breaking the dataset scaling