### PR TITLE
Ubuntu18 warnings

### DIFF
--- a/apps/vaporgui/GeometryWidget.cpp
+++ b/apps/vaporgui/GeometryWidget.cpp
@@ -205,10 +205,11 @@ void GeometryWidget::Reinit(
         showOrientationOptions();
         adjustLayoutToPlanar(XY, false);
     }
-    else
+    else {
         hideOrientationOptions();
+    }
 
-	_minMaxTab->adjustSize();
+    _minMaxTab->adjustSize();
 }
 
 GeometryWidget::~GeometryWidget() {

--- a/apps/vaporgui/Histo.cpp
+++ b/apps/vaporgui/Histo.cpp
@@ -239,8 +239,14 @@ int Histo::Populate(const std::string &varName, VAPoR::DataMgr *dm, VAPoR::Rende
     }
     
     
-    if (_below) delete [] _below; _below = nullptr;
-    if (_above) delete [] _above; _above = nullptr;
+    if (_below) {
+        delete [] _below; 
+        _below = nullptr;
+    }
+    if (_above) 
+        delete [] _above; 
+        _above = nullptr;
+    }
     
     _getDataRange(varName, dm, rp, &_minData, &_maxData);
     

--- a/apps/vaporgui/Histo.cpp
+++ b/apps/vaporgui/Histo.cpp
@@ -1,20 +1,20 @@
 //************************************************************************
-//									*
-//		     Copyright (C)  2004				*
-//     University Corporation for Atmospheric Research			*
-//		     All Rights Reserved				*
-//									*
+//                                    *
+//             Copyright (C)  2004                *
+//     University Corporation for Atmospheric Research            *
+//             All Rights Reserved                *
+//                                    *
 //************************************************************************/
 //
-//	File:		Histo.cpp
+//    File:        Histo.cpp
 //
-//	Author:		Alan Norton
-//			National Center for Atmospheric Research
-//			PO 3000, Boulder, Colorado
+//    Author:        Alan Norton
+//            National Center for Atmospheric Research
+//            PO 3000, Boulder, Colorado
 //
-//	Date:		November 2004
+//    Date:        November 2004
 //
-//	Description:  Implementation of Histo class 
+//    Description:  Implementation of Histo class 
 //
 #include <vapor/MyBase.h>
 #include <vapor/DataMgrUtils.h>
@@ -42,28 +42,28 @@ Histo::Histo(int numberBins)
 }
 
 Histo::Histo() : Histo(0) {}
-	
+    
 Histo::~Histo(){
-	if (_binArray) delete [] _binArray;
+    if (_binArray) delete [] _binArray;
     if (_below) delete [] _below;
     if (_above) delete [] _above;
 }
 void Histo::reset(int newNumBins) {
-	if ( newNumBins != _numBins && newNumBins != -1 ) {
-		_numBins = newNumBins;
-		if (_binArray) delete [] _binArray;
-		_binArray = new unsigned int[_numBins];
+    if ( newNumBins != _numBins && newNumBins != -1 ) {
+        _numBins = newNumBins;
+        if (_binArray) delete [] _binArray;
+        _binArray = new unsigned int[_numBins];
         if (_below) delete [] _below;
         if (_above) delete [] _above;
         _below = nullptr;
         _above = nullptr;
-	}
-	for (int i = 0; i< _numBins; i++) _binArray[i] = 0;
+    }
+    for (int i = 0; i< _numBins; i++) _binArray[i] = 0;
     if (_below) memset(_below, 0, _nBinsBelow*sizeof(*_below));
     if (_above) memset(_above, 0, _nBinsAbove*sizeof(*_above));
-	_numSamplesBelow = 0;
-	_numSamplesAbove = 0;
-	_maxBinSize = -1;
+    _numSamplesBelow = 0;
+    _numSamplesAbove = 0;
+    _maxBinSize = -1;
     _populated = false;
 }
 
