### PR TITLE
Removed static_cast in c file

### DIFF
--- a/apps/linuxlauncher/launcher.c
+++ b/apps/linuxlauncher/launcher.c
@@ -8,7 +8,7 @@ int main(int argc, char **argv)
 {
 	char path[PATH_MAX];
 	ssize_t rc = readlink("/proc/self/exe", path, PATH_MAX);
-	static_cast<void>(rc); 		// Remove warning
+	(void)(rc); 		// Remove warning
 
 	char *p = &path[strlen(path)-1];
 	int up = 2;


### PR DESCRIPTION
Using static_cast in launcher.c broke the CentOS build.  Suprisingly, no other platforms threw errors when using c++ style static_cast.