### PR TITLE
Fixed #2259 - Layered grid doesn't support grids with a dimension length of 1

### DIFF
--- a/lib/vdc/LayeredGrid.cpp
+++ b/lib/vdc/LayeredGrid.cpp
@@ -34,7 +34,8 @@ void LayeredGrid::_layeredGrid(
 	//
 	vector <size_t> dims = GetDimensions();
 	for (int i=0; i<_minu.size(); i++) {
-		_delta.push_back((_maxu[i] - _minu[i])/(double) (dims[i] - 1));
+		if (dims[i] < 2) _delta.push_back(0.0);
+		else _delta.push_back((_maxu[i] - _minu[i])/(double) (dims[i] - 1));
 	}
 
 	// Get extents of layered dimension
@@ -383,7 +384,7 @@ bool LayeredGrid::GetIndicesCell(
 			if (indices[i] == dims[i]-1) indices[i]--;
 		}
 
-		VAssert(indices[i]<dims[i]-1);
+		VAssert((indices[i]<dims[i]-1) || (indices[i] == 0 && dims[i] == 1));
 	}
 
 	// Now find index for layered grid


### PR DESCRIPTION
Fixed #2259 