@@ -113,17 +113,17 @@ void Histo::addToBin(float val) {
     } else
     {
         int intVal = 0;
-		if (_range == 0.f ) 
+        if (_range == 0.f ) 
             intVal = 0;
-		else 
+        else 
             intVal = (int)((val - _minMapData) / _range * (float)_numBins );
         
         if (intVal < 0) intVal = 0;
         if (intVal >= _numBins) intVal = _numBins-1;
-		_binArray[intVal]++;
-	}
+        _binArray[intVal]++;
+    }
 }
-	
+    
 int Histo::getMaxBinSize()
 {
     if (_maxBinSize == -1) // For legacy purposes. Can remove with new TF Editor
@@ -243,7 +243,7 @@ int Histo::Populate(const std::string &varName, VAPoR::DataMgr *dm, VAPoR::Rende
         delete [] _below; 
         _below = nullptr;
     }
-    if (_above) 
+    if (_above) {
         delete [] _above; 
         _above = nullptr;
     }
@@ -253,7 +253,7 @@ int Histo::Populate(const std::string &varName, VAPoR::DataMgr *dm, VAPoR::Rende
 #ifdef WIN32
     if (_maxMapData-_minMapData > FLT_EPSILON) {
 #else
-	if (_maxMapData - _minMapData > __FLT_EPSILON__) {
+    if (_maxMapData - _minMapData > __FLT_EPSILON__) {
 #endif
         _nBinsBelow = std::min(10000.0f, _numBins/(_maxMapData-_minMapData) * (_minMapData-_minData));
         _nBinsAbove = std::min(10000.0f, _numBins/(_maxMapData-_minMapData) * (_maxData-_maxMapData));

--- a/apps/vaporgui/MouseModeParams.cpp
+++ b/apps/vaporgui/MouseModeParams.cpp
@@ -100,6 +100,6 @@ void MouseModeParams::SetCurrentMouseMode(string t) {
     if (itr == _modes.cend())
         t = GetNavigateModeName();
 
-	SetValueString(_currentMouseModeTag, "Set mouse mode", t);
+    SetValueString(_currentMouseModeTag, "Set mouse mode", t);
 }
 

--- a/apps/vaporgui/RenderHolder.cpp
+++ b/apps/vaporgui/RenderHolder.cpp
@@ -721,12 +721,12 @@ void RenderHolder::Update() {
 
 	_vaporTable->Update(numRows, 4, tableValues, rowHeader, colHeader);
 	int row = _getRow(activeRenderInst);
-	if (row >= 0)
-		_vaporTable->SetActiveRow(row);
+    if (row >= 0)
+        _vaporTable->SetActiveRow(row);
     else
         p->SetActiveRenderer(activeViz, "", "");
 
-	_updateDupCombo();
+    _updateDupCombo();
 
     
     

--- a/apps/vaporgui/VizWin.cpp
+++ b/apps/vaporgui/VizWin.cpp
@@ -285,7 +285,7 @@ void VizWin::_setUpProjMatrix() {
     if (vParams->GetProjectionType() == ViewpointParams::MapOrthographic)
         vParams->SetOrthoProjectionSize(_trackBall->GetOrthoSize());
 
-	_controlExec->SetSaveStateEnabled(enabled);
+    _controlExec->SetSaveStateEnabled(enabled);
 
     mm->MatrixModeModelView();
 }
@@ -400,14 +400,15 @@ void VizWin::_mousePressEventNavigate(QMouseEvent* e)
 
     int trackballButtonNumber = _buttonNum;
     if (vParams->GetProjectionType() == ViewpointParams::MapOrthographic
-        && _buttonNum == 1)
+        && _buttonNum == 1) {
         trackballButtonNumber = 2;
+    }
     
 	// Let trackball handle mouse events for navigation
 	//
-	_trackBall->MouseOnTrackball(
-		0, trackballButtonNumber, e->x(), e->y(), width(), height()
-	);
+    _trackBall->MouseOnTrackball(
+        0, trackballButtonNumber, e->x(), e->y(), width(), height()
+    );
 
 	// Create a state saving group.
 	// Only save camera parameters after user release mouse
@@ -422,7 +423,7 @@ void VizWin::mousePressEvent(QMouseEvent* e) {
     if (_mouseClicked)
         return;
     
-	_buttonNum = 0;
+    _buttonNum = 0;
 	_mouseClicked = true;
 
 

--- a/apps/vaporgui/hide_std_error_util.cpp
+++ b/apps/vaporgui/hide_std_error_util.cpp
@@ -20,9 +20,7 @@ void HideSTDERR()
     else
         _savedSTDERR = rc;
 
-    // assigning the result of frepoen to throwawayVar 
-    // supresses gcc compiler warnings about ignoring return values
-    FILE* throwawayVar = freopen( "/dev/null", "w", stderr );
+    (void) freopen( "/dev/null", "w", stderr );
 #endif
 }
 void RestoreSTDERR()

--- a/apps/vaporgui/hide_std_error_util.cpp
+++ b/apps/vaporgui/hide_std_error_util.cpp
@@ -20,7 +20,9 @@ void HideSTDERR()
     else
         _savedSTDERR = rc;
 
-    freopen( "/dev/null", "w", stderr );
+    // assigning the result of frepoen to throwawayVar 
+    // supresses gcc compiler warnings about ignoring return values
+    FILE* throwawayVar = freopen( "/dev/null", "w", stderr );
 #endif
 }
 void RestoreSTDERR()

--- a/apps/vaporgui/hide_std_error_util.cpp
+++ b/apps/vaporgui/hide_std_error_util.cpp
@@ -20,7 +20,10 @@ void HideSTDERR()
     else
         _savedSTDERR = rc;
 
-    (void) freopen( "/dev/null", "w", stderr );
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+    freopen( "/dev/null", "w", stderr );
+#pragma GCC diagnostic pop
 #endif
 }
 void RestoreSTDERR()

--- a/apps/vaporgui/hide_std_error_util.cpp
+++ b/apps/vaporgui/hide_std_error_util.cpp
@@ -20,10 +20,8 @@ void HideSTDERR()
     else
         _savedSTDERR = rc;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
-    freopen( "/dev/null", "w", stderr );
-#pragma GCC diagnostic pop
+    auto* tmp = freopen( "/dev/null", "w", stderr );
+    (void) tmp;
 #endif
 }
 void RestoreSTDERR()

--- a/lib/params/DataStatus.cpp
+++ b/lib/params/DataStatus.cpp
@@ -290,7 +290,7 @@ void DataStatus::GetActiveExtents(
         {
             if (! auxVarNames[k].empty()) 
 				var.varnames.push_back(auxVarNames[k]);
-				variables.push_back(var);
+			variables.push_back(var);
         }
 	}
 	if (variables.size()) {

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -96,7 +96,7 @@ void RenderParams::SetDefaultVariables(
     if (dim == 3)
         fieldVarNames[2] = _findVarStartingWithLetter(varnames, 'w');
 
-	SetFieldVariableNames(fieldVarNames);
+    SetFieldVariableNames(fieldVarNames);
 
     string colorVar = varname;
     if (secondaryColormapVariable)

--- a/lib/render/AnnotationRenderer.cpp
+++ b/lib/render/AnnotationRenderer.cpp
@@ -512,7 +512,7 @@ void AnnotationRenderer::InScenePaint(size_t ts)
     if (vfParams->GetUseDomainFrame()) 
         drawDomainFrame(domainExtents);
 
-	vector<string> names = m_paramsMgr->GetDataMgrNames();
+    vector<string> names = m_paramsMgr->GetDataMgrNames();
     Transform* t = vpParams->GetTransform(names[0]);
 	applyTransform(t);
 

--- a/lib/render/Renderer.cpp
+++ b/lib/render/Renderer.cpp
@@ -430,7 +430,7 @@ int Renderer::makeColorbarTexture(){
     if ((vip = dynamic_cast<VolumeIsoParams*>(rParams)))
         useConstantColor = !vip->GetValueLong(VolumeParams::UseColormapVariableTag, 0);
     
-	float rgb[3];
+    float rgb[3];
 	if (useConstantColor)
 		rParams->GetConstantColor(rgb);
 

--- a/lib/render/Visualizer.cpp
+++ b/lib/render/Visualizer.cpp
@@ -200,7 +200,7 @@ int Visualizer::paintEvent(bool fast)
     if (_configureLighting())
         return -1;
 	
-	glDepthMask(GL_TRUE);
+    glDepthMask(GL_TRUE);
 	glEnable(GL_DEPTH_TEST);
 	glEnable (GL_BLEND);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -213,7 +213,7 @@ int Visualizer::paintEvent(bool fast)
     if (_initializeNewRenderers() < 0)
         return -1;
 
-	int rc = 0;
+    int rc = 0;
 	for (int i = 0; i< _renderers.size(); i++) {
         _glManager->matrixManager->MatrixModeModelView();
         _glManager->matrixManager->PushMatrix();
@@ -562,7 +562,7 @@ int Visualizer:: _captureImage(std::string path)
     if (FileUtils::Extension(path) == "")
         path += ".png";
     
-	ViewpointParams* vpParams = getActiveViewpointParams();
+    ViewpointParams* vpParams = getActiveViewpointParams();
 	int width, height;
 //	vpParams->GetWindowSize(width, height);
     _framebuffer.GetSize(&width, &height);

--- a/lib/render/VolumeCellTraversal.cpp
+++ b/lib/render/VolumeCellTraversal.cpp
@@ -367,13 +367,13 @@ int VolumeCellTraversal::_getHeuristicBBLevels() const
 	
     if (levels == 12)
         return levels - 4;
-	if (levels >= 9)
-		return levels - 3;
-	if (levels >= 7)
-		return levels - 2;
-	if (levels >= 2)
-		return levels - 1;
-	return levels;
+    if (levels >= 9)
+        return levels - 3;
+    if (levels >= 7)
+        return levels - 2;
+    if (levels >= 2)
+        return levels - 1;
+    return levels;
 }
 
 std::string VolumeCellTraversal::_addDefinitionsToShader(std::string shaderName) const

--- a/lib/render/WireFrameRenderer.cpp
+++ b/lib/render/WireFrameRenderer.cpp
@@ -318,9 +318,10 @@ size_t WireFrameRenderer::_buildCacheConnectivity(
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     
     GLenum err;
-    while((err = glGetError()) != GL_NO_ERROR)
+    while((err = glGetError()) != GL_NO_ERROR) {
         if (err == GL_OUT_OF_MEMORY)
             *GPUOutOfMemory = true;
+    }
 
 	return(indices.size());
 }

--- a/lib/vdc/DataMgrUtils.cpp
+++ b/lib/vdc/DataMgrUtils.cpp
@@ -450,11 +450,11 @@ int DataMgrUtils::GetDefaultMetaInfoStride(DataMgr *dataMgr, std::string varname
     for (int i=0; i<dimsAtLevel.size(); i++)
         size *= dimsAtLevel[i];
         
-        int stride = 1;
-        if (size > REQUIRED_SAMPLE_SIZE)
-            stride = 1 + size / REQUIRED_SAMPLE_SIZE;
-            
-            return stride;
+    int stride = 1;
+    if (size > REQUIRED_SAMPLE_SIZE)
+        stride = 1 + size / REQUIRED_SAMPLE_SIZE;
+        
+    return stride;
 }
 
 double DataMgrUtils::Get2DRendererDefaultZ(DataMgr *dataMgr, size_t ts, int refLevel, int lod)


### PR DESCRIPTION
Fixes warnings on Ubuntu 18.

These changes mostly involve unguarded conditionals, which regard inconsistent tabs after if statements.  We may want to consider fixing tabs throughout our codebase ('    ' instead of '\t')

I've also added a pragma to ignore an unused variable in hide_std_error_util.cpp