### PR TITLE
Fix for #2157

### DIFF
--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -231,11 +231,15 @@ int SliceRenderer::_resetBoxCache() {
         return rc;
     }
     
-    // Moving domain allows area outside of data to be selected
+    // Moving domains do not update Box classes as they change their extents,
+    // so our Box becomes invalid.  We need to store valid extents for efficient
+    // sampling - IE we don't want to sample outside of the domain.
     for (int i = 0; i < _cacheParams.boxMax.size(); i++) {
         _cacheParams.boxMin[i] = max(_cacheParams.boxMin[i], _cacheParams.domainMin[i]);
         _cacheParams.boxMax[i] = min(_cacheParams.boxMax[i], _cacheParams.domainMax[i]);
     }
+    // Now set our box to have valid extents, within the data domain
+    p->GetBox()->SetExtents(_cacheParams.boxMin, _cacheParams.boxMax);
     
     _setVertexPositions();
     _resetTextureCoordinates();

--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -231,12 +231,6 @@ int SliceRenderer::_resetBoxCache() {
         return rc;
     }
     
-    // Moving domain allows area outside of data to be selected
-    /*for (int i = 0; i < _cacheParams.boxMax.size(); i++) {
-        _cacheParams.boxMin[i] = max(_cacheParams.boxMin[i], _cacheParams.domainMin[i]);
-        _cacheParams.boxMax[i] = min(_cacheParams.boxMax[i], _cacheParams.domainMax[i]);
-    }*/
-    
     _setVertexPositions();
     _resetTextureCoordinates();
     return rc;

--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -231,15 +231,11 @@ int SliceRenderer::_resetBoxCache() {
         return rc;
     }
     
-    // Moving domains do not update Box classes as they change their extents,
-    // so our Box becomes invalid.  We need to store valid extents for efficient
-    // sampling - IE we don't want to sample outside of the domain.
-    for (int i = 0; i < _cacheParams.boxMax.size(); i++) {
+    // Moving domain allows area outside of data to be selected
+    /*for (int i = 0; i < _cacheParams.boxMax.size(); i++) {
         _cacheParams.boxMin[i] = max(_cacheParams.boxMin[i], _cacheParams.domainMin[i]);
         _cacheParams.boxMax[i] = min(_cacheParams.boxMax[i], _cacheParams.domainMax[i]);
-    }
-    // Now set our box to have valid extents, within the data domain
-    p->GetBox()->SetExtents(_cacheParams.boxMin, _cacheParams.boxMax);
+    }*/
     
     _setVertexPositions();
     _resetTextureCoordinates();
@@ -277,6 +273,15 @@ void SliceRenderer::_resetTextureCoordinates() {
               ( domainMax[yAxis] - domainMin[yAxis] );
     texMaxY = ( boxMax[yAxis] - domainMin[yAxis] ) / 
               ( domainMax[yAxis] - domainMin[yAxis] );
+
+    cout << texMinX << " " << texMinY << endl;
+    cout << texMaxX << " " << texMaxY << endl;
+    if ( texMinX < 0 ) texMinX = 0;
+    if ( texMinY < 0 ) texMinY = 0;
+    if ( texMaxX > 1 ) texMaxX = 1;
+    if ( texMaxY > 1 ) texMaxY = 1;
+    cout << "   " << texMinX << " " << texMinY << endl;
+    cout << "   " << texMaxX << " " << texMaxY << endl;
 
     _texCoords.clear();
     _texCoords = {

--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -274,15 +274,6 @@ void SliceRenderer::_resetTextureCoordinates() {
     texMaxY = ( boxMax[yAxis] - domainMin[yAxis] ) / 
               ( domainMax[yAxis] - domainMin[yAxis] );
 
-    cout << texMinX << " " << texMinY << endl;
-    cout << texMaxX << " " << texMaxY << endl;
-    if ( texMinX < 0 ) texMinX = 0;
-    if ( texMinY < 0 ) texMinY = 0;
-    if ( texMaxX > 1 ) texMaxX = 1;
-    if ( texMaxY > 1 ) texMaxY = 1;
-    cout << "   " << texMinX << " " << texMinY << endl;
-    cout << "   " << texMaxX << " " << texMaxY << endl;
-
     _texCoords.clear();
     _texCoords = {
         texMinX, texMinY,
@@ -631,15 +622,23 @@ void SliceRenderer::_resetState() {
 }
 
 void SliceRenderer::_setVertexPositions() {
-    std::vector<double> min = _cacheParams.boxMin;
-    std::vector<double> max = _cacheParams.boxMax;
+    std::vector<double> trimmedMin(3, 0.f);
+    std::vector<double> trimmedMax(3, 1.f);
+
+    // If the box is outside of our domain, trim the vertex coordinates to be within
+    // the domain.
+    for (int i = 0; i < _cacheParams.boxMax.size(); i++) {
+        trimmedMin[i] = max(_cacheParams.boxMin[i], _cacheParams.domainMin[i]);
+        trimmedMax[i] = min(_cacheParams.boxMax[i], _cacheParams.domainMax[i]);
+    }
+
     int orientation = _cacheParams.orientation;
     if (orientation == XY)
-        _setXYVertexPositions(min, max);
+        _setXYVertexPositions(trimmedMin, trimmedMax);
     else if (orientation == XZ)
-        _setXZVertexPositions(min, max);
+        _setXZVertexPositions(trimmedMin, trimmedMax);
     else if (orientation == YZ)
-        _setYZVertexPositions(min, max);
+        _setYZVertexPositions(trimmedMin, trimmedMax);
 
     glBindBuffer(GL_ARRAY_BUFFER, _vertexVBO);
     glBufferSubData(


### PR DESCRIPTION
The slow rendering in #2157 was due to the SliceRenderer::CachedBox values not matching the extents of the SliceParams::Box.

The SliceRenderer has logic to accommodate moving domains: 

If the SliceParams::Box has extents outside of the data domain, we set the SliceRenderer::CachedBox to be within the data domain.  However the SliceParams::Box would still remain outside of the domain.  When we would subsequently compare SliceParams::Box to SliceRenderer::CachedBox, we would get a mis-match and resample.

The fix is to set SliceParams::Box whenever we update SliceRenderer::CachedBox.