### PR TITLE
Minimal test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_ubuntu18
+      #- build_ubuntu18
       - build_ubuntu16
-      - build_centos7
-      - build_osx
+      #- build_centos7
+      #- build_osx


### PR DESCRIPTION
This disables CircleCI tests for OSX, as well as Ubuntu18 and Centos7.

We still test Ubunt16.  This is a temporary fix until CircleCI can tell us why we are still running tests on every push - instead of building with each PR, as our settings currently state.