### PR TITLE
Fix for VSliderEdit unitialized values

### DIFF
--- a/apps/vaporgui/VSliderEdit.cpp
+++ b/apps/vaporgui/VSliderEdit.cpp
@@ -8,6 +8,9 @@
 
 VSliderEdit::VSliderEdit( double min, double max, double value )
 : VContainer(),
+  _minValid( min ),
+  _maxValid( max ),
+  _value( value ),
   _isIntType( false )
 {
     _lineEdit = new VLineEdit();


### PR DESCRIPTION
Fix for uninitialized parameters in VSliderEdit, reported by Valgrind.