### PR TITLE
Issue 927 - Add support for vertical coordinate transforms

### DIFF
--- a/include/vapor/DC.h
+++ b/include/vapor/DC.h
@@ -1537,6 +1537,27 @@ public:
  }
 
 
+ //! Return the ordered list of dimensions for a mesh
+ //!
+ //! This method is a convenience function that returns the ordered 
+ //! vector of dimension lengths for the mesh named \p mesh. If \p mesh
+ //! is unknown, or invalid false is returned.
+ //!
+ //! \sa DC::GetMesh(), DC::GetDimension()
+ //
+ virtual bool GetMeshDimLens(string mesh_name, std::vector<size_t> &dims) const;
+
+ //! Return the ordered list of dimension names for a mesh
+ //!
+ //! This method is a convenience function that returns the ordered 
+ //! vector of dimension names for the mesh named \p mesh. If \p mesh
+ //! is unknown, or invalid false is returned.
+ //!
+ //! \sa DC::GetMesh(), DC::GetDimension()
+ //
+ virtual bool GetMeshDimNames(string mesh_name, std::vector<string> &dimnames) const;
+
+
  //! Return a coordinate variable's definition
  //!
  //! Return a reference to a DC::CoordVar object describing 

--- a/include/vapor/DataMgr.h
+++ b/include/vapor/DataMgr.h
@@ -1141,8 +1141,8 @@ UnstructuredGrid2D *_make_grid_unstructured2d(
  ) const;
 
  bool _hasVerticalXForm(string meshname) const {
-	string dummy;
-	return(_hasVerticalXForm(meshname, dummy, dummy));
+	string standard_name, formula_terms;
+	return(_hasVerticalXForm(meshname, standard_name, formula_terms));
  }
 
  // Hide public DC::GetDimLensAtLevel by making it private

--- a/include/vapor/DerivedVar.h
+++ b/include/vapor/DerivedVar.h
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <functional>
 #include <vapor/DC.h>
 #include <vapor/MyBase.h>
 #include <vapor/Proj4API.h>

--- a/include/vapor/DerivedVar.h
+++ b/include/vapor/DerivedVar.h
@@ -177,6 +177,75 @@ protected:
  string _formula;
 };
 
+
+//////////////////////////////////////////////////////////////////////////
+//
+// DerivedCFVertCoordVarFactory Class
+//
+/////////////////////////////////////////////////////////////////////////
+
+
+class PARAMS_API DerivedCFVertCoordVarFactory {
+public:
+ static DerivedCFVertCoordVarFactory *Instance() {
+	static DerivedCFVertCoordVarFactory instance;
+	return &instance;
+ }
+
+ void RegisterFactoryFunction(
+	string name,
+	function<DerivedCFVertCoordVar*(DC *, string, string)> classFactoryFunction) 
+ {
+
+	// register the class factory function
+	_factoryFunctionRegistry[name] = classFactoryFunction;
+ }
+
+ DerivedCFVertCoordVar *(CreateInstance(string standard_name, DC *, string, string));
+
+ vector <string> GetFactoryNames() const;
+
+private:
+ map<string, function<DerivedCFVertCoordVar * (DC *, string, string)>> _factoryFunctionRegistry;
+
+ DerivedCFVertCoordVarFactory() {}
+ DerivedCFVertCoordVarFactory(const DerivedCFVertCoordVarFactory &) { }
+ DerivedCFVertCoordVarFactory &operator=(const DerivedCFVertCoordVarFactory &) { return *this; }
+
+};
+
+
+//////////////////////////////////////////////////////////////////////////
+//
+// DerivedCFVertCoordVarFactoryRegistrar Class
+//
+// Register DerivedCFVertCoordVar derived class with:
+//
+//	static DerivedCFVertCoordVarFactoryRegistrar<class> registrar("standard_name");
+//
+// where 'class' is a class derived from 'DerivedCFVertCoordVar', and 
+// "standard_name" is the value of the CF "standard_name" attribute.
+//
+/////////////////////////////////////////////////////////////////////////
+
+template<class T>
+class DerivedCFVertCoordVarFactoryRegistrar {
+public:
+ DerivedCFVertCoordVarFactoryRegistrar(string standard_name) {
+
+	// register the class factory function 
+	//
+	DerivedCFVertCoordVarFactory::Instance()->RegisterFactoryFunction(
+		standard_name, [](DC *dc, string mesh, string formula) -> DerivedCFVertCoordVar * { 
+			return new T(dc, mesh, formula);
+	}
+	);
+ }
+};
+
+
+
+
 //!
 //! \class DerivedDataVar
 //!

