### PR TITLE
Fixed #2273 - jsmall no longer opens

### DIFF
--- a/include/vapor/DerivedVar.h
+++ b/include/vapor/DerivedVar.h
@@ -180,6 +180,24 @@ public:
 
  virtual bool GetCoordVarInfo(DC::CoordVar &cvar) const = 0;
 
+ //! Parse a CF conventions forumla string into terms and variables
+ //!
+ //! This static method parse the CF conventions 
+ //! formula string, typically 
+ //! associated with the \a formula_terms attribute, into a std::map
+ //! of term names and variable names.
+ //!
+ //! If \p formula cannot be parsed false is returned.
+ //!
+ //! \param[in] formula : A formatted CF formula string
+ //! \param[out] parse_terms A map from term names to variable names
+ //!
+ //! \sa http://cfconventions.org/
+ //!
+ static bool ParseFormula(
+	string formula_terms, map <string, string> &parsed_terms
+ );
+
  //! validate that a CF conventions forumla string is syntactically correct
  //!
  //! This static method checks to see if \p formula contains a 

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -2616,6 +2616,19 @@ bool DataMgr::_hasVerticalXForm(
 
 	if (formula_terms.empty()) return(false);
 
+
+	// Make sure all of the dependent variables needed by the 
+	// formula actually exist
+	//
+	map<string, string> parsed_terms;
+	ok = DerivedCFVertCoordVar::ParseFormula(formula_terms, parsed_terms);
+	if (! ok) return(false);
+
+	for (auto itr = parsed_terms.begin(); itr!=parsed_terms.end(); ++itr) {
+		const string &varname = itr->second;
+		if (! _dc->VariableExists(0,varname, 0,0)) return(false);
+    }
+	
 	// Does a converter exist for this standard name?
 	//
 	vector <string> names = 

--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -209,32 +209,6 @@ void make2D(
 }
 
 
-bool parse_formula(
-	string formula_terms, map <string, string> &parsed_terms
-) {
-	parsed_terms.clear();
-
-	// Remove ":" to ease parsing. It's superflous
-	//
-	replace(formula_terms.begin(), formula_terms.end(), ':', ' ');
-
-	string buf; // Have a buffer string
-	stringstream ss(formula_terms); // Insert the string into a stream
-
-	vector<string> tokens; // Create vector to hold our words
-
-	while (ss >> buf) {
-		tokens.push_back(buf);
-	}
-
-	if (tokens.size() % 2) return(false);
-
-	for (int i=0; i<tokens.size(); i+=2) {
-		parsed_terms[tokens[i]] = tokens[i+1];
-		if (parsed_terms[tokens[i]].empty()) return(false);
-	}
-	return(true);
-}
 
 
 // Transpose a 1D, 2D, or 3D array. For 1D 'a' is simply copied
@@ -2005,12 +1979,39 @@ bool DerivedCoordVar_UnStaggered::VariableExists(
 //
 ////////////////////////////////////////////////////////////////////////////// 
 
+bool DerivedCFVertCoordVar::ParseFormula(
+	string formula_terms, map <string, string> &parsed_terms
+) {
+	parsed_terms.clear();
+
+	// Remove ":" to ease parsing. It's superflous
+	//
+	replace(formula_terms.begin(), formula_terms.end(), ':', ' ');
+
+	string buf; // Have a buffer string
+	stringstream ss(formula_terms); // Insert the string into a stream
+
+	vector<string> tokens; // Create vector to hold our words
+
+	while (ss >> buf) {
+		tokens.push_back(buf);
+	}
+
+	if (tokens.size() % 2) return(false);
+
+	for (int i=0; i<tokens.size(); i+=2) {
+		parsed_terms[tokens[i]] = tokens[i+1];
+		if (parsed_terms[tokens[i]].empty()) return(false);
+	}
+	return(true);
+}
+
 bool DerivedCFVertCoordVar::ValidFormula(
 	const vector <string> &required_terms, string formula
 ) {
 
 	map <string, string> formulaMap;
-	if (! parse_formula(formula, formulaMap)) {
+	if (! ParseFormula(formula, formulaMap)) {
 		return(false);
 	}
 
@@ -2075,7 +2076,7 @@ DerivedCoordVarStandardWRF_Terrain::DerivedCoordVarStandardWRF_Terrain(
 int DerivedCoordVarStandardWRF_Terrain::Initialize() {
 
 	map <string, string> formulaMap;
-	if (! parse_formula(_formula, formulaMap)) {
+	if (! ParseFormula(_formula, formulaMap)) {
 		SetErrMsg("Invalid conversion formula \"%s\"", _formula.c_str());
 		return(-1);
 	}
@@ -2513,7 +2514,7 @@ int DerivedCoordVarStandardOceanSCoordinate::initialize_stagger_flags() {
 int DerivedCoordVarStandardOceanSCoordinate::Initialize() {
 
 	map <string, string> formulaMap;
-	if (! parse_formula(_formula, formulaMap)) {
+	if (! ParseFormula(_formula, formulaMap)) {
 		SetErrMsg("Invalid conversion formula \"%s\"", _formula.c_str());
 		return(-1);
 	}
@@ -2621,7 +2622,7 @@ bool DerivedCoordVarStandardOceanSCoordinate::GetCoordVarInfo(
 vector <string> DerivedCoordVarStandardOceanSCoordinate::GetInputs() const {
 
     map <string, string> formulaMap;
-    bool ok = parse_formula(_formula, formulaMap);
+    bool ok = ParseFormula(_formula, formulaMap);
 	VAssert(ok);
 
 	vector <string> inputs;


### PR DESCRIPTION
This PR ensures that VAPOR is backwards compatible with older VDC data sets that do not contain 0D variables. Essentially, when attempting to create a derived coordinate variable following the CF conventions the variable dependencies are first checked for existence. If any of the dependent variables do not exist VAPOR will simply fall back to the native coordinate system.