### PR TITLE
Change extension from .nc to .vdc

### DIFF
--- a/apps/cf2vdc/cf2vdc.cpp
+++ b/apps/cf2vdc/cf2vdc.cpp
@@ -273,14 +273,14 @@ int	main(int argc, char **argv) {
 	}
 
 	if (argc < 3) {
-		cerr << "Usage: " << ProgName << " cffiles... master.nc" << endl;
+		cerr << "Usage: " << ProgName << " cffiles... master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		return(1);
 	}
 	
 
 	if (opt.help) {
-		cerr << "Usage: " << ProgName << " master.nc" << endl;
+		cerr << "Usage: " << ProgName << " master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		return(0);
 	}

--- a/apps/cfvdccreate/cfvdccreate.cpp
+++ b/apps/cfvdccreate/cfvdccreate.cpp
@@ -197,14 +197,14 @@ int	main(int argc, char **argv) {
 	}
 
 	if (argc < 3) {
-		cerr << "Usage: " << ProgName << " cf_files... master.nc" << endl;
+		cerr << "Usage: " << ProgName << " cf_files... master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		return(1);
 	}
 	
 
 	if (opt.help) {
-		cerr << "Usage: " << ProgName << " cf_files... master.nc" << endl;
+		cerr << "Usage: " << ProgName << " cf_files... master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		return(0);
 	}

