### PR TITLE
Wireframe renderer handle GPU out of memory error

### DIFF
--- a/include/vapor/WireFrameRenderer.h
+++ b/include/vapor/WireFrameRenderer.h
@@ -67,6 +67,7 @@ private:
 	GLuint _VAO, _VBO, _EBO;
     unsigned int _nIndices;
     Texture1D _lutTexture;
+    bool _GPUOutOfMemory;
 
 	struct VertexData;
 	struct {
@@ -126,11 +127,11 @@ private:
 	};
 
 	void  _buildCacheVertices(
-		const Grid *grid, const Grid *heightGrid, vector <GLuint> &nodeMap
+		const Grid *grid, const Grid *heightGrid, vector <GLuint> &nodeMap, bool *GPUOutOfMemory
 	) const;
 
 	size_t _buildCacheConnectivity(
-		const Grid *grid, const vector <GLuint> &nodeMap
+		const Grid *grid, const vector <GLuint> &nodeMap, bool *GPUOutOfMemory
 	) const;
 
 	int  _buildCache();


### PR DESCRIPTION
The only other renderers that potentially load massive amounts of data to the GPU are the DVR and IsoSurface and I tested to make sure that those already handle this case.