--- a/include/vapor/DerivedVar.h
+++ b/include/vapor/DerivedVar.h
@@ -116,6 +116,12 @@ protected:
 	float *region
  ) const;
 
+ int _getVarDestagger(
+	DC *dc, size_t ts, string varname, int level, int lod,
+	const std::vector <size_t> &min, const std::vector <size_t> &max,
+	float *region, int stagDim
+ ) const;
+
  int _getVarBlock(
 	DC *dc, size_t ts, string varname, int level, int lod,
 	const std::vector <size_t> &min, const std::vector <size_t> &max,
@@ -757,11 +763,82 @@ private:
  
 };
 
+class VDF_API DerivedCoordVarStandardOceanSCoordinateG2 : public DerivedCFVertCoordVar {
+public:
+ DerivedCoordVarStandardOceanSCoordinateG2(
+	DC *dc, string mesh, string formula
+ );
+ virtual ~DerivedCoordVarStandardOceanSCoordinateG2() {}
+
+ virtual int Initialize();
+
+ virtual bool GetBaseVarInfo(DC::BaseVar &var) const;
+
+ virtual bool GetCoordVarInfo(DC::CoordVar &cvar) const;
+
+ virtual std::vector <string> GetInputs() const;
+
+ virtual int GetDimLensAtLevel(
+	int level, std::vector <size_t> &dims_at_level,
+	std::vector <size_t> &bs_at_level
+ ) const;
+
+ virtual size_t GetNumRefLevels() const {
+    return(_dc->GetNumRefLevels(_etaVar));
+ } 
+
+ virtual std::vector <size_t> GetCRatios() const {
+    return(_dc->GetCRatios(_etaVar));
+ }
+
+ virtual int OpenVariableRead(
+	size_t ts, int level=0, int lod=0
+ );
+
+ virtual int CloseVariable(int fd);
+ 
+ virtual int ReadRegionBlock(
+	int fd,
+	const std::vector <size_t> &min, const std::vector <size_t> &max,
+	float *region
+ ) {
+	return(ReadRegion(fd, min, max, region));
+ }
+
+ virtual int ReadRegion(
+	int fd,
+	const std::vector <size_t> &min, const std::vector <size_t> &max,
+	float *region
+ );
+
+ virtual bool VariableExists(
+	size_t ts,
+	int reflevel,
+	int lod
+ ) const;
+
+ static bool ValidFormula(string formula);
+
+private:
+ string _sVar;
+ string _CVar;
+ string _etaVar;
+ string _depthVar;
+ string _depth_cVar;
+ double _CVarMV;
+ double _etaVarMV;
+ double _depthVarMV;
+ bool _destaggerEtaXDim;
+ bool _destaggerEtaYDim;
+ bool _destaggerDepthXDim;
+ bool _destaggerDepthYDim;
+ DC::CoordVar _coordVarInfo;
+
+ int initialize_missing_values();
+ int initialize_stagger_flags();
+ 
+};
+
 };
 
 #endif
-
-
-
-
-

--- a/include/vapor/DerivedVar.h
+++ b/include/vapor/DerivedVar.h
@@ -169,6 +169,8 @@ public:
 
  virtual bool GetCoordVarInfo(DC::CoordVar &cvar) const = 0;
 
+ static bool ValidFormula(const vector <string> &required_terms,string formula);
+
 protected:
  DC *_dc;
  string _mesh;
@@ -820,6 +822,7 @@ public:
  static bool ValidFormula(string formula);
 
 private:
+ string _standard_name;
  string _sVar;
  string _CVar;
  string _etaVar;
@@ -836,6 +839,16 @@ private:
 
  int initialize_missing_values();
  int initialize_stagger_flags();
+ void compute_g1(
+	const vector <size_t> &min, const vector <size_t> &max,
+	const float *s, const float *C, const float *eta, const float *depth,
+	float depth_c, float *region
+ ) const;
+ void compute_g2(
+	const vector <size_t> &min, const vector <size_t> &max,
+	const float *s, const float *C, const float *eta, const float *depth,
+	float depth_c, float *region
+ ) const;
  
 };
 

