### PR TITLE
Fix overflow in raw2vdc and region size reporting in vdc2raw

### DIFF
--- a/apps/raw2vdc/raw2vdc.cpp
+++ b/apps/raw2vdc/raw2vdc.cpp
@@ -64,12 +64,12 @@ size_t size_of_type(string type) {
 		
 void    swapbytes(
 	void *vptr,
-	int size,
-	int	n
+	size_t size,
+	size_t	n
 ) {
 	unsigned char   *ucptr = (unsigned char *) vptr;
 	unsigned char   uc;
-	int             i,j;
+	size_t          i,j;
 
 	for (j=0; j<n; j++) {
 		for (i=0; i<size/2; i++) {
@@ -94,9 +94,9 @@ int read_data(
 	size_t element_sz = size_of_type(type);
 	unsigned char *buffer = (unsigned char *) smart_buf.Alloc(n * element_sz);
 	
-	int rc = fread(buffer, element_sz, n, fp);
+	size_t rc = fread(buffer, element_sz, n, fp);
 	if (rc != n) {
-		if (rc<0) { 
+		if (ferror(fp)!=0) { 
 			MyBase::SetErrMsg("Error reading input file : %M");
 		} else {
 			MyBase::SetErrMsg("Short read on input file");

--- a/apps/vdc2raw/vdc2raw.cpp
+++ b/apps/vdc2raw/vdc2raw.cpp
@@ -297,23 +297,29 @@ int	main(int argc, char **argv) {
 			opt.ts, opt.varname, opt.level, opt.lod, vdc,
 			fp, dims, opt.type
 		);
+
+		if (! opt.quiet) {
+			cout << "Wrote ";
+			for (int i=0;i<dims.size(); i++) {
+				cout << dims[i];
+				if (i!=dims.size()-1) cout << "x";
+			}
+			cout << endl;
+		}
 	}
 	else {
 		process_region(
 			opt.ts, opt.varname, opt.level, opt.lod, vdc, 
 			fp, dims, opt.type, opt.xregion, opt.yregion, opt.zregion
 		);
-	}
 
-	if (! opt.quiet) {
-		cout << "Wrote ";
-		for (int i=0;i<dims.size(); i++) {
-			cout << dims[i];
-			if (i!=dims.size()-1) cout << "x";
+		if (! opt.quiet) {
+			cout << "Wrote ";
+			cout << (opt.xregion[1] - opt.xregion[0] + 1) << "x";
+			cout << (opt.yregion[1] - opt.yregion[0] + 1) << "x";
+			cout << (opt.zregion[1] - opt.zregion[0] + 1) << endl;
 		}
-		cout << endl;
 	}
-
 
 	fclose(fp);
 


### PR DESCRIPTION
Converting large data sets (900 GB) would result in the overflow and then report either short read or error. I changed all affected types to size_t.

The vdc2raw would print the data dimensions instead of the region dimension. I added the extra print for the region case.