### PR TITLE
Create builtin colormap tree from palettes directory

### DIFF
--- a/apps/vaporgui/TFColorWidget.cpp
+++ b/apps/vaporgui/TFColorWidget.cpp
@@ -62,10 +62,23 @@ void TFColorMap::PopulateSettingsMenu(QMenu *menu) const
     
     QMenu *builtinColormapMenu = menu->addMenu("Load Built-In Colormap");
     string builtinPath = GetSharePath("palettes");
+    
+    populateBuiltinColormapMenu(builtinColormapMenu, builtinPath);
+}
+
+void TFColorMap::populateBuiltinColormapMenu(QMenu *menu, const std::string &builtinPath) const
+{
     auto fileNames = FileUtils::ListFiles(builtinPath);
     std::sort(fileNames.begin(), fileNames.end());
+    
     for (int i = 0; i < fileNames.size(); i++) {
+        string path = FileUtils::JoinPaths({builtinPath, fileNames[i]});
         
+        if (FileUtils::IsDirectory(path))
+            populateBuiltinColormapMenu(menu->addMenu(QString::fromStdString(fileNames[i])), path);
+    }
+    
+    for (int i = 0; i < fileNames.size(); i++) {
         string path = FileUtils::JoinPaths({builtinPath, fileNames[i]});
         
         if (FileUtils::Extension(path) != "tf3")
@@ -73,7 +86,7 @@ void TFColorMap::PopulateSettingsMenu(QMenu *menu) const
         
         QAction *item = new ColorMapMenuItem(path);
         connect(item, SIGNAL(triggered(std::string)), this, SLOT(menuLoadBuiltin(std::string)));
-        builtinColormapMenu->addAction(item);
+        menu->addAction(item);
     }
 }
 

--- a/apps/vaporgui/TFColorWidget.h
+++ b/apps/vaporgui/TFColorWidget.h
@@ -21,6 +21,9 @@ public:
     void PopulateContextMenu(QMenu *menu, const glm::vec2 &p) override;
     void PopulateSettingsMenu(QMenu *menu) const override;
     
+private:
+    void populateBuiltinColormapMenu(QMenu *menu, const std::string &builtinPath) const;
+    
 protected:
     void paramsUpdate() override;
     TFInfoWidget *createInfoWidget() override;


### PR DESCRIPTION
Palettes directory:
```
palettes
├── Cool\ Warm
│   ├── CoolWarm.tf3
│   ├── CoolWarmBent.tf3
│   └── CoolWarmSmooth.tf3
└── kindle
    ├── Kindlmann.tf3
    └── KindlmannExtended.tf3
```

Builtin menu:
![s](https://user-images.githubusercontent.com/2772687/74066379-362bc300-49b4-11ea-9e00-99f8b609a6f2.png)

There is a bug (#2218) but this is a bug in Qt and is fixed in version 5.14