### PR TITLE
Issue 2180

### DIFF
--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -379,8 +379,6 @@ void FlowSeedingSubtab::Update( VAPoR::DataMgr      *dataMgr,
     // Velocity multiplier
     double mltp = _params->GetVelocityMultiplier();
     _velocityMultiplierLineEdit->SetValue( mltp );
-    cout << "multiplier updating to " << mltp << endl;
-    //_velocityMultiplierLineEdit->SetValue( std::to_string( mltp ) );
 
     // Update seeding tab
     //
@@ -595,22 +593,22 @@ FlowSeedingSubtab::_velocityMultiplierChanged( const std::string& value )
 {
     double oldval = _params->GetVelocityMultiplier();
     double newval;
+    
     try
     {
+        // stod trips up on the character \n, so remove it if needed
+        //
         if (value.back() == '\n') {
             std::string tmp = value;
             tmp.pop_back();
             newval = std::stod( tmp );
-            std::cout << "pop endline" << std::endl;
         }
         else 
             newval = std::stod( value );
-        std::cout << "value/newval " << value << " / " << newval << std::endl;
     }
     catch ( const std::invalid_argument& e )
     {
-        MSG_ERR( "Bad input: " + value );
-        //_velocityMultiplierLineEdit->SetValue( std::to_string( oldval ) );
+        MSG_ERR( "Bad input to Velocity Multiplier: " + value );
         _velocityMultiplierLineEdit->SetValue( oldval );
         return;
     }
@@ -619,19 +617,13 @@ FlowSeedingSubtab::_velocityMultiplierChanged( const std::string& value )
     {
         // std::stod() would convert "3.83aaa" without throwing an exception.
         // We set the correct text based on the number identified.
-        //_velocityMultiplierLineEdit->SetValue( std::to_string(newval) ); 
         _velocityMultiplierLineEdit->SetValue( newval );
         // Only write back to _params if newval is different from oldval 
-        if( newval != oldval ) {
-            std::cout << "setting params to new " << newval << endl;
+        if( newval != oldval )
             _params->SetVelocityMultiplier( newval );
-        }
     }
-    else {
-        std::cout << "setting params to old " << oldval << endl;
+    else
         _velocityMultiplierLineEdit->SetValue( oldval );
-    }
-        //_velocityMultiplierLineEdit->SetValue( std::to_string( oldval ) );
 }
 
 

--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -377,8 +377,10 @@ void FlowSeedingSubtab::Update( VAPoR::DataMgr      *dataMgr,
     }
 
     // Velocity multiplier
-    auto mltp = _params->GetVelocityMultiplier();
-    _velocityMultiplierLineEdit->SetValue( std::to_string( mltp ) );
+    double mltp = _params->GetVelocityMultiplier();
+    _velocityMultiplierLineEdit->SetValue( mltp );
+    cout << "multiplier updating to " << mltp << endl;
+    //_velocityMultiplierLineEdit->SetValue( std::to_string( mltp ) );
 
     // Update seeding tab
     //
@@ -595,12 +597,21 @@ FlowSeedingSubtab::_velocityMultiplierChanged( const std::string& value )
     double newval;
     try
     {
-        newval = std::stod( value );
+        if (value.back() == '\n') {
+            std::string tmp = value;
+            tmp.pop_back();
+            newval = std::stod( tmp );
+            std::cout << "pop endline" << std::endl;
+        }
+        else 
+            newval = std::stod( value );
+        std::cout << "value/newval " << value << " / " << newval << std::endl;
     }
     catch ( const std::invalid_argument& e )
     {
         MSG_ERR( "Bad input: " + value );
-        _velocityMultiplierLineEdit->SetValue( std::to_string( oldval ) );
+        //_velocityMultiplierLineEdit->SetValue( std::to_string( oldval ) );
+        _velocityMultiplierLineEdit->SetValue( oldval );
         return;
     }
 
@@ -608,13 +619,19 @@ FlowSeedingSubtab::_velocityMultiplierChanged( const std::string& value )
     {
         // std::stod() would convert "3.83aaa" without throwing an exception.
         // We set the correct text based on the number identified.
-        _velocityMultiplierLineEdit->SetValue( std::to_string(newval) ); 
+        //_velocityMultiplierLineEdit->SetValue( std::to_string(newval) ); 
+        _velocityMultiplierLineEdit->SetValue( newval );
         // Only write back to _params if newval is different from oldval 
-        if( newval != oldval )
+        if( newval != oldval ) {
+            std::cout << "setting params to new " << newval << endl;
             _params->SetVelocityMultiplier( newval );
+        }
     }
-    else
-        _velocityMultiplierLineEdit->SetValue( std::to_string( oldval ) );
+    else {
+        std::cout << "setting params to old " << oldval << endl;
+        _velocityMultiplierLineEdit->SetValue( oldval );
+    }
+        //_velocityMultiplierLineEdit->SetValue( std::to_string( oldval ) );
 }
 
 

