### PR TITLE
Updates to rake initialization sequence to fix #2058

### DIFF
--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -72,8 +72,6 @@ FlowVariablesSubtab::Update( VAPoR::DataMgr      *dataMgr,
     assert(_params);
     
     _paramsMgr = paramsMgr;
-    
-    _variablesWidget->Update(dataMgr, paramsMgr, rParams);
 
     GUIStateParams *gp = dynamic_cast<GUIStateParams*>(_paramsMgr->GetParams(GUIStateParams::GetClassType()));
     int nDims = gp->GetFlowDimensionality();
@@ -91,8 +89,8 @@ FlowVariablesSubtab::Update( VAPoR::DataMgr      *dataMgr,
     // with, we need to configure these two different cases externally, which is what's
     // being done here.
     if ( no3DVars ) {
-        _variablesWidget->Configure2DFieldVars();
-        gp->SetFlowDimensionality( _variablesWidget->GetActiveDimension() );
+            _variablesWidget->Configure2DFieldVars();
+            gp->SetFlowDimensionality( _variablesWidget->GetActiveDimension() );
     }
     else if (nDims != _variablesWidget->GetActiveDimension() ) {
         if (nDims == 2 )
@@ -101,12 +99,14 @@ FlowVariablesSubtab::Update( VAPoR::DataMgr      *dataMgr,
             _variablesWidget->Configure3DFieldVars();
         gp->SetFlowDimensionality( _variablesWidget->GetActiveDimension() );
     }
+    
+    _variablesWidget->Update(dataMgr, paramsMgr, rParams);
 }
     
 void FlowVariablesSubtab::_dimensionalityChanged( int nDims ) const {
     GUIStateParams *gp = dynamic_cast<GUIStateParams*>(_paramsMgr->GetParams(GUIStateParams::GetClassType()));
     gp->SetFlowDimensionality( nDims );
-    if (nDims == 2 ) 
+    if (nDims == 2 )
         _variablesWidget->Configure2DFieldVars();
     else
         _variablesWidget->Configure3DFieldVars();

--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -72,6 +72,8 @@ FlowVariablesSubtab::Update( VAPoR::DataMgr      *dataMgr,
     assert(_params);
     
     _paramsMgr = paramsMgr;
+    
+    _variablesWidget->Update(dataMgr, paramsMgr, rParams);
 
     GUIStateParams *gp = dynamic_cast<GUIStateParams*>(_paramsMgr->GetParams(GUIStateParams::GetClassType()));
     int nDims = gp->GetFlowDimensionality();
@@ -89,8 +91,8 @@ FlowVariablesSubtab::Update( VAPoR::DataMgr      *dataMgr,
     // with, we need to configure these two different cases externally, which is what's
     // being done here.
     if ( no3DVars ) {
-            _variablesWidget->Configure2DFieldVars();
-            gp->SetFlowDimensionality( _variablesWidget->GetActiveDimension() );
+        _variablesWidget->Configure2DFieldVars();
+        gp->SetFlowDimensionality( _variablesWidget->GetActiveDimension() );
     }
     else if (nDims != _variablesWidget->GetActiveDimension() ) {
         if (nDims == 2 )
@@ -99,14 +101,12 @@ FlowVariablesSubtab::Update( VAPoR::DataMgr      *dataMgr,
             _variablesWidget->Configure3DFieldVars();
         gp->SetFlowDimensionality( _variablesWidget->GetActiveDimension() );
     }
-    
-    _variablesWidget->Update(dataMgr, paramsMgr, rParams);
 }
     
 void FlowVariablesSubtab::_dimensionalityChanged( int nDims ) const {
     GUIStateParams *gp = dynamic_cast<GUIStateParams*>(_paramsMgr->GetParams(GUIStateParams::GetClassType()));
     gp->SetFlowDimensionality( nDims );
-    if (nDims == 2 )
+    if (nDims == 2 ) 
         _variablesWidget->Configure2DFieldVars();
     else
         _variablesWidget->Configure3DFieldVars();

--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -443,7 +443,7 @@ void FlowSeedingSubtab::_updateRake( VAPoR::DataMgr* dataMgr ) {
                                      maxExt, 
                                      axes  );
     
-    // If there are no valid extents to set the rake with, set them to 0
+    // If there are no valid extents to set the rake with, set them to 0 and 1,
     // and set _noValidVars to true.  This function will continue to try
     // initializing our rake until we have valid variables.
     //

--- a/apps/vaporgui/FlowSubtabs.h
+++ b/apps/vaporgui/FlowSubtabs.h
@@ -147,6 +147,7 @@ private:
     float _oldZRakeMin;
     float _oldZRakeMax;
     bool _oldZPeriodicity;
+    bool _noValidVars;
 
     void _blockUnblockSignals( bool block );
     void _resizeFlowParamsVectors();

--- a/apps/vaporgui/VariablesWidget.cpp
+++ b/apps/vaporgui/VariablesWidget.cpp
@@ -149,6 +149,11 @@ void VariablesWidget::Configure3DFieldVars() {
     setVariableDims(1);
     blockSignals( false );
     _zFieldVarFrame->show();
+
+    if (_rParams != nullptr &&
+        _dataMgr != nullptr &&
+        _paramsMgr != nullptr )
+        Update( _dataMgr, _paramsMgr, _rParams );
 }
 
 void VariablesWidget::Configure2DFieldVars() {
@@ -156,6 +161,11 @@ void VariablesWidget::Configure2DFieldVars() {
     setVariableDims(0);
     blockSignals( false );
     _zFieldVarFrame->hide();
+
+    if (_rParams != nullptr &&
+        _dataMgr != nullptr &&
+        _paramsMgr != nullptr )
+        Update( _dataMgr, _paramsMgr, _rParams );
 }
 
 int VariablesWidget::GetActiveDimension() const {

--- a/apps/vaporgui/VariablesWidget.cpp
+++ b/apps/vaporgui/VariablesWidget.cpp
@@ -149,11 +149,6 @@ void VariablesWidget::Configure3DFieldVars() {
     setVariableDims(1);
     blockSignals( false );
     _zFieldVarFrame->show();
-
-    if (_rParams != nullptr &&
-        _dataMgr != nullptr &&
-        _paramsMgr != nullptr )
-        Update( _dataMgr, _paramsMgr, _rParams );
 }
 
 void VariablesWidget::Configure2DFieldVars() {
@@ -161,11 +156,6 @@ void VariablesWidget::Configure2DFieldVars() {
     setVariableDims(0);
     blockSignals( false );
     _zFieldVarFrame->hide();
-
-    if (_rParams != nullptr &&
-        _dataMgr != nullptr &&
-        _paramsMgr != nullptr )
-        Update( _dataMgr, _paramsMgr, _rParams );
 }
 
 int VariablesWidget::GetActiveDimension() const {


### PR DESCRIPTION
#2058 was the result of our rake being set with NaN values, when there are no valid field variables in the FlowRenderer.

For reasons I do not yet understand, the call to ParamsMgr::EndSaveStateGroup() (linked below) set Vapor into an infinite loop after issuing the call to ParamsBase::SetValueDoubleVec() with NaN.

https://github.com/NCAR/VAPOR/blob/310188472cc7fd6010cc12ad4701933b86724132/apps/vaporgui/FlowSubtabs.cpp#L532

The current fix is to test wheter we have valid variables.  We currently use dummy values of 0 and 1 for the rake extents until valid variables are assigned, and FlowSeedingSubtab::Update() is called.

Questions to consider:
1) Should SetValueDoubleVec() filter NaN values?
2) Should we be initializing parameters with NaN values?
3) Should the GUI be performing parameter initialization?