### PR TITLE
Partial fix for issue #2138

### DIFF
--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -155,7 +155,8 @@ FlowSeedingSubtab::FlowSeedingSubtab(QWidget* parent) :
     //
     _geometryWriterSection= new VSection("Write Flowlines to File");
     layout()->addWidget( _geometryWriterSection );
-    _geometryWriterSelector = new VFileWriter();
+    string defaultPath = QDir::homePath().toStdString() + "/vaporFlow.txt";
+    _geometryWriterSelector = new VFileWriter("Select", defaultPath);
     _geometryWriterSection->layout()->addWidget( new VLineItem("Target file", _geometryWriterSelector) );
     _geometryWriterExecutor = new VPushButton("Write to file");
     _geometryWriterSection->layout()->addWidget( new VLineItem("", _geometryWriterExecutor) );
@@ -774,6 +775,14 @@ FlowSeedingSubtab::_streamlineDirectionChanged( int index )
 }
 
 void FlowSeedingSubtab::_geometryWriterClicked() {
+    bool enabled = _params->IsEnabled();
+    if ( !enabled ) {
+        MSG_ERR( "The Flow renderer must be enabled to compute trajectories " \
+            "before writing the anything to a file." 
+        );
+        return;
+    }
+
     std::string file = _geometryWriterSelector->GetValue();
 
     _paramsMgr->BeginSaveStateGroup("Write flowline geometry file");


### PR DESCRIPTION
This is a partial fix for #2138.  It selects a better default file for the flow geometry export.  This fix also warns the user that we cannot write our file when the renderer is disabled (when no advection has been calculated yet).

The true fix is to write the flow geometry file every time the "Write to file" button is pressed.  We are only writing the file under unclear conditions, described in the bug report (#2138).