### PR TITLE
Fixed broken windows build

### DIFF
--- a/apps/vaporgui/hide_std_error_util.cpp
+++ b/apps/vaporgui/hide_std_error_util.cpp
@@ -6,7 +6,7 @@
 #endif
 
 static int _savedSTDERR;
-static fpos_t pos;
+static int pos;
 
 void HideSTDERR()
 {

--- a/apps/vaporgui/hide_std_error_util.cpp
+++ b/apps/vaporgui/hide_std_error_util.cpp
@@ -6,7 +6,6 @@
 #endif
 
 static int _savedSTDERR;
-static int pos;
 
 void HideSTDERR()
 {


### PR DESCRIPTION
We have an unused variable of type fpos_t, which is not recognized by Windows.

This PR just removes that variable