--- a/apps/vaporgui/VLineEdit.cpp
+++ b/apps/vaporgui/VLineEdit.cpp
@@ -32,9 +32,26 @@ void VLineEdit::UseDoubleMenu() {
         this, &VLineEdit::ShowContextMenu );
 }
 
+void VLineEdit::SetValue( double value ) {
+    VAssert( _isDouble );
+    
+    std::stringstream stream;
+    if (_menuEnabled) {
+        stream << std::fixed << std::setprecision( _decDigits );
+        if (_scientific)
+            stream << std::scientific;
+    }
+    stream << value << std::endl;
+    _value = stream.str();
+    
+    _lineEdit->blockSignals(true);
+    _lineEdit->setText( QString::fromStdString(_value) );
+    _lineEdit->blockSignals(false);
+}
+
 void VLineEdit::SetValue( const std::string& value ) {
     // see if value is a valid double
-    if (_isDouble) {
+    /*if (_isDouble) {
         double dValue;
         try {
             dValue = std::stod( value );
@@ -42,7 +59,6 @@ void VLineEdit::SetValue( const std::string& value ) {
         catch (...) {
             MSG_ERR("VLineEDit::SetValue failed to set value of " + value );
         }
-
         std::stringstream stream;
         if (_menuEnabled) {
             stream << std::fixed << std::setprecision( _decDigits );
@@ -52,7 +68,7 @@ void VLineEdit::SetValue( const std::string& value ) {
         stream << dValue << std::endl;
         _value = stream.str();
     }
-    else
+    else*/
         _value = value;
 
     _lineEdit->blockSignals(true);

--- a/apps/vaporgui/VLineEdit.cpp
+++ b/apps/vaporgui/VLineEdit.cpp
@@ -50,26 +50,7 @@ void VLineEdit::SetValue( double value ) {
 }
 
 void VLineEdit::SetValue( const std::string& value ) {
-    // see if value is a valid double
-    /*if (_isDouble) {
-        double dValue;
-        try {
-            dValue = std::stod( value );
-        }
-        catch (...) {
-            MSG_ERR("VLineEDit::SetValue failed to set value of " + value );
-        }
-        std::stringstream stream;
-        if (_menuEnabled) {
-            stream << std::fixed << std::setprecision( _decDigits );
-            if (_scientific)
-                stream << std::scientific;
-        }
-        stream << dValue << std::endl;
-        _value = stream.str();
-    }
-    else*/
-        _value = value;
+    _value = value;
 
     _lineEdit->blockSignals(true);
     _lineEdit->setText( QString::fromStdString(_value) );

--- a/apps/vaporgui/VLineEdit.h
+++ b/apps/vaporgui/VLineEdit.h
@@ -23,6 +23,7 @@ class VLineEdit : public VContainer {
 public:
     VLineEdit( const std::string& value = "");
 
+    void SetValue( double value );
     void SetValue( const std::string& value );
     std::string GetValue() const;
 


### PR DESCRIPTION
This PR adds a SetValue() method for VLineEdit that accepts a double.

Previously, we were relying on caller functions (FlowSubtabs) to convert double values retrieved from Params into strings.  This was being done with the std::to_string() function, which truncates precision.

Now, VLineEdit accepts doubles, and will convert them to strings with std::stringstream, conserving the precision set in the VLineEdit.