### PR TITLE
Progress Status Bar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,11 +472,11 @@ jobs:
 workflows:
   build:
     jobs:
-      - build_ubuntu18
+      #- build_ubuntu18
       #- build_ubuntu16
       #- build_centos7
       #- build_osx
-      #- build_win10_installer
+      - build_win10_installer
       #- test_win10_workspace
       #- release_on_github:
       #    requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,11 +472,11 @@ jobs:
 workflows:
   build:
     jobs:
-      #- build_ubuntu18
+      - build_ubuntu18
       #- build_ubuntu16
       #- build_centos7
       #- build_osx
-      - build_win10_installer
+      #- build_win10_installer
       #- test_win10_workspace
       #- release_on_github:
       #    requires:
@@ -487,9 +487,9 @@ workflows:
       #- build_centos7_installer
       #- build_osx_installer
       #- build_win10_installer
-      - release_on_github:
-          requires:
-            - build_win10_installer
+      #- release_on_github:
+      #    requires:
+      #      - build_win10_installer
       #      - build_ubuntu16_installer
       #      - build_ubuntu18_installer
       #      - build_centos7_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,9 +487,9 @@ workflows:
       #- build_centos7_installer
       #- build_osx_installer
       #- build_win10_installer
-      #- release_on_github:
-      #    requires:
-      #      - build_win10_installer
+      - release_on_github:
+          requires:
+            - build_win10_installer
       #      - build_ubuntu16_installer
       #      - build_ubuntu18_installer
       #      - build_centos7_installer

