### PR TITLE
compiler warnings

### DIFF
--- a/include/vapor/DC.h
+++ b/include/vapor/DC.h
@@ -664,10 +664,6 @@ public:
 	std::ostream &o, const Mesh &mesh
   );
 
-  friend std::ostream &operator<<(
-	std::ostream &o, const Mesh &mesh
-  );
-
  private:
   string _name;
   std::vector <string> _dim_names;


### PR DESCRIPTION
DC.h:669:3: warning: ‘std::ostream& VAPoR::operator<<(std::ostream&, const VAPoR::DC::Mesh&)’ is already a friend of class ‘VAPoR::DC::Mesh’ [enabled by default]