### PR TITLE
Fixed #1938 - Implicit time steps in NetCDF CF files not working 

### DIFF
--- a/include/vapor/NetCDFCFCollection.h
+++ b/include/vapor/NetCDFCFCollection.h
@@ -657,6 +657,41 @@ public:
   double *_timecoords;
  };
 
+ class DerivedVarTimeFromMem : public NetCDFCollection::DerivedVar {
+ public:
+  DerivedVarTimeFromMem(
+	string name, string units, string timeDimName, 
+	const std::vector <double> times
+  );
+
+  virtual int Open(size_t ts);
+  virtual int ReadSlice(float *slice, int);
+  virtual int Read(float *buf, int);
+  virtual int SeekSlice(int offset, int whence, int fd) { return(0); }
+  virtual int Close(int) {return(0); };
+  virtual bool TimeVarying() const {return(true); };
+  virtual std::vector <size_t>  GetSpatialDims() const {
+	return(std::vector<size_t>());
+  }
+  virtual std::vector <string>  GetSpatialDimNames() const {
+	return(std::vector <string>());
+  }
+  virtual size_t  GetTimeDim() const { return(_times.size()); }
+  virtual string  GetTimeDimName() const { return(_timeDimName); };
+  virtual bool GetMissingValue(double &mv) const {mv=0.0; return(false); }
+  virtual void GetAtt(string name, string &values) const {
+    values.clear();
+	if (name == "units") values = _units;
+  }
+
+ private:
+  size_t _ts;
+  string _name;
+  string _units;
+  string _timeDimName;
+  std::vector <double> _times;
+ };
+
  class DerivedVar_vertStag : public NetCDFCollection::DerivedVar {
 
  public:

--- a/include/vapor/NetCDFSimple.h
+++ b/include/vapor/NetCDFSimple.h
@@ -71,6 +71,9 @@ public:
 	//! Returns an ordered list of the variable's netCDF dimension names.
 	//! 
 	std::vector <string> GetDimNames() const {return(_dimnames); };
+	void SetDimNames(const std::vector <string> dimnames) {
+		_dimnames = dimnames;
+	}
 
 	//! Return the netCDF external data type for an attribute
 	//!

--- a/lib/vdc/NetCDFCFCollection.cpp
+++ b/lib/vdc/NetCDFCFCollection.cpp
@@ -77,6 +77,7 @@ int NetCDFCFCollection::_Initialize(
 	//
 	int rc = NetCDFCollection::Initialize(files, tv, tv);
 	if (rc<0) return(-1);
+
 	return(0);
 }
 
@@ -115,10 +116,13 @@ int NetCDFCFCollection::Initialize(
 	// make a distinction between "coordinate variable" and 
 	// "auxiliary coordinate variable".
 	//
-	// First look for "coordinate variables", which are 1D and have
+	// First look for "coordinate variables", which are 1D in space 
+	// or 1D in time and have
 	// the same name as their one dimension
 	//
-	vector <string> vars = NetCDFCollection::GetVariableNames(1, false);
+	vector <string> vars = NetCDFCollection::GetVariableNames(1, true);
+	vector <string> tcvars = NetCDFCollection::GetVariableNames(1, false);
+	vars.insert(vars.end(), tcvars.begin(), tcvars.end());
 	for (int i=0; i<vars.size(); i++) {
 
 		NetCDFSimple::Variable varinfo;
@@ -144,10 +148,13 @@ int NetCDFCFCollection::Initialize(
 	v = NetCDFCollection::GetVariableNames(4, false);
 	vars.insert(vars.end(), v.begin(), v.end());
 
+	string timeDimName;
 	for (int i=0; i<vars.size(); i++) {
 
 		NetCDFSimple::Variable varinfo;
 		(void) NetCDFCollection::GetVariableInfo(vars[i], varinfo);
+
+		if (! GetTimeDimName(vars[i]).empty()) timeDimName = GetTimeDimName(vars[i]);
 
 		vector <string> coordattr = _GetCoordAttrs(varinfo);
 		if (! coordattr.size()) continue;
@@ -183,7 +190,6 @@ int NetCDFCFCollection::Initialize(
 			stagVar, derived_var, 2
 		);
 
-		_derivedVarsMap[stagVar] = derived_var;
 	}
 	
 
@@ -220,6 +226,22 @@ int NetCDFCFCollection::Initialize(
 		else if (_IsTimeCoordVar(varinfo)) {
 			_timeCoordVars.push_back(cvars[i]);
 		}
+	}
+
+	// 
+	// If a time dimension exists but no time coordinate variable
+	// we derive one. The is messed up. The base class, NetCDFCollection,
+	// may not contain a NetCDF time coordinate variable, but it does
+	// sythesize a list of user times
+	//
+	if (_timeCoordVars.empty() && ! timeDimName.empty()) {
+		DerivedVarTimeFromMem *derived_var = new DerivedVarTimeFromMem(
+			timeDimName, "seconds", timeDimName, GetTimes() 
+		);
+			
+		NetCDFCFCollection::InstallDerivedCoordVar(
+			timeDimName, derived_var, 3
+		);
 	}
 
 	
@@ -681,8 +703,6 @@ int NetCDFCFCollection::InstallStandardVerticalConverter(
 
 	NetCDFCFCollection::InstallDerivedCoordVar(newvar, derived_var, 2);
 
-	_derivedVarsMap[newvar] = derived_var;
-	
 
 	return(0);
 }
@@ -725,8 +745,6 @@ int NetCDFCFCollection::InstallStandardTimeConverter(
 	NetCDFCFCollection::UninstallStandardTimeConverter(newvar);
 
 	NetCDFCFCollection::InstallDerivedCoordVar(newvar, derived_var, 3);
-
-	_derivedVarsMap[newvar] = derived_var;
 
 	return(0);
 }
@@ -777,6 +795,8 @@ void NetCDFCFCollection::InstallDerivedCoordVar(
 	default:
 	break;
 	}
+
+	_derivedVarsMap[varname] = derivedVar;
 
 }
 
@@ -973,11 +993,15 @@ bool NetCDFCFCollection::_IsCoordinateVar(
 	string varname = varinfo.GetName();
 	vector <string> dimnames = varinfo.GetDimNames();
 
-	if (dimnames.size() != 1) return(false);
+	// A CF "coordinate variable" is a 1D variable whose name matches
+	// its dimension name. Here we also allow a variable with 1 spatial 
+	// dimension and 1 time dimension
+	//
+	if (dimnames.size() == 1 && varname == dimnames[0]) return (true);
 
-	if (varname.compare(dimnames[0]) != 0) return(false);
+	if (dimnames.size() == 2 && IsTimeVarying(varname) && varname == dimnames[1]) return (true);
 
-	return(true);
+	return(false);
 }
 
 vector <string> NetCDFCFCollection::_GetCoordAttrs(
@@ -2253,6 +2277,41 @@ int NetCDFCFCollection::DerivedVarTime::SeekSlice(
 	int offset, int whence, int 
 ) {
 	return(0);
+}
+
+NetCDFCFCollection::DerivedVarTimeFromMem::DerivedVarTimeFromMem(
+	string name, string units, string timeDimName,
+	const std::vector <double> times
+) : DerivedVar(NULL) {
+
+	_ts = 0;
+	
+	_name = name;
+	_units = units;
+	_timeDimName = timeDimName;
+	_times = times;
+}
+
+int NetCDFCFCollection::DerivedVarTimeFromMem::Open(size_t ts) {
+
+	if (ts >= _times.size()) ts = 0;
+	_ts = ts;
+
+	return(0);
+}
+
+int NetCDFCFCollection::DerivedVarTimeFromMem::Read(
+	float *buf, int
+) {
+	*buf = _times[_ts];
+	return(0);
+}
+
+int NetCDFCFCollection::DerivedVarTimeFromMem::ReadSlice(
+	float *slice, int 
+) {
+	*slice = _times[_ts];
+	return(1);
 }
 
 


### PR DESCRIPTION
This PR allows multiple NetCDF CF files without a time dimension to be read and interpreted as having file number represent an implicit time dimension. E.g. if 10 files are read 10 time steps are generated. 