### PR TITLE
Discard transparent fragments for slice renderer

### DIFF
--- a/share/shaders/Slice.frag
+++ b/share/shaders/Slice.frag
@@ -24,4 +24,7 @@ void main(void)
 
     vec4  color = texture(colormap, normalized);
     fragColor = vec4(color.rgb, color.a*constantOpacity);
+    
+    if (color.a <  0.001)
+        discard;
 }


### PR DESCRIPTION
Mitigate #2175 

The current proper solution would require adding a mechanism for determining if a renderer is fully opaque in which case we could automatically sort the isosurface to the back. We could also allow the user to manually sort the isosurface renderer as this is not currently possible.