--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -31,6 +31,7 @@ set (SRCS
 	SettingsParams.cpp
 	main.cpp
 	MainForm.cpp
+	MainForm_isOpenGLContextActive.cpp
     VizWin.cpp
 	VizWinMgr.cpp
 	TabManager.cpp

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -84,6 +84,10 @@
 #include "MouseModeParams.h"
 #include "ParamsWidgetDemo.h"
 
+#include <QProgressDialog>
+#include <QOpenGLContext>
+#include <vapor/Progress.h>
+
 //Following shortcuts are provided:
 // CTRL_N: new session
 // CTRL_O: open session
@@ -371,7 +375,9 @@ MainForm::MainForm(
 
     createMenus();
 
-	createToolBars();	
+	createToolBars();
+    
+    _createProgressWidget();
 	
 	addMouseModes();
     (void)statusBar();
@@ -719,6 +725,76 @@ void MainForm::createToolBars(){
 	_createAnimationToolBar();
 	_createVizToolBar();
 	
+}
+
+void MainForm::_createProgressWidget()
+{
+    if (_progressEnabled)
+        return;
+    
+    // The modal version adds an animation that takes a little less than
+    // a second however on OSX the non-modal version is broken.
+    
+    if (!_progressDialog) {
+        _progressDialog = new QProgressDialog("Title", "Cancel", 0, 100, this);
+        _progressDialog->close();
+        _progressDialog->setWindowModality(Qt::WindowModal);
+        _progressDialog->setAutoClose(false);
+        _progressDialog->setMinimumDuration(1500);
+    }
+    
+    Progress::Start_t start = [this](const std::string &name, long total, bool cancelable)
+    {
+        if (QOpenGLContext::currentContext() && _progressSavedFB < 0) {
+            glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &_progressSavedFB);
+            glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        }
+        
+        _progressDialog->reset();
+        if (cancelable)
+            _progressDialog->setCancelButtonText(QString("Cancel"));
+        else
+            _progressDialog->setCancelButton(nullptr);
+        _progressDialog->setLabelText(QString::fromStdString(name));
+        _progressDialog->setValue(0);
+        _progressDialog->setMaximum(total);
+    };
+    
+    Progress::Finish_t finish = [this]()
+    {
+        _progressDialog->close();
+        
+        if (QOpenGLContext::currentContext() && _progressSavedFB >= 0) {
+            glBindFramebuffer(GL_FRAMEBUFFER, _progressSavedFB);
+            _progressSavedFB = -1;
+        }
+    };
+    
+    Progress::Update_t update = [this, finish](long done, bool *cancelled)
+    {
+        _progressDialog->setValue(done);
+        if (_progressDialog->wasCanceled()) {
+            *cancelled = true;
+            finish();
+        }
+    };
+    
+    Progress::SetHandlers(start, update, finish);
+    _progressEnabled = true;
+    if (_progressEnabledMenuItem)
+        _progressEnabledMenuItem->setChecked(true);
+}
+
+void MainForm::_disableProgressWidget()
+{
+    if (!_progressEnabled)
+        return;
+    
+    Progress::Finish();
+    Progress::SetHandlers([](const string&, long, bool){}, [](long,bool*){}, [](){});
+    _progressEnabled = false;
+    if (_progressEnabledMenuItem)
+        _progressEnabledMenuItem->setChecked(false);
 }
 
 void MainForm::hookupSignals() {
@@ -1135,6 +1211,19 @@ void MainForm::_createDeveloperMenu()
     
     _developerMenu = menuBar()->addMenu("Developer");
     _developerMenu->addAction("Show PWidget Demo", _paramsWidgetDemo, &QWidget::show);
+    
+    
+    QAction *enableProgress = new QAction(QString("Enable Progress Bar"), nullptr);
+    enableProgress->setCheckable(true);
+    enableProgress->setChecked(_progressEnabled);
+    QObject::connect(enableProgress, &QAction::toggled, [this](bool checked){
+        if (checked)
+            _createProgressWidget();
+        else
+            _disableProgressWidget();
+    });
+    _developerMenu->addAction(enableProgress);
+    _progressEnabledMenuItem = enableProgress;
 }
 
 void MainForm::createMenus(){
@@ -1712,12 +1801,14 @@ void MainForm::_setAnimationOnOff(bool on) {
 		enableAnimationWidgets(false);
 
 		_App->removeEventFilter(this);
+        _disableProgressWidget(); // Need to disable as popup prevents users from pressing pause
 	}
 	else  {
 		_playForwardAction->setChecked(false);
 		_playBackwardAction->setChecked(false);
 		enableAnimationWidgets(true);
 		_App->installEventFilter(this);
+        _createProgressWidget();
 
 		// Generate an event and force an update
 		//

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1885,20 +1885,12 @@ void MainForm::_setAnimationOnOff(bool on) {
 		enableAnimationWidgets(false);
 
 		_App->removeEventFilter(this);
-//        if (_progressEnabled) {
-//            _disableProgressWidget(); // Need to disable as no longer have event filter
-//            _needToReenableProgressAfterAnimation = true;
-//        }
 	}
 	else  {
 		_playForwardAction->setChecked(false);
 		_playBackwardAction->setChecked(false);
 		enableAnimationWidgets(true);
 		_App->installEventFilter(this);
-//        if (_needToReenableProgressAfterAnimation) {
-//            _createProgressWidget();
-//            _needToReenableProgressAfterAnimation = false;
-//        }
 
 		// Generate an event and force an update
 		//

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -88,7 +88,6 @@
 #include <QProgressBar>
 #include <QToolButton>
 #include <QStyle>
-#include <QOpenGLContext>
 #include <vapor/Progress.h>
 
 //Following shortcuts are provided:
@@ -828,7 +827,7 @@ void MainForm::_createProgressWidget()
         _progressLastUpdateTime = now;
         
         // Qt will clear the currently bound framebuffer for some reason
-        bool insideOpenGL = (bool)QOpenGLContext::currentContext();
+        bool insideOpenGL = isOpenGLContextActive();
         if (insideOpenGL && _progressSavedFB < 0) {
             glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &_progressSavedFB);
             glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -52,6 +52,7 @@ class QMdiArea;
 class QDockWindow;
 class QLabel;
 class QSpinBox;
+class QProgressDialog;
 
 class VizWindow;
 class VizWinMgr;
@@ -174,6 +175,11 @@ private:
  QAction* _stepBackAction;
  QSpinBox* _interactiveRefinementSpin;
  QDockWidget* _tabDockWindow;
+    
+ QProgressDialog *_progressDialog = nullptr;
+ int _progressSavedFB = -1;
+ bool _progressEnabled = false;
+ QAction *_progressEnabledMenuItem = nullptr;;
 
  Statistics *_stats;
  Plot *_plot;
@@ -304,6 +310,8 @@ private:
  void _createAnimationToolBar();
  void _createVizToolBar();
  void createToolBars();
+ void _createProgressWidget();
+ void _disableProgressWidget();
  virtual void sessionOpenHelper(string fileName);
     
  template<class T> bool isDatasetValidFormat(const std::vector<std::string> &paths) const;

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -53,6 +53,7 @@ class QDockWindow;
 class QLabel;
 class QSpinBox;
 class QProgressDialog;
+class QProgressBar;
 
 class VizWindow;
 class VizWinMgr;
@@ -179,14 +180,21 @@ private:
  QProgressDialog *_progressDialog = nullptr;
  int _progressSavedFB = -1;
  bool _progressEnabled = false;
- QAction *_progressEnabledMenuItem = nullptr;;
+ bool _needToReenableProgressAfterAnimation = false;
+ QAction *_progressEnabledMenuItem = nullptr;
+    
+    QProgressBar *_progressBar = nullptr;
+    QLabel *_test = nullptr;
+    QWidget *_status = nullptr;
+    std::chrono::time_point<std::chrono::system_clock> _progressLastUpdateTime;
+    const QObject * _disableUserInputForAllExcept = nullptr;
+    bool _insideMessedUpQtEventLoop = false;
 
  Statistics *_stats;
  Plot *_plot;
  PythonVariables *_pythonVariables;
  BannerGUI* _banner;
  VizSelectCombo* _windowSelector;
- QLabel* _modeStatusWidget;
  VAPoR::ControlExec* _controlExec;
  VAPoR::ParamsMgr *_paramsMgr;
  TabManager *_tabMgr;

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -52,8 +52,7 @@ class QMdiArea;
 class QDockWindow;
 class QLabel;
 class QSpinBox;
-class QProgressDialog;
-class QProgressBar;
+class ProgressStatusBar;
 
 class VizWindow;
 class VizWinMgr;
@@ -177,15 +176,12 @@ private:
  QSpinBox* _interactiveRefinementSpin;
  QDockWidget* _tabDockWindow;
     
- QProgressDialog *_progressDialog = nullptr;
  int _progressSavedFB = -1;
  bool _progressEnabled = false;
  bool _needToReenableProgressAfterAnimation = false;
  QAction *_progressEnabledMenuItem = nullptr;
     
-    QProgressBar *_progressBar = nullptr;
-    QLabel *_test = nullptr;
-    QWidget *_status = nullptr;
+    ProgressStatusBar *_status = nullptr;
     std::chrono::time_point<std::chrono::system_clock> _progressLastUpdateTime;
     const QObject * _disableUserInputForAllExcept = nullptr;
     bool _insideMessedUpQtEventLoop = false;

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -53,6 +53,7 @@ class QDockWindow;
 class QLabel;
 class QSpinBox;
 class ProgressStatusBar;
+class QTimer;
 
 class VizWindow;
 class VizWinMgr;

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -322,6 +322,7 @@ private:
  template<class T> bool isDatasetValidFormat(const std::vector<std::string> &paths) const;
  bool determineDatasetFormat(const std::vector<std::string> &paths, std::string *fmt) const;
 
+ bool isOpenGLContextActive() const;
 
  // Enable/Disable all the widgets that require data to be present
  //

--- a/apps/vaporgui/MainForm_isOpenGLContextActive.cpp
+++ b/apps/vaporgui/MainForm_isOpenGLContextActive.cpp
@@ -1,0 +1,10 @@
+#include "MainForm.h"
+#include <QOpenGLContext>
+
+// This is to address a warning caused by QOpenGLContext and vapor/glutil.h
+// being imported in the same file.
+
+bool MainForm::isOpenGLContextActive() const
+{
+    return (bool)QOpenGLContext::currentContext();
+}

--- a/apps/vaporgui/VizWin.cpp
+++ b/apps/vaporgui/VizWin.cpp
@@ -647,6 +647,7 @@ void VizWin::setFocus(){
 }
 
 void VizWin::Render(bool fast) {
+    // Failsafe to prevent VizWin::Render from being called recursively.
     if (_insideRender)
         return;
     _insideRender = true;

--- a/apps/vaporgui/VizWin.cpp
+++ b/apps/vaporgui/VizWin.cpp
@@ -647,6 +647,14 @@ void VizWin::setFocus(){
 }
 
 void VizWin::Render(bool fast) {
+    if (_insideRender)
+        return;
+    _insideRender = true;
+    _renderHelper(fast);
+    _insideRender = false;
+}
+
+void VizWin::_renderHelper(bool fast) {
 	// Need to call since we're not overriding QGLWidget::paintGL()
 	//
 	makeCurrent();

--- a/apps/vaporgui/VizWin.h
+++ b/apps/vaporgui/VizWin.h
@@ -100,6 +100,7 @@ public slots:
 
 private:
 
+    void _renderHelper(bool fast);
 	void updateManip(bool initialize=false);
 
     //Event handling
@@ -132,6 +133,7 @@ private:
 	VAPoR::ControlExec* _controlExec;
     VAPoR::GLManager *_glManager;
 	double _strHandleMid[3];
+    bool _insideRender = false;
 	
 	bool _mouseClicked;  //Indicates mouse has been clicked but not move
 	int _buttonNum; // currently pressed button (0=none, 1=left,2=mid, 3=right)

--- a/apps/vaporgui/VizWinMgr.cpp
+++ b/apps/vaporgui/VizWinMgr.cpp
@@ -345,11 +345,24 @@ void VizWinMgr::_vizAboutToDisappear(string vizName)  {
 
 
 void VizWinMgr::Update(bool fast){
-
+    // Certain actions queue multiple renders within Qt's event queue (e.g. changing the
+    // renderer variable dimension). Normally, Qt will then process each of these events
+    // sequentially and render multiple times. While not ideal, this just results in extra
+    // renders and computation time. When using the progress bar, however, it sometimes
+    // requests a redraw of the entire GUI at which point Qt processes queued events.
+    // When you have pending render events, it will now try to initiate a new render
+    // before the first has finished. This prevents that but it does not fix the
+    // underlying issue.
+    if (_insideRender)
+        return;
+    _insideRender = true;
+    
 	map<string, VizWin*>::const_iterator it;
 	for (it = _vizWindow.begin(); it != _vizWindow.end(); it++){
 		(it->second)->Render(fast);
 	}
+    
+    _insideRender = false;
 }
 
 int VizWinMgr::EnableImageCapture(string filename, string winName)

--- a/apps/vaporgui/VizWinMgr.h
+++ b/apps/vaporgui/VizWinMgr.h
@@ -146,6 +146,7 @@ private:
  VAPoR::ControlExec* _controlExec;
  Trackball *_trackBall;
  bool _initialized;
+ bool _insideRender = false;
 
  void _attachVisualizer(string vizName);
 

--- a/include/vapor/Progress.h
+++ b/include/vapor/Progress.h
@@ -1,9 +1,10 @@
 #pragma once
 #include <string>
 #include <functional>
+#include <vapor/common.h>
 
 namespace VAPoR {
-class Progress {
+class COMMON_API Progress {
 public:
     typedef std::function<void(const std::string&, long, bool)> Start_t;
     typedef std::function<void(long, bool*)> Update_t;

--- a/include/vapor/Progress.h
+++ b/include/vapor/Progress.h
@@ -4,20 +4,44 @@
 #include <vapor/common.h>
 
 namespace VAPoR {
+
+//! \class Progress
+//! Used for displaying the progress of actions to the user. The actual method
+//! for displaying the progress can vary based on the callback.
+//!
+//! The situations where this should be used is top-level calculations
+//! that may take longer than a second. This should not be used (although
+//! it will not break) for non-top level calculations, i.e. in the DC library
+//! as typically loading data will be part of a higher-level calculation.
+//!
+//! The primary use case would be a renderer that has to precompute data, e.g.
+//! the Flow renderer computing particle advection.
+
 class COMMON_API Progress {
 public:
-    typedef std::function<void(const std::string&, long, bool)> Start_t;
-    typedef std::function<void(long, bool*)> Update_t;
+    typedef std::function<void(const std::string& name, long nTotal, bool cancellable)> Start_t;
+    typedef std::function<void(long nDone, bool* cancelled)> Update_t;
     typedef std::function<void()> Finish_t;
     
+    //! Signifies the beginning of a computation called "name" with "total" elements
+    //! Can be called multiple times to signifiy a series of computations but must
+    //! always end with a Finish
     static void Start(const std::string &name, long total, bool cancelable=false);
+    //! Same as start but the progress is unknown. Update(0) still needs to be called periodically
     static void StartIndefinite(const std::string &name, bool cancelable=false);
+    //! Update the progress status.
     static void Update(long completed);
+    //! If Start was called with cancelled=true, the user will have the option to cancel
+    //! the computation.
     static inline bool Cancelled() { return _cancelled; }
+    //! Signify the computation was cancelled.
     static void Finish();
+    //! This class does not handle actually displaying progress information to
+    //! the user. The interface (e.g. vaporgui) must set callbacks to accomplish this.
     static void SetHandlers(Start_t start, Update_t update, Finish_t finish);
     
 #ifndef NDEBUG
+    //! For testing purposes only.
     static void Sleep(double s);
 #endif
     

--- a/include/vapor/Progress.h
+++ b/include/vapor/Progress.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <string>
+#include <functional>
+
+namespace VAPoR {
+class Progress {
+public:
+    typedef std::function<void(const std::string&, long, bool)> Start_t;
+    typedef std::function<void(long, bool*)> Update_t;
+    typedef std::function<void()> Finish_t;
+    
+    static void Start(const std::string &name, long total, bool cancelable=false);
+    static void Update(long completed);
+    static inline bool Cancelled() { return _cancelled; }
+    static void Finish();
+    static void SetHandlers(Start_t start, Update_t update, Finish_t finish);
+    
+private:
+    static bool _cancelled;
+    static long _total;
+    
+    static Start_t  _start;
+    static Update_t _update;
+    static Finish_t _finish;
+};
+}

--- a/include/vapor/Progress.h
+++ b/include/vapor/Progress.h
@@ -16,6 +16,10 @@ public:
     static void Finish();
     static void SetHandlers(Start_t start, Update_t update, Finish_t finish);
     
+#ifndef NDEBUG
+    static void Sleep(double s);
+#endif
+    
 private:
     static bool _cancelled;
     static long _total;

--- a/include/vapor/Progress.h
+++ b/include/vapor/Progress.h
@@ -10,6 +10,7 @@ public:
     typedef std::function<void()> Finish_t;
     
     static void Start(const std::string &name, long total, bool cancelable=false);
+    static void StartIndefinite(const std::string &name, bool cancelable=false);
     static void Update(long completed);
     static inline bool Cancelled() { return _cancelled; }
     static void Finish();

--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -1,5 +1,4 @@
 configure_file (CMakeConfig.cpp.in CMakeConfig.cpp)
-
 set (SRC
 	common.cpp
 	MyBase.cpp
@@ -15,6 +14,7 @@ set (SRC
 	LegacyVectorMath.cpp
 	STLUtils.cpp
 	VAssert.cpp
+	Progress.cpp
 	${CMAKE_CURRENT_BINARY_DIR}/CMakeConfig.cpp
 )
 
@@ -36,6 +36,7 @@ set (HEADERS
     ${PROJECT_SOURCE_DIR}/include/vapor/STLUtils.h
     ${PROJECT_SOURCE_DIR}/include/vapor/NonCopyableMixin.h
 	${PROJECT_SOURCE_DIR}/include/vapor/VAssert.h
+	${PROJECT_SOURCE_DIR}/include/vapor/Progress.h
 )
 
 add_library (common SHARED ${SRC} ${HEADERS})

--- a/lib/common/Progress.cpp
+++ b/lib/common/Progress.cpp
@@ -1,0 +1,41 @@
+#include <vapor/Progress.h>
+#include <cassert>
+
+using namespace VAPoR;
+
+Progress::Start_t  Progress::_start  = [](const std::string&, long, bool){};
+Progress::Update_t Progress::_update = [](long,bool*){};
+Progress::Finish_t Progress::_finish = [](){};
+
+bool Progress::_cancelled = false;
+long Progress::_total = 1;
+
+void Progress::Start(const std::string &name, long total, bool cancelable)
+{
+    _start(name, total, cancelable);
+    _cancelled = false;
+    _total = total;
+}
+
+void Progress::Update(long completed)
+{
+    if (_total > 100 && completed % (_total/100) != 0 && completed != 0)
+        return;
+    _update(completed, &_cancelled);
+}
+
+void Progress::Finish()
+{
+    _finish();
+}
+
+void Progress::SetHandlers(Start_t start, Update_t update, Finish_t finish)
+{
+    assert((bool)start);
+    assert((bool)update);
+    assert((bool)finish);
+    
+    _start = start;
+    _update = update;
+    _finish = finish;
+}

--- a/lib/common/Progress.cpp
+++ b/lib/common/Progress.cpp
@@ -17,6 +17,11 @@ void Progress::Start(const std::string &name, long total, bool cancelable)
     _total = total;
 }
 
+void Progress::StartIndefinite(const std::string &name, bool cancelable)
+{
+    Progress::Start(name, 0, cancelable);
+}
+
 void Progress::Update(long completed)
 {
     if (_total > 100 && completed % (_total/100) != 0 && completed != 0)

--- a/lib/common/Progress.cpp
+++ b/lib/common/Progress.cpp
@@ -44,3 +44,11 @@ void Progress::SetHandlers(Start_t start, Update_t update, Finish_t finish)
     _update = update;
     _finish = finish;
 }
+
+#ifndef NDEBUG
+#include <unistd.h>
+void Progress::Sleep(double s)
+{
+    usleep(s * 1e6L);
+}
+#endif

--- a/lib/render/FlowRenderer.cpp
+++ b/lib/render/FlowRenderer.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <cstring>
 #include <random>
+#include <vapor/Progress.h>
 
 #define GL_ERROR     -20
 
@@ -297,11 +298,24 @@ FlowRenderer::_paintGL( bool fast )
             if( params->GetFlowDirection() == 1 )           // backward integration
                 deltaT *= -1.0f;
             int numOfSteps = params->GetSteadyNumOfSteps();
+            int total = numOfSteps - (_advection.GetMaxNumOfPart() - 1);
+            int done = 0;
+            
+            if(_2ndAdvection)
+                total += numOfSteps - (_2ndAdvection->GetMaxNumOfPart() - 1);
+                
+            
+            Progress::Start("Advect particles", total, true);
             for( size_t i = _advection.GetMaxNumOfPart() - 1;  // existing number of advection steps 
                  i < numOfSteps && rv == flow::ADVECT_HAPPENED; i++ )
             {
+                Progress::Update(done++);
+                if (Progress::Cancelled())
+                    return 0;
                 rv = _advection.AdvectOneStep( &_velocityField, deltaT );
             }
+            if (!_2ndAdvection)
+                Progress::Finish();
 
             /* If the advection is bi-directional */
             if( _2ndAdvection )
@@ -312,8 +326,12 @@ FlowRenderer::_paintGL( bool fast )
                 for( size_t i = _2ndAdvection->GetMaxNumOfPart() - 1; 
                      i < numOfSteps && rv == flow::ADVECT_HAPPENED; i++ )
                 {
+                    Progress::Update(done++);
+                    if (Progress::Cancelled())
+                        return 0;
                     rv = _2ndAdvection->AdvectOneStep( &_velocityField, deltaT2 );
                 }
+                Progress::Finish();
             }
 
         }

--- a/lib/render/VolumeCellTraversal.cpp
+++ b/lib/render/VolumeCellTraversal.cpp
@@ -177,7 +177,7 @@ int VolumeCellTraversal::LoadData(const Grid *grid)
         return -1;
     }
     
-    Progress::Start("Load coord data", nCoords, true);
+    Progress::Start("Load coord data", nCoords);
     auto coord = grid->ConstCoordBegin();
     for (size_t i = 0; i < nCoords; ++i, ++coord) {
         Progress::Update(i);
@@ -209,7 +209,7 @@ int VolumeCellTraversal::LoadData(const Grid *grid)
     int ch = h-1;
     int cd = d-1;
     
-    Progress::Start("Compute acceleration data", 6, true);
+    Progress::Start("Compute acceleration data", 6);
     ComputeSideBBoxes(F_LEFT,  1, 2, boxMins, boxMaxs, data, ivec3(cw, ch, cd), ivec3(w, h, d), bd, sd);
     Progress::Update(1);
     ComputeSideBBoxes(F_RIGHT, 1, 2, boxMins, boxMaxs, data, ivec3(cw, ch, cd), ivec3(w, h, d), bd, sd);
@@ -254,7 +254,7 @@ int VolumeCellTraversal::LoadData(const Grid *grid)
     mipDims[0][FI_FRONT] = ivec2(cw, cd);
     mipDims[0][FI_BACK]  = ivec2(cw, cd);
     
-    Progress::Start("Generate tree", levels, true);
+    Progress::Start("Generate tree", levels);
     for (int level = 1; level < levels; level++) {
         Progress::Update(level);
         int ms = bd >> level;

--- a/lib/render/VolumeCellTraversal.cpp
+++ b/lib/render/VolumeCellTraversal.cpp
@@ -6,6 +6,7 @@
 #include <glm/glm.hpp>
 #include <vapor/GLManager.h>
 #include <vapor/ShaderManager.h>
+#include <vapor/Progress.h>
 
 #ifndef FLT16_MAX
 #define FLT16_MAX 6.55E4
@@ -176,12 +177,15 @@ int VolumeCellTraversal::LoadData(const Grid *grid)
         return -1;
     }
     
+    Progress::Start("Load coord data", nCoords, true);
     auto coord = grid->ConstCoordBegin();
     for (size_t i = 0; i < nCoords; ++i, ++coord) {
+        Progress::Update(i);
         data[i*3  ] = (*coord)[0];
         data[i*3+1] = (*coord)[1];
         data[i*3+2] = (*coord)[2];
     }
+    Progress::Finish();
     
     _coordTexture.TexImage(GL_RGB32F, dims[0], dims[1], dims[2], GL_RGB, GL_FLOAT, data);
     
@@ -205,12 +209,19 @@ int VolumeCellTraversal::LoadData(const Grid *grid)
     int ch = h-1;
     int cd = d-1;
     
+    Progress::Start("Compute acceleration data", 6, true);
     ComputeSideBBoxes(F_LEFT,  1, 2, boxMins, boxMaxs, data, ivec3(cw, ch, cd), ivec3(w, h, d), bd, sd);
+    Progress::Update(1);
     ComputeSideBBoxes(F_RIGHT, 1, 2, boxMins, boxMaxs, data, ivec3(cw, ch, cd), ivec3(w, h, d), bd, sd);
+    Progress::Update(2);
     ComputeSideBBoxes(F_UP,    0, 1, boxMins, boxMaxs, data, ivec3(cw, ch, cd), ivec3(w, h, d), bd, sd);
+    Progress::Update(3);
     ComputeSideBBoxes(F_DOWN,  0, 1, boxMins, boxMaxs, data, ivec3(cw, ch, cd), ivec3(w, h, d), bd, sd);
+    Progress::Update(4);
     ComputeSideBBoxes(F_FRONT, 0, 2, boxMins, boxMaxs, data, ivec3(cw, ch, cd), ivec3(w, h, d), bd, sd);
+    Progress::Update(5);
     ComputeSideBBoxes(F_BACK,  0, 2, boxMins, boxMaxs, data, ivec3(cw, ch, cd), ivec3(w, h, d), bd, sd);
+    Progress::Finish();
     
     int levels = 1;
     int size = bd;
@@ -243,7 +254,9 @@ int VolumeCellTraversal::LoadData(const Grid *grid)
     mipDims[0][FI_FRONT] = ivec2(cw, cd);
     mipDims[0][FI_BACK]  = ivec2(cw, cd);
     
+    Progress::Start("Generate tree", levels, true);
     for (int level = 1; level < levels; level++) {
+        Progress::Update(level);
         int ms = bd >> level;
         int mUpS = sizes[level-1];
         
@@ -332,6 +345,7 @@ int VolumeCellTraversal::LoadData(const Grid *grid)
         _minTexture.TexImage(GL_RGB32F, ms, ms, 6, GL_RGB, GL_FLOAT, minMip[level], level);
         _maxTexture.TexImage(GL_RGB32F, ms, ms, 6, GL_RGB, GL_FLOAT, maxMip[level], level);
     }
+    Progress::Finish();
     
     _BBLevelDimTexture.TexImage(GL_RG32I, 6, levels, 0, GL_RG_INTEGER, GL_INT, mipDims.data());
     

--- a/lib/render/VolumeRegular.cpp
+++ b/lib/render/VolumeRegular.cpp
@@ -3,6 +3,7 @@
 #include <vapor/glutil.h>
 #include <glm/glm.hpp>
 #include <vapor/GLManager.h>
+#include <vapor/Progress.h>
 
 using std::vector;
 
@@ -61,10 +62,17 @@ int VolumeRegular::_loadDataDirect(const Grid *grid, Texture3D *dataTexture, Tex
         return -1;
     }
     
+    Progress::Start("Load volume data", nVerts, true);
     auto dataIt = grid->cbegin();
     for (size_t i = 0; i < nVerts; ++i, ++dataIt) {
+        Progress::Update(i);
+        if (Progress::Cancelled()) {
+            delete [] data;
+            return -1;
+        }
         data[i] = *dataIt;
     }
+    Progress::Finish();
     
     dataTexture->TexImage(GL_R32F, dims[0], dims[1], dims[2], GL_RED, GL_FLOAT, data);
     

--- a/lib/render/WireFrameRenderer.cpp
+++ b/lib/render/WireFrameRenderer.cpp
@@ -34,6 +34,7 @@
 #include <vapor/ControlExecutive.h>
 #include "vapor/GLManager.h"
 #include "vapor/debug.h"
+#include <vapor/Progress.h>
 
 using namespace VAPoR;
 
@@ -188,8 +189,11 @@ void WireFrameRenderer::_buildCacheVertices(
     Grid::ConstNodeIterator nodeEnd = grid->ConstNodeEnd();
     Grid::ConstCoordItr coordItr = grid->ConstCoordBegin();
     Grid::ConstCoordItr coordEnd = grid->ConstCoordEnd();
-	for (; nodeItr != nodeEnd; ++nodeItr, ++coordItr) {
+    Progress::Start("Load Grid", numNodes);
+    long done = 0;
+    for (; nodeItr != nodeEnd; ++nodeItr, ++coordItr, ++done) {
 
+        Progress::Update(done);
 	
 		// Get current node's coordinates
 		//
@@ -280,8 +284,12 @@ size_t WireFrameRenderer::_buildCacheConnectivity(
 		//
 		Grid::ConstCellIterator cellItr = grid->ConstCellBegin();
 		Grid::ConstCellIterator cellEnd = grid->ConstCellEnd();
-		for (; cellItr != cellEnd; ++cellItr)
+        Progress::Start("Generate Connectivity", numCells, true);
+		for (int done = 0; cellItr != cellEnd; ++cellItr, ++done)
 		{
+            Progress::Update(done);
+            if (Progress::Cancelled())
+                return 0;
 			int numNodes;
 			grid->GetCellNodes((*cellItr).data(), cellNodeIndices.data(), numNodes);
 
@@ -368,6 +376,8 @@ int WireFrameRenderer::_buildCache()
 
 	if (grid) delete grid;
 	if (heightGrid) delete heightGrid;
+    
+    Progress::Finish();
 	return 0;
 
 }
@@ -377,6 +387,11 @@ int WireFrameRenderer::_paintGL(bool fast)
     int rc = 0;
     if (_isCacheDirty())
         rc = _buildCache();
+    
+    if (Progress::Cancelled()) {
+        _cacheParams.varName = "";
+        return 0;
+    }
     
     if (_GPUOutOfMemory) {
         SetErrMsg("GPU out of memory");


### PR DESCRIPTION
Partly because of how Qt is implemented and partly because of how we use Qt, this code commits several atrocities. The consequences are then mitigated by more atrocities. In the end, however, it converges into something that seems to work.

The main issue is that the only way to get this to work is to manually processes Qt's event loop recursively. I later discovered that Qt does this itself on a few occasions (the Qt popup progress bar in the other PR works this way) however it has Band-Aid code in its backend implementation that prevents issues. 

If it ends up being problematic it can all be disabled with one line of code. There is a way to do this without hacks, however the amount of refactoring required would warrant Vapor 4.

With regards to performance, it limits the number of updates to either 100 per calculation or a maximum of 10 progress updates per second, whichever is lower. In my testing, showing the progress bar adds about 5-10% overhead to the computation time when doing a simple calculation with many updates. This would be lower for a heavier calculation with a higher ratio of calculation to progress updates of course. Also, the progress bar is only updated when the user is actively using the application. When rendering a sequence of timesteps, it is disabled.

This PR implements progress bars for the Wireframe, Flow, and Volume renderers.

Some pitfalls:

It sometimes breaks the Fidelity radio buttons but those were always somewhat glitchy (they disappear and reappear on updates) and they are being replaced soon (from my understanding) so I didn't look into fixing it.

I almost had this working for everything, i.e. it would show progress for loading data from disk, populating histograms, etc. however I could not get Qt to behave consistently when doing this and this project was already taking way too long. It would sometimes correctly process the updates and sometimes it would claim to process them but not do anything. Therefore the progress bar is limited to code within the visualizer rendering which works consistently for some reason.

![Progress](https://user-images.githubusercontent.com/2772687/88233177-6d292480-cc34-11ea-8866-1027fd8a7396.gif)
