### PR TITLE
Issue2026 jsmall buggy dataset bounds

### DIFF
--- a/include/vapor/DataMgrUtils.h
+++ b/include/vapor/DataMgrUtils.h
@@ -251,6 +251,12 @@ namespace DataMgrUtils {
 //! Used by the histo for calculating some meta data.
     VDF_API int GetDefaultMetaInfoStride(DataMgr *dataMgr, std::string varname, int refinementLevel);
 
+    //! Get default z value at the base of the domain.  Useful
+    //! for applying a height value to 2D renderers.
+    //! \param[in] dataMgr Current (valid) dataMgr
+    //! \retval default height value for current dataset
+    VDF_API double Get2DRendererDefaultZ(DataMgr *dataMgr, size_t ts, int refLevel, int lod);
+
  //! Find the first variable that exists 
  //!
  //! This function searches a data collection looking over all 

--- a/lib/params/DataStatus.cpp
+++ b/lib/params/DataStatus.cpp
@@ -192,10 +192,14 @@ void DataStatus::_getExtents(
 			if (! status) continue;
             
             if (minVExts.size() == 2) {
-                double z = DataMgrUtils::Get2DRendererDefaultZ(dataMgr, ts, var.refLevel, var.compLevel);
-                minVExts.push_back(z);
-                maxVExts.push_back(z);
-                axes.push_back(2);
+                bool has3D = !dataMgr->GetDataVarNames(3).empty();
+                
+                if (has3D) {
+                    double z = DataMgrUtils::Get2DRendererDefaultZ(dataMgr, ts, var.refLevel, var.compLevel);
+                    minVExts.push_back(z);
+                    maxVExts.push_back(z);
+                    axes.push_back(2);
+                }
             }
 
 			print_extents(dataSetName, minVExts, maxVExts);

--- a/lib/params/DataStatus.cpp
+++ b/lib/params/DataStatus.cpp
@@ -190,6 +190,13 @@ void DataStatus::_getExtents(
 				minVExts, maxVExts, axes
 			);
 			if (! status) continue;
+            
+            if (minVExts.size() == 2) {
+                double z = DataMgrUtils::Get2DRendererDefaultZ(dataMgr, ts, var.refLevel, var.compLevel);
+                minVExts.push_back(z);
+                maxVExts.push_back(z);
+                axes.push_back(2);
+            }
 
 			print_extents(dataSetName, minVExts, maxVExts);
 

--- a/lib/render/Renderer.cpp
+++ b/lib/render/Renderer.cpp
@@ -129,15 +129,7 @@ double Renderer::GetDefaultZ(
 	int refLevel = rParams->GetRefinementLevel();
 	int lod = rParams->GetCompressionLevel();
 
-	vector <double> minExts;
-	vector <double> maxExts;
-
-	bool status = DataMgrUtils::GetExtents(
-		dataMgr, ts, "", refLevel, lod, minExts, maxExts
-	);
-	if (! status) return(0.0);
-
-	return(minExts.size() == 3 ? minExts[2] : 0.0); 
+    return DataMgrUtils::Get2DRendererDefaultZ(dataMgr, ts, refLevel, lod);
 }
 
 int Renderer::paintGL(bool fast) {

--- a/lib/vdc/DataMgrUtils.cpp
+++ b/lib/vdc/DataMgrUtils.cpp
@@ -457,6 +457,19 @@ int DataMgrUtils::GetDefaultMetaInfoStride(DataMgr *dataMgr, std::string varname
             return stride;
 }
 
+double DataMgrUtils::Get2DRendererDefaultZ(DataMgr *dataMgr, size_t ts, int refLevel, int lod)
+{
+    vector <double> minExts;
+    vector <double> maxExts;
+
+    bool status = DataMgrUtils::GetExtents(
+        dataMgr, ts, "", refLevel, lod, minExts, maxExts
+    );
+    if (! status) return(0.0);
+
+    return(minExts.size() == 3 ? minExts[2] : 0.0);
+}
+
 bool DataMgrUtils::GetFirstExistingVariable(
 	DataMgr *dataMgr, int level, int lod, int ndim, string &varname, size_t &ts
 ) {


### PR DESCRIPTION
Fix #2026 

So this is not a bug specific to jsmall but it is only very noticeable because of its short Z axis. The default location to place a 2D renderer, “Default Z”, is at the bottom of the bounding box of the first 3D variable. When you query DataStatus::GetActiveExtents (assuming 1 dataset for simplicity) it returns the bounds of the union of the active variables, or the bounds of the first 3D variable if there are none. In this case, when you have no renderers enabled, it shows the correct bounds since it takes the bounds of the first 3D variable. Once you enable the 2D renderer, however, it computes the bounds based on the 2D variable’s 2D bounds and then sets the Z bounds to a default 0 to 1, which is just above the dataset’s -1 to 0 bounds. One solution is instead of setting the default Z from 0 to 1, set it to the 2D renderer “Default Z”. Another solution is to always compute the bounds using 3D variables, unless there are none available.

I chose to go with option 1 because that is closest to our current behavior so it is more of a “bug fix” than a functionality change however I think that option 2 is better. DataStatus::_getExtents always returns a 3D vector so I implemented it here.