### PR TITLE
Issue 2255 - Loading very large MPAS files results in an abort 

### DIFF
--- a/apps/vaporgui/PlotParams.h
+++ b/apps/vaporgui/PlotParams.h
@@ -66,16 +66,6 @@ public:
         return("PlotParams");
     }
 
-    // virtual functions required by RenderParams
-    virtual bool IsOpaque() const
-    {
-        return true; 
-    }
-    virtual bool usingVariable( const std::string& varname )
-    {
-        return false;
-    }
-
 private:
     static const string _minMaxTSTag;
     static const string _p1Tag;         // point1 in space mode

--- a/apps/vaporgui/StatisticsParams.h
+++ b/apps/vaporgui/StatisticsParams.h
@@ -59,16 +59,6 @@ public:
         return("StatisticsParams");
     }
 
-    // virtual functions required by RenderParams
-    virtual bool IsOpaque() const
-    {
-        return true; 
-    }
-    virtual bool usingVariable( const std::string& varname )
-    {
-        return false;
-    }
-
 private:
     static const string _maxTSTag;
     static const string _autoUpdateTag;

--- a/apps/vaporgui/VariablesWidget.cpp
+++ b/apps/vaporgui/VariablesWidget.cpp
@@ -255,12 +255,14 @@ void VariablesWidget::setVariableDims(int index){
 	//_activeDim = index == 0 ? TWODIMS : THREEDIMS;
     if (index == 0) {
         _activeDim = TWODIMS;
+        _rParams->GetBox()->SetPlanar(true);
         _rParams->GetBox()->SetOrientation(VAPoR::Box::XY);
         //orientationFrame->show();
     }
     else {
         _activeDim = THREEDIMS;
         orientationFrame->hide();
+        _rParams->GetBox()->SetPlanar(false);
         _rParams->GetBox()->SetOrientation(VAPoR::Box::XYZ);
     }
 

--- a/apps/vaporgui/VariablesWidget.cpp
+++ b/apps/vaporgui/VariablesWidget.cpp
@@ -266,7 +266,6 @@ void VariablesWidget::setVariableDims(int index){
 
     _paramsMgr->BeginSaveStateGroup("Set variable dimensions");
 	setDefaultVariables();
-    _rParams->InitBox(_activeDim);
     _paramsMgr->EndSaveStateGroup();
 
 	// Need to referesh variable list if dimension changes

--- a/include/vapor/BarbParams.h
+++ b/include/vapor/BarbParams.h
@@ -38,13 +38,6 @@ public:
 	SetValueDouble(_lengthScaleTag, "Barb length", val);
  }
 
- //! \copydoc RenderParams::IsOpaque()
- virtual bool IsOpaque() const;
-
- //!
- //! \copydoc RenderParams::usingVariable()
- virtual bool usingVariable(const std::string& varname);
-
  //! Determine the size of the discrete grid
  //! E.g. the grid on which barbs are placed.
  //! \retval vector<long> grid

--- a/include/vapor/ContourParams.h
+++ b/include/vapor/ContourParams.h
@@ -33,13 +33,6 @@ public:
 
  void MakeNewContours(string varName);
 
- //! \copydoc RenderParams::IsOpaque()
- virtual bool IsOpaque() const;
-
- //!
- //! \copydoc RenderParams::usingVariable()
- virtual bool usingVariable(const std::string& varname);
-
  //! Set the variable type being used by the barbs
  //!
  void SetVariables3D(bool val) {

--- a/include/vapor/FlowParams.h
+++ b/include/vapor/FlowParams.h
@@ -42,6 +42,8 @@ public:
 
     virtual ~FlowParams();
 
+	virtual int Initialize();
+
     //
     // (Pure virtual methods from RenderParams)
     //

--- a/include/vapor/FlowParams.h
+++ b/include/vapor/FlowParams.h
@@ -42,7 +42,7 @@ public:
 
     virtual ~FlowParams();
 
-	virtual int Initialize();
+	virtual int Initialize() override;
 
     //
     // (Pure virtual methods from RenderParams)

--- a/include/vapor/FlowParams.h
+++ b/include/vapor/FlowParams.h
@@ -44,17 +44,6 @@ public:
 
 	virtual int Initialize() override;
 
-    //
-    // (Pure virtual methods from RenderParams)
-    //
-    virtual bool IsOpaque() const override
-    { 
-        return false; 
-    }
-    virtual bool usingVariable(const std::string& varname) override
-    {
-        return false;
-    }
 
     static std::string GetClassType() 
     {

--- a/include/vapor/HelloParams.h
+++ b/include/vapor/HelloParams.h
@@ -20,14 +20,6 @@ public:
 
  virtual ~HelloParams();
 
- //! \copydoc RenderParams::IsOpaque()
- virtual bool IsOpaque() const {return true;}
-
- //! \copydoc RenderParams::usingVariable()
- virtual bool usingVariable(const std::string& varname){
-	return(GetVariableName() == varname);
- }
-
  //! Determine line thickness in voxels
  //! \retval double line thickness
  double GetLineThickness(){

--- a/include/vapor/ImageParams.h
+++ b/include/vapor/ImageParams.h
@@ -19,6 +19,8 @@ public:
 
   virtual ~ImageParams();
 
+  virtual int Initialize();
+
   static std::string GetClassType() 
   {
     return ("ImageParams");

--- a/include/vapor/ImageParams.h
+++ b/include/vapor/ImageParams.h
@@ -89,20 +89,6 @@ public:
     SetValueLong( _orientationTag, "set orientation value", val );
   }
 
-
-  //
-  // (Pure virtual methods from RenderParams)
-  //
-  virtual bool IsOpaque() const override
-  { 
-    return false; 
-  }
-  virtual bool usingVariable(const std::string& varname) override
-  {
-    return false;   // since this class is for an image, not rendering a variable.
-  }
-
-
 private:
   static const std::string          _fileNameTag;
   static const std::string          _isGeoRefTag;

--- a/include/vapor/ImageParams.h
+++ b/include/vapor/ImageParams.h
@@ -19,7 +19,7 @@ public:
 
   virtual ~ImageParams();
 
-  virtual int Initialize();
+  virtual int Initialize() override;
 
   static std::string GetClassType() 
   {

--- a/include/vapor/ModelParams.h
+++ b/include/vapor/ModelParams.h
@@ -15,10 +15,6 @@ public:
  ModelParams(DataMgr *dataMgr, ParamsBase::StateSave *ssave, XmlNode *node);
  virtual ~ModelParams();
 
- virtual bool IsOpaque() const;
-
- virtual bool usingVariable(const std::string& varname);
-
   static string GetClassType() 
   {
 	  return("ModelParams");

--- a/include/vapor/ParamsMgr.h
+++ b/include/vapor/ParamsMgr.h
@@ -443,18 +443,9 @@ public:
  //!
  //! \sa ParamsMgr()
  //
- void GetAppRenderParams(string dataSetName, vector <RenderParams *> &appRenderParams) const {
-	appRenderParams.clear();
-	std::map <string, RenParamsContainer *>::const_iterator itr;
-	itr = _otherRenParams.find(dataSetName);
-	if (itr == _otherRenParams.cend()) return;
-	vector <string> v = itr->second->GetNames();
-	for (int i=0; i<v.size(); i++) {
-		if (itr->second->GetParams(v[i]))
-			appRenderParams.push_back(itr->second->GetParams(v[i]));
-	}
- }
-
+ void GetAppRenderParams(
+	string dataSetName, vector <RenderParams *> &appRenderParams
+ ) const;
  
  //! Save current state to a file
  //!

--- a/include/vapor/ParamsMgr.h
+++ b/include/vapor/ParamsMgr.h
@@ -432,6 +432,29 @@ public:
 	return(itr != _otherRenParams.cend() ? itr->second->GetParams(classType) : NULL);
  }
 
+ //! Optain any render paramers registered by the application for a given data set
+ //!
+ //! This method returns params that have been registered on the
+ //! ParamsMgr via RegisterAppParams() for the data set named
+ //! by \p dataSetName;
+ //!
+ //! \param[in] dataSetName  
+ //! \param[out] appRenderParams a vector of application render params associated with \p dataSetName  
+ //!
+ //! \sa ParamsMgr()
+ //
+ void GetAppRenderParams(string dataSetName, vector <RenderParams *> &appRenderParams) const {
+	appRenderParams.clear();
+	std::map <string, RenParamsContainer *>::const_iterator itr;
+	itr = _otherRenParams.find(dataSetName);
+	if (itr == _otherRenParams.cend()) return;
+	vector <string> v = itr->second->GetNames();
+	for (int i=0; i<v.size(); i++) {
+		if (itr->second->GetParams(v[i]))
+			appRenderParams.push_back(itr->second->GetParams(v[i]));
+	}
+ }
+
  
  //! Save current state to a file
  //!
@@ -668,7 +691,7 @@ private:
  static const string _windowsTag;
 
  void _init(std::vector <string> appParamNames, XmlNode *node);
- void _initAppRenParams(string dataSetName);
+ void _createAppRenParams(string dataSetName);
  void _destroy();
 
  const map <string, map <string, RenParamsContainer *>> *getWinMap3(

--- a/include/vapor/RayCasterParams.h
+++ b/include/vapor/RayCasterParams.h
@@ -21,18 +21,6 @@ public:
     virtual ~RayCasterParams();
 
     //
-    // (Pure virtual methods from RenderParams)
-    //
-    virtual bool IsOpaque() const override
-    { 
-        return false; 
-    }
-    virtual bool usingVariable(const std::string& varname) override
-    {
-        return false;   // since this class is for an image, not rendering a variable.
-    }
-
-    //
     //! Obtain current MapperFunction for the primary variable.
     //
     MapperFunction* GetMapperFunc();

--- a/include/vapor/RenderParams.h
+++ b/include/vapor/RenderParams.h
@@ -199,12 +199,6 @@ public:
 	//!
 	virtual void SetCompressionLevel(int val);
 
-	//! Pure virtual method indicates whether or not the object will render as opaque.
-	//! Important to support multiple transparent (nonoverlapping) objects in the scene
-	//! \retval bool true if all geometry is opaque.
-	virtual bool IsOpaque() const = 0;
-
-
 	//! Specify a stretch factor used in displaying histograms in 
 	//! mapper functions.
 	//! Can be ignored if there is no mapper function in the params.
@@ -368,12 +362,6 @@ public:
  }
 
 	void initializeBypassFlags();
-
-	//! Pure virtual method indicates if a particular variable name 
-	//! is currently used by the renderer.
-	//! \param[in] varname name of the variable
-	//!
-	virtual bool usingVariable(const std::string& varname) = 0;
 
  //! Set reasonable default variables
  //! \param[in] The dimension of the variables being set

--- a/include/vapor/RenderParams.h
+++ b/include/vapor/RenderParams.h
@@ -61,6 +61,22 @@ public:
 
 	virtual ~RenderParams();
 
+	//! Initialize the class. 
+	//!
+	//! Must be called immediately after the constructor:
+	//!
+	//!  RenderParams(DataMgr *, ParamsBase::StateSave *, const string &, int maxdim);
+	//!
+	//! The results of 
+	//! calling any other methods before calling Initialize() are 
+	//! undefined.
+	//!
+	//! Subsequent calls to Initialize() after the first call are a no-op.
+	//!
+	//! \retval returns integer >= 0 on success, otherwise failure
+	//
+	virtual int Initialize();
+	
 
 	//! Determine if this params has been enabled for rendering
 	//!
@@ -375,7 +391,6 @@ public:
     vector<double> GetIsoValues() { return GetIsoValues(GetVariableName()); }
     void SetIsoValues(const vector<double> &values) { SetIsoValues(GetVariableName(), values); }
 	
- bool InitBox(int ndim);
 protected:
 	DataMgr *_dataMgr;
     int _maxDim;
@@ -391,6 +406,7 @@ private:
  Box *_Box;
  ColorbarPbase *_Colorbar;
  Transform *_transform;
+ bool _classInitialized;	//
 
  static const string _EnabledTag;
  static const string _histoScaleTag;

--- a/include/vapor/SliceParams.h
+++ b/include/vapor/SliceParams.h
@@ -35,8 +35,6 @@ public:
 
  void SetSampleRate(int rate);
 
- bool IsOpaque() const;
-
  int  GetDefaultSampleRate() const;
 
  void SetCachedValues(std::vector<double> values);
@@ -46,7 +44,6 @@ public:
 private:
 
  void _init();
- bool usingVariable(const std::string& varname);
  std::vector<double> _cachedValues;
 
  static const string _sampleRateTag;

--- a/include/vapor/SliceParams.h
+++ b/include/vapor/SliceParams.h
@@ -22,7 +22,7 @@ public:
 
  virtual ~SliceParams();
 
- virtual int Initialize();
+ virtual int Initialize() override;
 
  // Get static string identifier for this params class
  //
@@ -55,4 +55,3 @@ private:
 };
 
 #endif 
-

--- a/include/vapor/SliceParams.h
+++ b/include/vapor/SliceParams.h
@@ -22,6 +22,8 @@ public:
 
  virtual ~SliceParams();
 
+ virtual int Initialize();
+
  // Get static string identifier for this params class
  //
  static string GetClassType() 

--- a/include/vapor/TwoDDataParams.h
+++ b/include/vapor/TwoDDataParams.h
@@ -28,13 +28,6 @@ public:
  virtual void Validate(int type);
 #endif
 
- //! \copydoc RenderParams::IsOpaque()
- virtual bool IsOpaque() const;
-
- //!
- //! \copydoc RenderParams::usingVariable()
- virtual bool usingVariable(const std::string& varname);
-
  // Get static string identifier for this params class
  //
   static string GetClassType() 

--- a/include/vapor/VolumeParams.h
+++ b/include/vapor/VolumeParams.h
@@ -19,9 +19,6 @@ public:
  VolumeParams(DataMgr *dataMgr, ParamsBase::StateSave *ssave, XmlNode *node);
  virtual ~VolumeParams();
 
- virtual bool IsOpaque() const;
-
- virtual bool usingVariable(const std::string& varname);
  virtual string GetDefaultAlgorithmName() const;
     
     virtual bool GetDefaultLightingEnabled() const { return true; }

--- a/include/vapor/WireFrameParams.h
+++ b/include/vapor/WireFrameParams.h
@@ -22,13 +22,6 @@ public:
 
  virtual ~WireFrameParams();
 
- //! \copydoc RenderParams::IsOpaque()
- virtual bool IsOpaque() const;
-
- //!
- //! \copydoc RenderParams::usingVariable()
- virtual bool usingVariable(const std::string& varname);
-
  // Get static string identifier for this params class
  //
   static string GetClassType() 

--- a/include/vapor/utils.h
+++ b/include/vapor/utils.h
@@ -142,7 +142,8 @@ COMMON_API std::vector <size_t> VectorizeCoords(
 //    s1,s2: size of entire matrix (row,col)
 //
 COMMON_API void Transpose(
-	const float *a,float *b,int p1,int m1,int s1,int p2,int m2,int s2
+	const float *a,float *b,size_t p1,size_t m1,size_t s1,
+	size_t p2,size_t m2,size_t s2
 );
 
 //
@@ -151,7 +152,7 @@ COMMON_API void Transpose(
 //   *b : pointer to output matrix
 //    s1,s2: size of entire matrix (row,col)
 //
-COMMON_API void Transpose(const float *a,float *b,int s1,int s2);
+COMMON_API void Transpose(const float *a,float *b,size_t s1,size_t s2);
 
 
 

--- a/lib/common/utils.cpp
+++ b/lib/common/utils.cpp
@@ -179,12 +179,13 @@ size_t Wasp::VProduct(const vector <size_t> &a) {
 #define BLOCKSIZE 256
 
 void Wasp::Transpose(
-	const float *a,float *b,int p1,int m1,int s1,int p2,int m2,int s2
+	const float *a,float *b,size_t p1,size_t m1,size_t s1,
+	size_t p2,size_t m2,size_t s2
 ) {
-    int I1,I2;
-    int i1,i2;
-    int q,r;
-    const int block=BLOCKSIZE;
+    size_t I1,I2;
+    size_t i1,i2;
+    size_t q,r;
+    const size_t block=BLOCKSIZE;
     for(I2=p2;I2<p2+m2;I2+=block)
       for(I1=p1;I1<p1+m1;I1+=block)
 	for(i2=I2;i2<min(I2+block,p2+m2);i2++)
@@ -196,7 +197,7 @@ void Wasp::Transpose(
 	    }
 }
 
-void Wasp::Transpose(const float *a,float *b,int s1,int s2) {
+void Wasp::Transpose(const float *a,float *b,size_t s1,size_t s2) {
 	Wasp::Transpose(a,b,0,s1,s1,0,s2,s2);
 }
 

--- a/lib/params/BarbParams.cpp
+++ b/lib/params/BarbParams.cpp
@@ -50,18 +50,6 @@ void BarbParams::SetNeedToRecalculateScales(bool val) {
 	dval);
 }
 
-bool BarbParams::IsOpaque() const {
-	return true;
-}
-
-bool BarbParams::usingVariable(const std::string& varname) {
-	if ((varname.compare(GetHeightVariableName()) == 0)){
-		return(true);
-	}
-
-	return(varname.compare(GetVariableName()) == 0);
-}
-
 void BarbParams::_init() {
 	SetDiagMsg("BarbParams::_init()");
 

--- a/lib/params/ContourParams.cpp
+++ b/lib/params/ContourParams.cpp
@@ -72,18 +72,6 @@ ContourParams::~ContourParams() {
 	}
 }
 
-bool ContourParams::IsOpaque() const {
-	return true;
-}
-
-bool ContourParams::usingVariable(const std::string& varname) {
-	if ((varname.compare(GetHeightVariableName()) == 0)){
-		return(true);
-	}
-
-	return(varname.compare(GetVariableName()) == 0);
-}
-
 vector<double> ContourParams::GetIsoValues(const string &variable)
 {
     return GetContourValues(variable);

--- a/lib/params/FlowParams.cpp
+++ b/lib/params/FlowParams.cpp
@@ -33,18 +33,6 @@ FlowParams::FlowParams(   DataMgr*                 dataManager,
 	SetVariableName("");
     SetDiagMsg("FlowParams::FlowParams() this=%p", this);
 
-    // At this point the base class is initialized, and the _Box is properly initialized
-    // to be the extents of the domain. Let's use that information to initialize the rake! 
-    std::vector<double> minext, maxext;
-    auto box = RenderParams::GetBox();
-    box->GetExtents( minext, maxext );
-    std::vector<float> floats( minext.size() * 2 );
-    for( int i = 0; i < minext.size(); i++ )
-    {
-        floats[i*2]   = minext[i];
-        floats[i*2+1] = maxext[i];
-    }
-    this->SetRake( floats );
 }
 
 FlowParams::FlowParams(   DataMgr*                dataManager, 
@@ -62,6 +50,30 @@ FlowParams::FlowParams(   DataMgr*                dataManager,
 FlowParams::~FlowParams()
 {
     SetDiagMsg( "FlowParams::~FlowParams() this=%p", this );
+}
+
+int FlowParams::Initialize() {
+						  
+	int rc = RenderParams::Initialize();            
+	if (rc<0) return(rc);   
+
+    // At this point the base class is initialized, and the _Box is 
+	// properly initialized
+    // to be the extents of the domain. Let's use that information to 
+	// initialize the rake! 
+	//
+    std::vector<double> minext, maxext;
+    auto box = RenderParams::GetBox();
+    box->GetExtents( minext, maxext );
+    std::vector<float> floats( minext.size() * 2 );
+    for( int i = 0; i < minext.size(); i++ )
+    {
+        floats[i*2]   = minext[i];
+        floats[i*2+1] = maxext[i];
+    }
+    this->SetRake( floats );
+						  
+	return(0);
 }
 
 

--- a/lib/params/ImageParams.cpp
+++ b/lib/params/ImageParams.cpp
@@ -27,11 +27,6 @@ ImageParams::ImageParams( DataMgr*                dataManager,
   SetDiagMsg("ImageParams::ImageParams() this=%p", this);
 
 
-  // The image renderer behaves like a 2D renderer, but it doesn't operate
-  // on any data variables. Make sure the box is planar.
-  //
-  GetBox()->SetOrientation(VAPoR::Box::XY);
-  GetBox()->SetPlanar(true);
 }
 
 ImageParams::ImageParams( DataMgr*                dataManager, 
@@ -46,6 +41,20 @@ ImageParams::ImageParams( DataMgr*                dataManager,
 ImageParams::~ImageParams()
 {
   SetDiagMsg( "ImageParams::~ImageParams() this=%p", this );
+}
+
+int ImageParams::Initialize() {
+
+  int rc = RenderParams::Initialize();
+  if (rc<0) return(rc);
+	
+  // The image renderer behaves like a 2D renderer, but it doesn't operate
+  // on any data variables. Make sure the box is planar.
+  //
+  GetBox()->SetOrientation(VAPoR::Box::XY);
+  GetBox()->SetPlanar(true);
+
+  return(0);
 }
 
 std::string ImageParams::GetImagePath( ) const

--- a/lib/params/ImageParams.cpp
+++ b/lib/params/ImageParams.cpp
@@ -27,18 +27,11 @@ ImageParams::ImageParams( DataMgr*                dataManager,
   SetDiagMsg("ImageParams::ImageParams() this=%p", this);
 
 
-  //
   // The image renderer behaves like a 2D renderer, but it doesn't operate
-  // on any data variables. If InitBox() fails to initialize using 2D
-  // data variables (because none are present in the data collection) try
-  // to initialize the Box using 3D variables
+  // on any data variables. Make sure the box is planar.
   //
-  bool ok = InitBox(2);
-  if (! ok) {
-    InitBox(3);
-    GetBox()->SetOrientation(VAPoR::Box::XY);
-    GetBox()->SetPlanar(true);
-  }
+  GetBox()->SetOrientation(VAPoR::Box::XY);
+  GetBox()->SetPlanar(true);
 }
 
 ImageParams::ImageParams( DataMgr*                dataManager, 

--- a/lib/params/ModelParams.cpp
+++ b/lib/params/ModelParams.cpp
@@ -37,14 +37,6 @@ ModelParams::~ModelParams() {
 
 }
 
-bool ModelParams::IsOpaque() const {
-	return true;
-}
-
-bool ModelParams::usingVariable(const std::string& varname) {
-    return false;
-}
-
 //Set everything to default values
 void ModelParams::_init() {
 	SetDiagMsg("ModelParams::_init()");

--- a/lib/params/ParamsMgr.cpp
+++ b/lib/params/ParamsMgr.cpp
@@ -240,10 +240,10 @@ void ParamsMgr::addDataMgrMerge(string dataSetName) {
 
 	delete windowsSep;
 
-	_initAppRenParams(dataSetName);
+	_createAppRenParams(dataSetName);
 }
 
-void ParamsMgr::_initAppRenParams(string dataSetName) {
+void ParamsMgr::_createAppRenParams(string dataSetName) {
 
 	// Deal with any application render Params registered by the application
 	//

--- a/lib/params/ParamsMgr.cpp
+++ b/lib/params/ParamsMgr.cpp
@@ -1136,6 +1136,21 @@ int ParamsMgr::loadFromFile(string path)
 
 #endif
 
+void ParamsMgr::GetAppRenderParams(
+	string dataSetName, vector <RenderParams *> &appRenderParams
+) const {
+	appRenderParams.clear();
+	std::map <string, RenParamsContainer *>::const_iterator itr;
+	itr = _otherRenParams.find(dataSetName);
+	if (itr == _otherRenParams.cend()) return;
+	vector <string> v = itr->second->GetNames();
+	for (int i=0; i<v.size(); i++) {
+		if (itr->second->GetParams(v[i])) {
+			appRenderParams.push_back(itr->second->GetParams(v[i]));
+		}
+	}
+}
+
 //----------------------------------------------------------------------------
 // Save the transfer function to a file. 
 //----------------------------------------------------------------------------

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -119,7 +119,9 @@ void RenderParams::_init() {
 	SetConstantOpacity(1.0);
 }
 
-bool RenderParams::InitBox(int ndim) {
+int RenderParams::Initialize() {
+	if (_classInitialized) return(0);
+
 	vector <double> minExt, maxExt;
 
 	//
@@ -130,16 +132,19 @@ bool RenderParams::InitBox(int ndim) {
 	string varname = GetVariableName();
 	size_t ts = 0;
 	if (! _dataMgr->VariableExists(ts, varname, 0, 0)) {
-		bool ok = DataMgrUtils::GetFirstExistingVariable(
-			_dataMgr, 0, 0, ndim, varname, ts
-		);
-		if (! ok) varname = "";
+		for (int ndim=3; ndim>0; ndim--) {
+			bool ok = DataMgrUtils::GetFirstExistingVariable(
+				_dataMgr, 0, 0, ndim, varname, ts
+			);
+			if (ok) break;
+			else varname = "";
+		}
 	}
 
-	if (varname.empty()) return(false);
+	if (varname.empty()) return(0);
 
 	int rc = _dataMgr->GetVariableExtents(ts, varname, 0, 0, minExt, maxExt);
-	VAssert(rc >= 0);
+	if (rc < 0) return(-1);
 	
 	VAssert(
 		minExt.size()==maxExt.size() && 
@@ -156,7 +161,15 @@ bool RenderParams::InitBox(int ndim) {
 
 	_Box->SetExtents(minExt, maxExt);
 	_Box->SetPlanar(planar);
-	return(true);
+
+	vector<double> origin (minExt.size());
+	for (int i = 0; i < minExt.size(); i++) {
+		origin[i] = minExt[i] + (maxExt[i] - minExt[i]) * 0.5;
+	}
+	_transform->SetOrigin(origin);
+
+	_classInitialized = true;
+	return(0);
 }
 	
 
@@ -165,6 +178,7 @@ RenderParams::RenderParams(
 	int maxdim
 ) : ParamsBase(ssave, classname) {
 
+	_classInitialized = false;
 	_dataMgr = dataMgr;
 	_maxDim = maxdim;
     _stride = 1;
@@ -178,7 +192,6 @@ RenderParams::RenderParams(
 
 	_Box = new Box(ssave);
 	_Box->SetParent(this);
-    (void) InitBox(_maxDim);
 
 	_Colorbar = new ColorbarPbase(ssave);
 	_Colorbar->SetParent(this);
@@ -186,15 +199,7 @@ RenderParams::RenderParams(
 	_transform = new Transform(ssave);
 	_transform->SetParent(this);
 
-	vector<double> minExt;
-	vector<double> maxExt;
-	vector<double> origin;
 
-	_Box->GetExtents(minExt, maxExt);
-	origin.resize(minExt.size());
-	for (int i = 0; i < minExt.size(); i++)
-		origin[i] = minExt[i] + (maxExt[i] - minExt[i]) * 0.5;
-	_transform->SetOrigin(origin);
 }
 
 RenderParams::RenderParams(
@@ -202,6 +207,7 @@ RenderParams::RenderParams(
 	int maxdim
 ) : ParamsBase(ssave, node) {
 
+	_classInitialized = true;
 	_dataMgr = dataMgr;
 	_maxDim = maxdim;
     _stride = 1;

--- a/lib/params/SliceParams.cpp
+++ b/lib/params/SliceParams.cpp
@@ -49,6 +49,14 @@ void SliceParams::_init() {
 
 	SetFieldVariableNames(vector <string>());
 
+
+    SetSampleRate(MIN_DEFAULT_SAMPLERATE);
+}
+
+int SliceParams::Initialize() {
+	int rc = RenderParams::Initialize();
+	if (rc<0) return(rc);
+
     Box* box = GetBox();
     box->SetOrientation(XY);
 
@@ -59,8 +67,9 @@ void SliceParams::_init() {
     maxExt[Z] = average;
     box->SetExtents(minExt, maxExt);
 
-    SetSampleRate(MIN_DEFAULT_SAMPLERATE);
+	return(0);
 }
+
 
 int SliceParams::GetDefaultSampleRate() const {
     string varName = GetVariableName();

--- a/lib/params/SliceParams.cpp
+++ b/lib/params/SliceParams.cpp
@@ -84,18 +84,6 @@ int SliceParams::GetDefaultSampleRate() const {
     return sampleRate;
 }
 
-bool SliceParams::IsOpaque() const {
-    return true;
-}
-
-bool SliceParams::usingVariable(const std::string& varname) {
-    if ((varname.compare(GetHeightVariableName()) == 0)){
-        return(true);
-    }
-
-    return(varname.compare(GetVariableName()) == 0);
-}
-
 int SliceParams::GetSampleRate() const {
     int rate = (int)GetValueDouble(_sampleRateTag, MIN_DEFAULT_SAMPLERATE);
     return rate;

--- a/lib/params/TwoDDataParams.cpp
+++ b/lib/params/TwoDDataParams.cpp
@@ -33,19 +33,6 @@ TwoDDataParams::~TwoDDataParams() {
 
 }
 
-bool TwoDDataParams::IsOpaque() const {
-	return true;
-}
-
-bool TwoDDataParams::usingVariable(const std::string& varname) {
-	if ((varname.compare(GetHeightVariableName()) == 0)){
-		return(true);
-	}
-
-	return(varname.compare(GetVariableName()) == 0);
-}
-
-
 //Set everything to default values
 void TwoDDataParams::_init() {
 	SetDiagMsg("TwoDDataParams::_init()");

--- a/lib/params/VolumeParams.cpp
+++ b/lib/params/VolumeParams.cpp
@@ -51,14 +51,6 @@ VolumeParams::~VolumeParams() {
 
 }
 
-bool VolumeParams::IsOpaque() const {
-	return true;
-}
-
-bool VolumeParams::usingVariable(const std::string& varname) {
-	return(varname.compare(GetVariableName()) == 0);
-}
-
 string VolumeParams::GetDefaultAlgorithmName() const
 {
     return "Regular";

--- a/lib/params/WireFrameParams.cpp
+++ b/lib/params/WireFrameParams.cpp
@@ -32,19 +32,6 @@ WireFrameParams::~WireFrameParams() {
 
 }
 
-bool WireFrameParams::IsOpaque() const {
-	return true;
-}
-
-bool WireFrameParams::usingVariable(const std::string& varname) {
-	if ((varname.compare(GetHeightVariableName()) == 0)){
-		return(true);
-	}
-
-	return(varname.compare(GetVariableName()) == 0);
-}
-
-
 //Set everything to default values
 void WireFrameParams::_init() {
 	SetDiagMsg("WireFrameParams::_init()");

--- a/lib/render/ControlExecutive.cpp
+++ b/lib/render/ControlExecutive.cpp
@@ -199,7 +199,7 @@ int ControlExec::ActivateRender(
 		int rc = rp->Initialize();
 		if (rc < 0) {
 			SetErrMsg("Failed to initialize of type \"%s\"",renderType.c_str());
-			return(0);
+			return(-1);
 		}
 
 		rc = v->CreateRenderer(dataSetName, renderType, renderName);
@@ -558,6 +558,8 @@ int ControlExec::OpenData(
 	for (int i=0; i<appRenderParams.size(); i++) {
 		int rc = appRenderParams[i]->Initialize();
 		if (rc<0) {
+			_dataStatus->Close(dataSetName);
+			_paramsMgr->RemoveDataMgr(dataSetName);
 			SetErrMsg(
 				"Failure to initialize application renderer \"%s\"",
 				appRenderParams[i]->GetName().c_str()

--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -236,30 +236,6 @@ bool parse_formula(
 }
 
 
-#define BLOCKSIZE 256
-
-void Transpose(
-    const float *a,float *b,int p1,int m1,int s1,int p2,int m2,int s2
-) {
-    int I1,I2;
-    int i1,i2;
-    int q,r;
-    const int block=BLOCKSIZE;
-    for(I2=p2;I2<p2+m2;I2+=block)
-      for(I1=p1;I1<p1+m1;I1+=block)
-    for(i2=I2;i2<min(I2+block,p2+m2);i2++)
-      for(i1=I1;i1<min(I1+block,p1+m1);i1++)
-        {
-          q=i2*s1+i1;
-          r=i1*s2+i2;
-          b[r]=a[q];
-        }
-}
-
-void Transpose(const float *a,float *b,int s1,int s2) {
-    Transpose(a,b,0,s1,s1,0,s2,s2);
-}
-
 // Transpose a 1D, 2D, or 3D array. For 1D 'a' is simply copied
 // to 'b'. Otherwise 'b' contains a permuted version of 'a' as follows:
 //
@@ -295,7 +271,7 @@ void transpose(
 	if (inDims.size() == 2) {
 		VAssert(axis == 1);
 
-		Transpose(a, b, inDims[0], inDims[1]);
+		Wasp::Transpose(a, b, inDims[0], inDims[1]);
 	}
 	else if (inDims.size() == 3) {
 		VAssert(axis == 1 || axis == 2);
@@ -305,7 +281,7 @@ void transpose(
 		const float *aptr = a;
 		float *bptr = b;
 		for (size_t i=0; i<inDims[2]; i++) {
-			Transpose(aptr, bptr, inDims[0], inDims[1]);
+			Wasp::Transpose(aptr, bptr, inDims[0], inDims[1]);
 			aptr += stride;
 			bptr += stride;
 		}
@@ -316,7 +292,7 @@ void transpose(
 
 			// We can treat 3D array as 2D in this case, linearizing X and Y
 			//
-			Transpose(b, a, inDims[0]*inDims[1], inDims[2]);
+			Wasp::Transpose(b, a, inDims[0]*inDims[1], inDims[2]);
 
 			// Ugh need to copy data from a back to b
 			//


### PR DESCRIPTION
Fixes #2255 

This PR fixes #2255 and also adds an initializer to the RenderParams class. The underlying problem was simply that there were portions of the code that were not 64bit clean. Compounding the problem was that, even after addressing the word size issue, the application asserted because insufficient memory was available to process 3D coordinate variables of this data set. An assert was thrown because the RenderParams class was attempting to compute variable extents inside of its constructor and constructors must be no-fail (this one was not). The addition of the RenderParams::Initialize() method allows for moving the extents query outside of the constructor and into Initialize() where error handling can take place. The addition of the initializer resulted in some changes upstream, namely in the VariablesWidget and various other RenderParams derived classes.