### PR TITLE
Fix #2153 - Added size check before resizing Flow's vectors

### DIFF
--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -496,19 +496,27 @@ void FlowSeedingSubtab::_resizeFlowParamsVectors() {
 
     // Going from 3d vectors to 2d vectors.
     // Save the values we remove for restoration later on.
+    int seedSize = rakeSeeds.size();
+    int periodicitySize = periodicity.size();
+    int regionSize = rakeRegion.size();
+    VAssert( seedSize == 3 || seedSize == 2 );
+    VAssert( periodicitySize == 3 || periodicitySize == 2 );
+    VAssert( regionSize == 6 || regionSize == 4 );
+
     if ( _numDims == 2 ) {  
-        if ( rakeSeeds.size() != 2 ) {
+
+        if ( seedSize == 3 ) {
             _oldZRakeNumSeeds = rakeSeeds[Z];
             rakeSeeds.resize(2);
         }
 
-        if ( rakeRegion.size() != 2 ) {
+        if ( regionSize == 6 ) {
             _oldZRakeMin = rakeRegion[Z_RAKE_MIN];
             _oldZRakeMax = rakeRegion[Z_RAKE_MAX];
             rakeRegion.resize(4);
         }
 
-        if ( periodicity.size() != 2 ) {
+        if ( periodicitySize == 3 ) {
             _oldZPeriodicity = periodicity[Z];
             periodicity.resize(2);
         }
@@ -516,18 +524,18 @@ void FlowSeedingSubtab::_resizeFlowParamsVectors() {
     // Going from 2D vectors to 3D vectors.
     // Restore previously saved values.
     else {
-        if ( periodicity.size() !=3 ) {
+        if ( periodicitySize == 2 ) {
             periodicity.resize(3);
             periodicity[Z] = _oldZPeriodicity;
         }
 
-        if ( rakeRegion.size() != 6 ) {
+        if ( regionSize == 4 ) {
             rakeRegion.resize(6);
             rakeRegion[Z_RAKE_MIN] = _oldZRakeMin;
             rakeRegion[Z_RAKE_MAX] = _oldZRakeMax;
         }
 
-        if ( rakeSeeds.size() != 3 ) {
+        if ( seedSize == 2 ) {
             rakeSeeds.resize(3);
             rakeSeeds[Z] = _oldZRakeNumSeeds;
         }

--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -497,29 +497,40 @@ void FlowSeedingSubtab::_resizeFlowParamsVectors() {
     // Going from 3d vectors to 2d vectors.
     // Save the values we remove for restoration later on.
     if ( _numDims == 2 ) {  
-        _oldZRakeNumSeeds = rakeSeeds[Z];
-        rakeSeeds.resize(2);
+        if ( rakeSeeds.size() != 2 ) {
+            _oldZRakeNumSeeds = rakeSeeds[Z];
+            rakeSeeds.resize(2);
+        }
 
-        _oldZRakeMin = rakeRegion[Z_RAKE_MIN];
-        _oldZRakeMax = rakeRegion[Z_RAKE_MAX];
-        rakeRegion.resize(4);
+        if ( rakeRegion.size() != 2 ) {
+            _oldZRakeMin = rakeRegion[Z_RAKE_MIN];
+            _oldZRakeMax = rakeRegion[Z_RAKE_MAX];
+            rakeRegion.resize(4);
+        }
 
-        _oldZPeriodicity = periodicity[Z];
-        periodicity.resize(2);
+        if ( periodicity.size() != 2 ) {
+            _oldZPeriodicity = periodicity[Z];
+            periodicity.resize(2);
+        }
     }
     // Going from 2D vectors to 3D vectors.
     // Restore previously saved values.
-    else {  
-        periodicity.resize(3);
-        periodicity[Z] = _oldZPeriodicity;
+    else {
+        if ( periodicity.size() !=3 ) {
+            periodicity.resize(3);
+            periodicity[Z] = _oldZPeriodicity;
+        }
 
-        for (int i=0; i<6; i++)
-        rakeRegion.resize(6);
-        rakeRegion[Z_RAKE_MIN] = _oldZRakeMin;
-        rakeRegion[Z_RAKE_MAX] = _oldZRakeMax;
+        if ( rakeRegion.size() != 6 ) {
+            rakeRegion.resize(6);
+            rakeRegion[Z_RAKE_MIN] = _oldZRakeMin;
+            rakeRegion[Z_RAKE_MAX] = _oldZRakeMax;
+        }
 
-        rakeSeeds.resize(3);
-        rakeSeeds[Z] = _oldZRakeNumSeeds;
+        if ( rakeSeeds.size() != 3 ) {
+            rakeSeeds.resize(3);
+            rakeSeeds[Z] = _oldZRakeNumSeeds;
+        }
     }
 
     _paramsMgr->BeginSaveStateGroup("Resizing flow params vectors");


### PR DESCRIPTION
Fixes #2153.

The FlowSubtabs have a private variable called _numDims, which keeps track of what dimensionality is currently being used.  The default uninitialized value is -1.

When we opened a session, GUIStateParams would inform a dimensionality of 3.  This mismatch between _numDims and GUIStateParams triggers the Subtabs to resize the vectors used in FlowParams (seeds, periodicity, and rake).

This fix guards against the case where our vectors are already of correct size, and the GUI is uninitialized - in this case we want to set _numDims to whatever is in GUIStateParams, and not  resize anything.