--- a/apps/cfvdccreate/cfvdccreate.cpp
+++ b/apps/cfvdccreate/cfvdccreate.cpp
@@ -216,7 +216,7 @@ int	main(int argc, char **argv) {
 	string master = argv[argc-1];
 
     if (FileUtils::Extension(master) != "vdc")
-        printf("Warning: VDC files should the extension .vdc\n");
+        fprintf(stderr, "Warning: VDC files should the extension .vdc\n");
 
 	VDCNetCDF    vdc(opt.nthreads);
 

--- a/apps/cfvdccreate/cfvdccreate.cpp
+++ b/apps/cfvdccreate/cfvdccreate.cpp
@@ -215,6 +215,9 @@ int	main(int argc, char **argv) {
 	for (int i=0; i<argc-1; i++) cffiles.push_back(argv[i]);
 	string master = argv[argc-1];
 
+    if (FileUtils::Extension(master) != "vdc")
+        printf("Warning: VDC files should the extension .vdc\n");
+
 	VDCNetCDF    vdc(opt.nthreads);
 
 	if (vdc.DataDirExists(master) && !opt.force) {

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -405,7 +405,7 @@ MainForm::MainForm(
             paths.push_back(f.toStdString());
         
         string fmt;
-        if (determineDatasetFormat(paths, &fmt) == 0) {
+        if (determineDatasetFormat(paths, &fmt)) {
             loadDataHelper(paths, "", "", fmt, true);
         } else {
             MSG_ERR("Could not determine dataset format for command line parameters");
@@ -444,7 +444,7 @@ template<class T> bool MainForm::isDatasetValidFormat(const std::vector<std::str
     return ret == 0;
 }
 
-int MainForm::determineDatasetFormat(const std::vector<std::string> &paths, std::string *fmt) const
+bool MainForm::determineDatasetFormat(const std::vector<std::string> &paths, std::string *fmt) const
 {
     if (isDatasetValidFormat<VDCNetCDF>(paths))
         *fmt = "vdc";
@@ -455,8 +455,8 @@ int MainForm::determineDatasetFormat(const std::vector<std::string> &paths, std:
     else if (isDatasetValidFormat<DCCF>(paths))
         *fmt = "cf";
     else
-        return -1;
-    return 0;
+        return false;
+    return true;
 }
 
 void MainForm::_createModeToolBar() {

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -306,8 +306,8 @@ private:
  void createToolBars();
  virtual void sessionOpenHelper(string fileName);
     
- bool isFileValidVDC(const std::string &path);
- bool isFileValidWRF(const std::string &path);
+ template<class T> bool isDatasetValidFormat(const std::vector<std::string> &paths) const;
+ int determineDatasetFormat(const std::vector<std::string> &paths, std::string *fmt) const;
 
 
  // Enable/Disable all the widgets that require data to be present

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -305,6 +305,9 @@ private:
  void _createVizToolBar();
  void createToolBars();
  virtual void sessionOpenHelper(string fileName);
+    
+ bool isFileValidVDC(const std::string &path);
+ bool isFileValidWRF(const std::string &path);
 
 
  // Enable/Disable all the widgets that require data to be present

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -307,7 +307,7 @@ private:
  virtual void sessionOpenHelper(string fileName);
     
  template<class T> bool isDatasetValidFormat(const std::vector<std::string> &paths) const;
- int determineDatasetFormat(const std::vector<std::string> &paths, std::string *fmt) const;
+ bool determineDatasetFormat(const std::vector<std::string> &paths, std::string *fmt) const;
 
 
  // Enable/Disable all the widgets that require data to be present

--- a/apps/vaporgui/main.cpp
+++ b/apps/vaporgui/main.cpp
@@ -136,6 +136,12 @@ if (getenv("VAPOR_DEBUG"))
 	MyBase::SetDiagMsg("PYTHONHOME = %s", phome.c_str());
 							   
 #endif
+    
+    // Show help
+    if (argc >= 2 && string(argv[1]) == "-h") {
+        fprintf(stderr, "Usage: %s [session.vs3] [data.vdc | data.nc ... | data.wrf ...]\n", argv[0]);
+        return 0;
+    }
 
 	app = &a;
 	a.setPalette(QPalette(QColor(233,236,216), QColor(233,236,216)));

--- a/apps/vdccreate/vdccreate.cpp
+++ b/apps/vdccreate/vdccreate.cpp
@@ -302,6 +302,9 @@ int	main(int argc, char **argv) {
 
 	string master = argv[1];
 
+    if (FileUtils::Extension(master) != "vdc")
+        printf("Warning: VDC files should the extension .vdc\n");
+
 	if (opt.help) {
 		cerr << "Usage: " << ProgName << " master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);

--- a/apps/vdccreate/vdccreate.cpp
+++ b/apps/vdccreate/vdccreate.cpp
@@ -289,12 +289,12 @@ int	main(int argc, char **argv) {
 	}
 
 	if (argc != 2) {
-		cerr << "Usage: " << ProgName << " [options] master.nc" << endl;
+		cerr << "Usage: " << ProgName << " [options] master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		exit(1);
 	}
 	if (opt.extents.size() && opt.extents.size() != 6) {
-		cerr << "Usage: " << ProgName << " master.nc" << endl;
+		cerr << "Usage: " << ProgName << " master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		exit(1);
 	}
@@ -303,7 +303,7 @@ int	main(int argc, char **argv) {
 	string master = argv[1];
 
 	if (opt.help) {
-		cerr << "Usage: " << ProgName << " master.nc" << endl;
+		cerr << "Usage: " << ProgName << " master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		exit(0);
 	}

--- a/apps/vdccreate/vdccreate.cpp
+++ b/apps/vdccreate/vdccreate.cpp
@@ -303,7 +303,7 @@ int	main(int argc, char **argv) {
 	string master = argv[1];
 
     if (FileUtils::Extension(master) != "vdc")
-        printf("Warning: VDC files should the extension .vdc\n");
+        fprintf(stderr, "Warning: VDC files should the extension .vdc\n");
 
 	if (opt.help) {
 		cerr << "Usage: " << ProgName << " master.vdc" << endl;

--- a/apps/vdcdump/vdcdump.cpp
+++ b/apps/vdcdump/vdcdump.cpp
@@ -294,12 +294,12 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 	if (opt.help) {
-		cerr << "Usage: " << progName << " [options] vdc.nc" << endl;
+		cerr << "Usage: " << progName << " [options] vdc.vdc" << endl;
 		op.PrintOptionHelp(stderr);
 		exit(0);
 	}
 	if (argc != 2) {
-		cerr << "Usage: " << progName << " vdcmaster.nc" << endl;
+		cerr << "Usage: " << progName << " vdcmaster.vdc" << endl;
 		exit(1);
 	}
 

--- a/apps/wrf2vdc/wrf2vdc.cpp
+++ b/apps/wrf2vdc/wrf2vdc.cpp
@@ -91,14 +91,14 @@ int	main(int argc, char **argv) {
 	}
 
 	if (argc < 3) {
-		cerr << "Usage: " << ProgName << " wrffiles... master.nc" << endl;
+		cerr << "Usage: " << ProgName << " wrffiles... master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		return(1);
 	}
 	
 
 	if (opt.help) {
-		cerr << "Usage: " << ProgName << " master.nc" << endl;
+		cerr << "Usage: " << ProgName << " master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		return(0);
 	}

--- a/apps/wrfvdccreate/wrfvdccreate.cpp
+++ b/apps/wrfvdccreate/wrfvdccreate.cpp
@@ -115,7 +115,7 @@ int	main(int argc, char **argv) {
 	string master = argv[argc-1];
 
     if (FileUtils::Extension(master) != "vdc")
-        printf("Warning: VDC files should the extension .vdc\n");
+        fprintf(stderr, "Warning: VDC files should the extension .vdc\n");
 
 	VDCNetCDF    vdc(opt.nthreads);
 

--- a/apps/wrfvdccreate/wrfvdccreate.cpp
+++ b/apps/wrfvdccreate/wrfvdccreate.cpp
@@ -96,14 +96,14 @@ int	main(int argc, char **argv) {
 	}
 
 	if (argc < 3) {
-		cerr << "Usage: " << ProgName << " wrf_file1 wrf_file2 ... master.nc" << endl;
+		cerr << "Usage: " << ProgName << " wrf_file1 wrf_file2 ... master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		exit(1);
 	}
 	
 
 	if (opt.help) {
-		cerr << "Usage: " << ProgName << "wrffiles... master.nc" << endl;
+		cerr << "Usage: " << ProgName << "wrffiles... master.vdc" << endl;
 		op.PrintOptionHelp(stderr, 80, false);
 		exit(0);
 	}

--- a/apps/wrfvdccreate/wrfvdccreate.cpp
+++ b/apps/wrfvdccreate/wrfvdccreate.cpp
@@ -114,6 +114,9 @@ int	main(int argc, char **argv) {
 	for (int i=0; i<argc-1; i++) wrffiles.push_back(argv[i]);
 	string master = argv[argc-1];
 
+    if (FileUtils::Extension(master) != "vdc")
+        printf("Warning: VDC files should the extension .vdc\n");
+
 	VDCNetCDF    vdc(opt.nthreads);
 
 	if (vdc.DataDirExists(master) && !opt.force) {

--- a/include/vapor/VDCNetCDF.h
+++ b/include/vapor/VDCNetCDF.h
@@ -123,8 +123,8 @@ public:
  //! zero results in NC_SIZEHINT_DEFAULT being used.
  //
  virtual int Initialize(
-	const vector <string> &paths, const vector <string> &options,
-	AccessMode mode, vector <size_t> bs = {64,64,64}, size_t chunksizehint = 0
+    const vector <string> &paths, const vector <string> &options = {},
+	AccessMode mode = VDC::R, vector <size_t> bs = {64,64,64}, size_t chunksizehint = 0
  );
  virtual int Initialize(
 	string path, const vector <string> &options,


### PR DESCRIPTION
In some cases I left the ability to use .nc extensions for usability. For example, in the Open Dataset dialog on OSX where disabling it would force users to rename their files. The sphinx documentation needs to be re-generated to include the changes but that can be done at the next release.

Fix #2248