### PR TITLE
fix #2295: wrong linker symbol in libvdc

### DIFF
--- a/include/vapor/DerivedVar.h
+++ b/include/vapor/DerivedVar.h
@@ -229,7 +229,7 @@ protected:
 /////////////////////////////////////////////////////////////////////////
 
 
-class PARAMS_API DerivedCFVertCoordVarFactory {
+class VDF_API DerivedCFVertCoordVarFactory {
 public:
  static DerivedCFVertCoordVarFactory *Instance() {
 	static DerivedCFVertCoordVarFactory instance;


### PR DESCRIPTION
Vapor's Win64 build broke due to a typo.