### PR TITLE
Fixed #1957 - 2D data renderer crashes when variables are missing

### DIFF
--- a/include/vapor/DataMgr.h
+++ b/include/vapor/DataMgr.h
@@ -723,6 +723,8 @@ private:
 
  };
 
+ mutable std::map <size_t, std::vector<string> > _dataVarNamesCache;
+
  string _format;
  int _nthreads;
  size_t _mem_size;
@@ -767,7 +769,18 @@ private:
 
  std::map <string, BlkExts> _blkExtsCache;
 
- std::vector <string> _get_var_dependencies(string varname) const;
+ // Get the immediate variable dependencies of a variable
+ //
+ std::vector <string> _get_var_dependencies_1(string varname) const;
+
+ // Recursively get all of the dependencies of a list of variables. 
+ // Handles cycles in the dependency graph
+ //
+ std::vector <string> _get_var_dependencies_all(
+	std::vector <string> varnames,
+	std::vector <string> dependencies
+ ) const;
+
 
  // Return true if native data has a transformable horizontal coordinate
  //

--- a/include/vapor/DataMgr.h
+++ b/include/vapor/DataMgr.h
@@ -231,7 +231,7 @@ public:
 	timecoords = _timeCoordinates;
  };
 
- std::vector <double> GetTimeCoordinates() const {
+ const std::vector <double> &GetTimeCoordinates() const {
 	return(_timeCoordinates);
  };
 

--- a/include/vapor/DataMgrUtils.h
+++ b/include/vapor/DataMgrUtils.h
@@ -251,6 +251,45 @@ namespace DataMgrUtils {
 //! Used by the histo for calculating some meta data.
     VDF_API int GetDefaultMetaInfoStride(DataMgr *dataMgr, std::string varname, int refinementLevel);
 
+ //! Find the first variable that exists 
+ //!
+ //! This function searches a data collection looking over all 
+ //! time steps and variable names for the first 
+ //! variable it can find with a given dimension \p ndim, refinement level
+ //! \p level, and level of detail \p lod. A variable is "available" if
+ //! DataMgr::VariableExists() returns true
+ //!
+ //! \param[in] ndim Number of spatial dimensions
+ //!
+ //! \retval varname Returns the name of the first variable found, or the
+ //! empty string if none is found.
+ //!
+ //! \sa DataMgr::VariableExists()
+ //
+ string GetFirstExistingVariable(
+    DataMgr *dataMgr, int level, int lod, int ndim
+ );
+
+ //! Find the first variable that exists at a given time step
+ //!
+ //! This function searches a data collection looking 
+ //! variable names for the first 
+ //! variable it can find with a given dimension \p ndim, time step \p ts,
+ //! refinement level
+ //! \p level, and level of detail \p lod. A variable is "available" if
+ //! DataMgr::VariableExists() returns true
+ //!
+ //! \param[in] ndim Number of spatial dimensions
+ //!
+ //! \retval varname Returns the name of the first variable found, or the
+ //! empty string if none is found.
+ //!
+ //! \sa DataMgr::VariableExists()
+ //
+ string GetFirstExistingVariable(
+    DataMgr *dataMgr, size_t ts, int level, int lod, int ndim
+ );
+
 #ifdef	VAPOR3_0_0_ALPHA
 
 

--- a/include/vapor/DataMgrUtils.h
+++ b/include/vapor/DataMgrUtils.h
@@ -254,26 +254,27 @@ namespace DataMgrUtils {
  //! Find the first variable that exists 
  //!
  //! This function searches a data collection looking over all 
- //! time steps and variable names for the first 
+ //! time steps and variable names for the first available
  //! variable it can find with a given dimension \p ndim, refinement level
  //! \p level, and level of detail \p lod. A variable is "available" if
  //! DataMgr::VariableExists() returns true
  //!
  //! \param[in] ndim Number of spatial dimensions
  //!
- //! \retval varname Returns the name of the first variable found, or the
- //! empty string if none is found.
+ //! \param[out] varname Returns the name of the first variable found
+ //! \param[out] ts Returns the time step of the first variable found
+ //! \retval status Returns true if a variable is found, false otherwise
  //!
  //! \sa DataMgr::VariableExists()
  //
- string GetFirstExistingVariable(
-    DataMgr *dataMgr, int level, int lod, int ndim
+ bool GetFirstExistingVariable(
+    DataMgr *dataMgr, int level, int lod, int ndim, string &varname, size_t &ts
  );
 
  //! Find the first variable that exists at a given time step
  //!
- //! This function searches a data collection looking 
- //! variable names for the first 
+ //! This function searches a data collection looking over all
+ //! variable names for the first available
  //! variable it can find with a given dimension \p ndim, time step \p ts,
  //! refinement level
  //! \p level, and level of detail \p lod. A variable is "available" if
@@ -281,13 +282,13 @@ namespace DataMgrUtils {
  //!
  //! \param[in] ndim Number of spatial dimensions
  //!
- //! \retval varname Returns the name of the first variable found, or the
- //! empty string if none is found.
+ //! \param[out] varname Returns the name of the first variable found
+ //! \retval status Returns true if a variable is found, false otherwise
  //!
  //! \sa DataMgr::VariableExists()
  //
- string GetFirstExistingVariable(
-    DataMgr *dataMgr, size_t ts, int level, int lod, int ndim
+ bool GetFirstExistingVariable(
+    DataMgr *dataMgr, size_t ts, int level, int lod, int ndim, string &varname
  );
 
 #ifdef	VAPOR3_0_0_ALPHA

--- a/include/vapor/DataStatus.h
+++ b/include/vapor/DataStatus.h
@@ -216,8 +216,8 @@ private:
 		vector <double> &minExt, vector <double> &maxExt
 	) const;
 	
-	map <string, vector <var_info_t>> _getFirstVars(
-		string dataSetName
+	map <string, vector <var_info_t>> _getFirstVar(
+		string dataSetName, size_t &ts
 	) const;
 
 	void reset_time();

--- a/include/vapor/DerivedVar.h
+++ b/include/vapor/DerivedVar.h
@@ -439,7 +439,7 @@ public:
  virtual bool GetCoordVarInfo(DC::CoordVar &cvar) const;
 
  virtual std::vector <string> GetInputs() const {
-	return(std::vector <string> ());
+	return(std::vector <string> {_wrfTimeVar});
  }
 
  virtual int GetDimLensAtLevel(
@@ -512,7 +512,7 @@ public:
  virtual bool GetCoordVarInfo(DC::CoordVar &cvar) const;
 
  virtual std::vector <string> GetInputs() const {
-	return(std::vector <string> ());
+	return(std::vector <string> {_nativeTimeVar});
  }
 
  virtual int GetDimLensAtLevel(
@@ -574,7 +574,7 @@ public:
  virtual bool GetCoordVarInfo(DC::CoordVar &cvar) const;
 
  virtual std::vector <string> GetInputs() const {
-	return(std::vector <string> ());
+	return(std::vector <string> {_inName});
  }
 
  virtual int GetDimLensAtLevel(
@@ -635,7 +635,7 @@ public:
  virtual bool GetCoordVarInfo(DC::CoordVar &cvar) const;
 
  virtual std::vector <string> GetInputs() const {
-	return(std::vector <string> ());
+	return(std::vector <string> {_inName});
  }
 
  virtual int GetDimLensAtLevel(
@@ -698,7 +698,7 @@ public:
  virtual bool GetCoordVarInfo(DC::CoordVar &cvar) const;
 
  virtual std::vector <string> GetInputs() const {
-	return(std::vector <string> ());
+	return(std::vector <string> {"PH", "PHB"});
  }
 
  virtual int GetDimLensAtLevel(

--- a/lib/params/ContourParams.cpp
+++ b/lib/params/ContourParams.cpp
@@ -150,36 +150,9 @@ void ContourParams::MakeNewContours(string varName) {
 void ContourParams::_init() {
 	SetDiagMsg("ContourParams::_init()");
 
-	// Only 2D variables supported. Override base class
-	//
-	vector <string> varnames = _dataMgr->GetDataVarNames(2);
-	string varname;
-
-	if (! varnames.empty()) varname = varnames[0];
-	SetVariableName(varname);
-
-
-	// Initialize 2D box
-	//
-	if (varname.empty()) return;
-
-	if (! _dataMgr->VariableExists(0,varname, 0, 0)) return;
-
-    if (! _dataMgr->VariableExists(0,varname, 0, 0)) return;
-
-	vector <double> minExt, maxExt;
-	int rc = _dataMgr->GetVariableExtents(0, varname, 0, 0, minExt, maxExt);
-
 	float rgb[] = {1.,1.,1.};
 	SetConstantColor(rgb);
 
-	// Crap. No error handling from constructor. Need Initialization()
-	// method.
-	//
-	VAssert (rc >=0);
-	VAssert(minExt.size()==maxExt.size() && minExt.size()>=2);
-
-	GetBox()->SetExtents(minExt, maxExt);
 }
 
 int ContourParams::GetContourCount() {

--- a/lib/params/DataStatus.cpp
+++ b/lib/params/DataStatus.cpp
@@ -220,24 +220,26 @@ void DataStatus::_getExtents(
     return;
 }
 
-map <string, vector <DataStatus::var_info_t>> DataStatus::_getFirstVars(
-	string dataSetName
+map <string, vector <DataStatus::var_info_t>> DataStatus::_getFirstVar(
+	string dataSetName, size_t &ts
 ) const {
 	map <string, vector <var_info_t>> defaultVars;
 
-		DataMgr *dataMgr = GetDataMgr(dataSetName);
-		vector <string> varnames;
-		for (int dim=3; dim>1; dim--) {
-			varnames = dataMgr->GetDataVarNames(dim);
-			if (varnames.size()) {
-				var_info_t var;
-				var.varnames = vector <string> (1, varnames[0]);
-				var.refLevel = 0;
-				var.compLevel = 0;
-				defaultVars[dataSetName] = vector <var_info_t>(1,var);
-				break;
-			}
+	DataMgr *dataMgr = GetDataMgr(dataSetName);
+	for (int dim=3; dim>1; dim--) {
+		string varname;
+		bool ok = DataMgrUtils::GetFirstExistingVariable(
+			dataMgr, 0, 0, dim, varname, ts
+		);
+		if (ok) {
+			var_info_t var;
+			var.varnames = vector <string> (1, varname);
+			var.refLevel = 0;
+			var.compLevel = 0;
+			defaultVars[dataSetName] = vector <var_info_t>(1,var);
+			break;
 		}
+	}
 	return(defaultVars);
 }
 
@@ -287,7 +289,9 @@ void DataStatus::GetActiveExtents(
 		// If we didn't find any enabled variable use the first variables
 		// found in each data set
 		//
-		varMap = _getFirstVars(dataSetName);
+		size_t l_ts;
+		varMap = _getFirstVar(dataSetName, l_ts);
+		ts = l_ts;
 	}
 
 	_getExtents(ts, varMap, minExts, maxExts);

--- a/lib/params/TwoDDataParams.cpp
+++ b/lib/params/TwoDDataParams.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <vapor/RenderParams.h>
 #include <vapor/TwoDDataParams.h>
+#include <vapor/DataMgrUtils.h>
 
 
 using namespace Wasp;
@@ -59,34 +60,9 @@ bool TwoDDataParams::usingVariable(const std::string& varname) {
 void TwoDDataParams::_init() {
 	SetDiagMsg("TwoDDataParams::_init()");
 
-	// Only 2D variables supported. Override base class
+	// Necessary?
 	//
-    vector <string> varnames = _dataMgr->GetDataVarNames(2);
-	string varname;
-
-	if (! varnames.empty()) varname = varnames[0];
-    SetVariableName(varname);
-	SetColorMapVariableName(varname);
-
 	SetFieldVariableNames(vector <string>());
 
-	// Initialize 2D box
-	//
-	if (varname.empty()) return;
-
-    if (! _dataMgr->VariableExists(0,varname, 0, 0)) return;
-
-    vector <double> minExt, maxExt;
-    int rc = _dataMgr->GetVariableExtents(0, varname, 0, 0, minExt, maxExt);
-
-	// Crap. No error handling from constructor. Need Initialization()
-	// method.
-	//
-	VAssert (rc >=0);
-	VAssert(minExt.size()==maxExt.size() && minExt.size()==2);
-
-	GetBox()->SetExtents(minExt, maxExt);
-	GetBox()->SetPlanar(true);	
-	GetBox()->SetOrientation(Box::XY);	
 }
 

--- a/lib/render/Renderer.cpp
+++ b/lib/render/Renderer.cpp
@@ -135,7 +135,7 @@ double Renderer::_getDefaultZ(
 	bool status = DataMgrUtils::GetExtents(
 		dataMgr, ts, "", refLevel, lod, minExts, maxExts
 	);
-	VAssert(status);
+	if (! status) return(0.0);
 
 	return(minExts.size() == 3 ? minExts[2] : 0.0); 
 }

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -562,6 +562,10 @@ void _sanitizeFloats(T *buffer, size_t n) {
 template< typename T, enable_if_t<std::is_integral<T>::value, int> = 0 >
 void _sanitizeFloats(T *buffer, size_t n) {}
 
+template <typename T> bool contains(const vector <T> &v, T element) {
+	return(find(v.begin(), v.end(), element) != v.end());
+}
+
 };
 
 
@@ -792,6 +796,10 @@ vector <string> DataMgr::GetDataVarNames() const {
 vector <string> DataMgr::GetDataVarNames(int ndim) const {
 	VAssert(_dc);
 
+	if (_dataVarNamesCache[ndim].size()) {
+		return(_dataVarNamesCache[ndim]);
+	}
+
 	vector <string> vars = _dc->GetDataVarNames(ndim);
 	vector <string> derived_vars = _getDataVarNamesDerived(ndim);
 	vars.insert(vars.end(), derived_vars.begin(), derived_vars.end());
@@ -809,6 +817,8 @@ vector <string> DataMgr::GetDataVarNames(int ndim) const {
 
 		validVars.push_back(vars[i]);
 	}
+
+	_dataVarNamesCache[ndim] = validVars;
 	return(validVars);
 }
 
@@ -1738,10 +1748,15 @@ int DataMgr::GetDimLensAtLevel(
 }
 
 
-vector <string> DataMgr::_get_var_dependencies(string varname) const {
-	vector <string> varnames = {varname};
+vector <string> DataMgr::_get_var_dependencies_1(string varname) const {
+	vector <string> varnames;
 
-	// No dependencies
+	DerivedVar *derivedVar = _getDerivedVar(varname);
+	if (derivedVar) {
+		varnames = derivedVar->GetInputs();
+	}
+
+	// No more dependencies if not a data variable
 	//
 	if (! _isDataVar(varname)) return(varnames);
 
@@ -1773,12 +1788,45 @@ vector <string> DataMgr::_get_var_dependencies(string varname) const {
 		if (! edge_face_var.empty()) varnames.push_back(edge_face_var);
 	}
 
+	sort( varnames.begin(), varnames.end() );
+	varnames.erase( unique( varnames.begin(), varnames.end()), varnames.end());
 	return(varnames);
+}
+
+vector <string> DataMgr::_get_var_dependencies_all(
+	vector <string> varnames,
+	vector <string> dependencies
+) const {
+
+	// Recursively look for all of a variable's dependencies, handing any
+	// cycles in the dependency graph
+	//
+	vector <string> new_varnames;
+	for (int i=0; i<varnames.size(); i++) {
+		vector <string> new_dependencies = _get_var_dependencies_1(varnames[i]);
+
+		for (int j=0; j<new_dependencies.size(); j++) {
+
+			// Avoid cycles by not adding variable names that are already
+			// in the dependencies vector
+			//
+			if (! contains(dependencies, new_dependencies[j])) {
+				dependencies.push_back(new_dependencies[j]);
+				new_varnames.push_back(new_dependencies[j]);
+			}
+		}
+	}
+
+	if (new_varnames.size()) {
+		return(_get_var_dependencies_all(new_varnames, dependencies));
+	}
+	return(dependencies);
 }
 
 bool DataMgr::VariableExists(
     size_t ts, string varname, int level, int lod
 ) const {
+
 	if (varname.empty()) return (false);
 
     // disable error reporting
@@ -1798,65 +1846,52 @@ bool DataMgr::VariableExists(
 	EnableErrMsg(enabled);
 
 	string key = "VariableExists";
-	vector <size_t> dummy;
-	if (_varInfoCacheSize_T.Get(ts, varname, level, lod, key, dummy)) {
-		return(true);
+	vector <size_t> found;
+	if (_varInfoCacheSize_T.Get(ts, varname, level, lod, key, found)) {
+		return(found[0]);
 	}
 
-	// If a data variable need to test for existance of all coordinate
-	// variables
+	// 
+	// Recursively find all variable dependencies needed by this
+	// varible. E.g. coordinate variables, input for derived variables,
+	// auxillary variables
 	//
-	vector <string> varnames =  _get_var_dependencies(varname);
+	vector <string> varnames = _get_var_dependencies_all(
+		vector <string> ({varname}), vector <string> ()
+	);
+	varnames.insert(varnames.begin(), varname);
 
-	// Separate native and derived variables. Derived variables are 
-	// recursively tested
+
+	// Now check for the existence of the variable and all of its 
+	// dependencies, updating variable existence cache in process
 	//
-	vector <string> native_vars;
-	vector <string> derived_vars;
-	for (int i = 0; i<varnames.size(); i++) {
+	for (int i=0; i<varnames.size(); i++) {
+		if (_varInfoCacheSize_T.Get(ts, varnames[i], level, lod, key, found)) {
+			if (found[0]) continue;
+			else return(false);
+		}
+
 		if (DataMgr::IsVariableNative(varnames[i])) {
-			native_vars.push_back(varnames[i]);
+			bool exists = _dc->VariableExists(ts, varnames[i], level, lod);
+			if (! exists) {
+				_varInfoCacheSize_T.Set(ts, varnames[i], level, lod, key, vector<size_t> ({0}));
+				return(false);
+			}
 		}
 		else {
-			derived_vars.push_back(varnames[i]);
+			DerivedVar *derivedVar = _getDerivedVar(varnames[i]);
+			if(! derivedVar) {
+				_varInfoCacheSize_T.Set(ts, varnames[i], level, lod, key, vector<size_t> ({0}));
+				return (false); 
+			}
 		}
 	}
-
-
-	// Check native variables
+		
+	// Cache found results for later. 
 	//
-	vector <size_t> exists_vec;
-	for (int i=0; i<native_vars.size(); i++) {
-		if (_varInfoCacheSize_T.Get(ts, native_vars[i], level, lod, key, exists_vec)) {
-			continue;
-		}
-		bool exists = _dc->VariableExists(ts, native_vars[i], level, lod);
-		if (exists) {
-			_varInfoCacheSize_T.Set(ts, native_vars[i], level, lod, key, exists_vec);
-		}
-		else {
-			return(false);
-		}
+	for (int i=0; i<varnames.size(); i++) {
+		_varInfoCacheSize_T.Set(ts, varnames[i], level, lod, key, vector<size_t> ({1}));
 	}
-
-    // Check derived variables
-    //
-	for (int i=0; i<derived_vars.size(); i++) {
-
-		DerivedVar *derivedVar = _getDerivedVar(derived_vars[i]);
-		if(! derivedVar) return (false); 
-
-		vector  <string> ivars = derivedVar->GetInputs();
-
-		//
-		// Recursively test existence of all dependencies
-		//
-		for (int i=0; i<ivars.size(); i++) {
-			if (! VariableExists(ts, ivars[i], level, lod)) return(false);
-		}
-	}
-
-	_varInfoCacheSize_T.Set(ts, varname, level, lod, key, exists_vec);
 	return(true);
 }
 
@@ -1883,6 +1918,16 @@ int DataMgr::AddDerivedVar(DerivedDataVar *derivedVar) {
 	}
 	_dvm.AddDataVar(derivedVar);
 
+	// 
+	// Clear variable name cache
+	//
+	for (auto itr = _dataVarNamesCache.begin(); itr!=_dataVarNamesCache.end(); ++itr) {
+		vector <string> &ref = itr->second;
+		ref.clear();
+	}
+
+	_varInfoCacheSize_T.Purge(vector<string> ({varname}));
+
 	return(0);
 }
 
@@ -1893,6 +1938,16 @@ void DataMgr::RemoveDerivedVar(string varname) {
 	_dvm.RemoveVar(_dvm.GetVar(varname));
 
 	_free_var(varname);
+
+	// 
+	// Clear variable name cache
+	//
+	for (auto itr = _dataVarNamesCache.begin(); itr!=_dataVarNamesCache.end(); ++itr) {
+		vector <string> &ref = itr->second;
+		ref.clear();
+	}
+
+	_varInfoCacheSize_T.Purge(vector<string> ({varname}));
 }
 
 void	DataMgr::Clear() {

--- a/lib/vdc/DataMgrUtils.cpp
+++ b/lib/vdc/DataMgrUtils.cpp
@@ -333,10 +333,18 @@ bool DataMgrUtils::GetExtents(
 	if (varname.empty()) {
 		vector <string> varnames;
 		for (int ndim = 3; ndim > 0; ndim--) {
-			varnames = dataMgr->GetDataVarNames(ndim);
-			if (! varnames.empty()) break;
+			vector <string> v = dataMgr->GetDataVarNames(ndim);
+			varnames.insert(varnames.end(), v.begin(), v.end());
 		}
-		varname = varnames.size() ? varnames[0] : "";
+
+		// Find a variable that is present at requested time step.
+		//
+		for (int i=0; i<varnames.size(); i++) {
+			if (dataMgr->VariableExists(timestep,varnames[i], refLevel, lod)){
+				varname = varnames[i];
+				break;
+			}
+		}
 	}
 	if (varname.empty()) return (false);
 

--- a/lib/vdc/DataMgrUtils.cpp
+++ b/lib/vdc/DataMgrUtils.cpp
@@ -462,6 +462,30 @@ int DataMgrUtils::GetDefaultMetaInfoStride(DataMgr *dataMgr, std::string varname
             return stride;
 }
 
+string DataMgrUtils::GetFirstExistingVariable(
+	DataMgr *dataMgr, int level, int lod, int ndim
+) {
+	size_t numTS = dataMgr->GetTimeCoordinates().size();
+	for (size_t ts = 0; ts<numTS; ts++) {
+		string varname = GetFirstExistingVariable(dataMgr, ts, level, lod,ndim);
+		if (! varname.empty()) return(varname);
+	}
+	return("");
+		
+}
+
+string DataMgrUtils::GetFirstExistingVariable(
+	DataMgr *dataMgr, size_t ts, int level, int lod, int ndim
+) {
+	vector <string> varnames = dataMgr->GetDataVarNames(ndim);
+	for (int i=0; i<varnames.size(); i++) {
+		if (dataMgr->VariableExists(ts, varnames[i], level, lod)) {
+			return(varnames[i]);
+		}
+	}
+	return("");
+}
+
 #ifdef	VAPOR3_0_0_ALPHA
 //Map corners of box to voxels.  
 void DataMgrUtils::mapBoxToVox(


### PR DESCRIPTION
This PR prevents a crash with this data set. However, an error message is still generated because the data set does not contain sufficient coordinate information. 