--- a/lib/vdc/DC.cpp
+++ b/lib/vdc/DC.cpp
@@ -1117,6 +1117,37 @@ vector <int> DC::FileTable::GetEntries() const {
 	return(fds);
 }
 
+bool DC::GetMeshDimLens(string mesh_name, std::vector<size_t> &dims) const {
+	dims.clear();
+
+	DC::Mesh mesh;
+	bool status = GetMesh(mesh_name, mesh);
+	if (! status) return (false);
+
+	vector <string> dimNames = mesh.GetDimNames();
+	for (int i=0; i<dimNames.size(); i++) {
+		DC::Dimension dimension;
+
+		status = GetDimension(dimNames[i], dimension);
+		if (! status) return(false);
+
+		dims.push_back(dimension.GetLength());
+	}
+	return(true);
+}
+
+bool DC::GetMeshDimNames(string mesh_name, std::vector<string> &dimnames) const {
+	dimnames.clear();
+
+	DC::Mesh mesh;
+	bool status = GetMesh(mesh_name, mesh);
+	if (! status) return (false);
+
+	dimnames = mesh.GetDimNames();
+
+	return(true);
+}
+
 
 namespace VAPoR {
 

--- a/lib/vdc/DCCF.cpp
+++ b/lib/vdc/DCCF.cpp
@@ -769,11 +769,11 @@ int DCCF::_InitVars(NetCDFCFCollection *ncdfc)
 
 	vector <bool> periodic(3, false);
 	//
-	// Get names of variables  in the CF data set that have 2 or 3
+	// Get names of variables  in the CF data set that have 0 to 3
 	// spatial dimensions
 	//
 	vector <string> vars;
-	for (int i=2; i<4; i++) {
+	for (int i=0; i<4; i++) {
         vector <string> v = ncdfc->GetDataVariableNames(i,true);
 		vars.insert(vars.end(), v.begin(), v.end());
 	}

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -2584,6 +2584,8 @@ bool DataMgr::_hasVerticalXForm(
 	bool ok = _dc->GetMesh(meshname, m);
 	if (! ok) return(false);
 
+	if (m.GetDimNames().size() != 3) return(false);
+
 	vector <string> coordVars = m.GetCoordVars();
 	
 	bool hasVertCoord = false;
@@ -2616,7 +2618,8 @@ bool DataMgr::_hasVerticalXForm(
 
 	// Currently only support one vertical transform!!!
 	//
-	if (! DerivedCoordVarStandardWRF_Terrain::ValidFormula(formula_terms)) {
+	if (! DerivedCoordVarStandardWRF_Terrain::ValidFormula(formula_terms) &&
+		! DerivedCoordVarStandardOceanSCoordinateG2::ValidFormula(formula_terms)) {
 		return(false);
 	}
 
@@ -3856,10 +3859,19 @@ int DataMgr::_initVerticalCoordVars() {
 
 		VAssert (m.GetCoordVars().size() > 2);
 
-		DerivedCoordVarStandardWRF_Terrain *derivedVar = 
-			new DerivedCoordVarStandardWRF_Terrain(
+		DerivedCoordVar *derivedVar = NULL;
+
+		if (DerivedCoordVarStandardWRF_Terrain::ValidFormula(formula_terms)) {
+			derivedVar = new DerivedCoordVarStandardWRF_Terrain(
 				_dc, meshnames[i], formula_terms
 			);
+		}
+		if (DerivedCoordVarStandardOceanSCoordinateG2::ValidFormula(formula_terms)) {
+			derivedVar = new DerivedCoordVarStandardOceanSCoordinateG2(
+				_dc, meshnames[i], formula_terms
+			);
+		}
+		VAssert(derivedVar != NULL);
 
 		int rc = derivedVar->Initialize(); 
 		if (rc<0) {

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -2616,14 +2616,16 @@ bool DataMgr::_hasVerticalXForm(
 
 	if (formula_terms.empty()) return(false);
 
-	// Currently only support one vertical transform!!!
+	// Does a converter exist for this standard name?
 	//
-	if (! DerivedCoordVarStandardWRF_Terrain::ValidFormula(formula_terms) &&
-		! DerivedCoordVarStandardOceanSCoordinateG2::ValidFormula(formula_terms)) {
-		return(false);
+	vector <string> names = 
+		DerivedCFVertCoordVarFactory::Instance()->GetFactoryNames();
+
+	for (int i=0; i<names.size(); i++) {
+		if (standard_name == names[i]) return(true);
 	}
 
-	return(true);
+	return(false);
 }
 
 
@@ -3861,17 +3863,13 @@ int DataMgr::_initVerticalCoordVars() {
 
 		DerivedCoordVar *derivedVar = NULL;
 
-		if (DerivedCoordVarStandardWRF_Terrain::ValidFormula(formula_terms)) {
-			derivedVar = new DerivedCoordVarStandardWRF_Terrain(
-				_dc, meshnames[i], formula_terms
-			);
+		derivedVar = DerivedCFVertCoordVarFactory::Instance()->CreateInstance(
+			standard_name, _dc, meshnames[i], formula_terms
+		);
+		if (! derivedVar) {
+			SetErrMsg("Failed to initialize derived coord variable");
+			return(-1);
 		}
-		if (DerivedCoordVarStandardOceanSCoordinateG2::ValidFormula(formula_terms)) {
-			derivedVar = new DerivedCoordVarStandardOceanSCoordinateG2(
-				_dc, meshnames[i], formula_terms
-			);
-		}
-		VAssert(derivedVar != NULL);
 
 		int rc = derivedVar->Initialize(); 
 		if (rc<0) {

--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -2046,12 +2046,51 @@ bool DerivedCFVertCoordVar::ValidFormula(
 	return(true);
 }
 		
+//////////////////////////////////////////////////////////////////////////
+//
+// DerivedCFVertCoordVarFactory Class
+//
+/////////////////////////////////////////////////////////////////////////
+
+
+DerivedCFVertCoordVar *DerivedCFVertCoordVarFactory::CreateInstance(
+	string standard_name, DC *dc, string mesh, string formula
+) {
+    DerivedCFVertCoordVar * instance = NULL;
+
+    // find standard_name in the registry and call factory method.
+	//
+    auto it = _factoryFunctionRegistry.find(standard_name);
+    if(it != _factoryFunctionRegistry.end())
+        instance = it->second(dc, mesh, formula);
+
+    if(instance != NULL)
+        return instance;
+    else
+        return NULL;
+}
+
+vector <string> DerivedCFVertCoordVarFactory::GetFactoryNames() const {
+	vector <string> names;
+	map<string, function<DerivedCFVertCoordVar * (DC *, string , string )>>::const_iterator itr;
+
+	for (
+		itr = _factoryFunctionRegistry.begin();
+		itr!=_factoryFunctionRegistry.end();
+		++itr
+	) {
+		names.push_back(itr->first);
+	}
+	return(names);
+}
 
 ////////////////////////////////////////////////////////////////////////////// 
 //
 //	DerivedCoordVarStandardWRF_Terrain
 //
 ////////////////////////////////////////////////////////////////////////////// 
+
+static DerivedCFVertCoordVarFactoryRegistrar<DerivedCoordVarStandardWRF_Terrain> registrar_wrf_terrain("wrf_terrain");
 
 DerivedCoordVarStandardWRF_Terrain::DerivedCoordVarStandardWRF_Terrain(
 	DC *dc, string mesh, string formula
@@ -2419,6 +2458,13 @@ bool DerivedCoordVarStandardWRF_Terrain::ValidFormula(string formula) {
 //	DerivedCoordVarStandardOceanSCoordinateG2
 //
 ////////////////////////////////////////////////////////////////////////////// 
+
+//
+// Register class with object factory!!!
+//
+static DerivedCFVertCoordVarFactoryRegistrar<DerivedCoordVarStandardOceanSCoordinateG2> registrar_ocean_s_coordinate_g1("ocean_s_coordinate_g1");
+
+static DerivedCFVertCoordVarFactoryRegistrar<DerivedCoordVarStandardOceanSCoordinateG2> registrar_ocean_s_coordinate_g2("ocean_s_coordinate_g2");
 
 DerivedCoordVarStandardOceanSCoordinateG2::DerivedCoordVarStandardOceanSCoordinateG2(
 	DC *dc, string mesh, string formula


### PR DESCRIPTION
This PR partially addresses issue #927, adding vertical coordinate transforms for the CF conventions defined "Ocean s-coordinate, generic form 1" and "Ocean s-coordinate, generic form 2 transforms".  It does not include the "Atmosphere hybrid sigma pressure coordinate" transform supported in VAPOR2 