### PR TITLE
Render timesteps

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -384,7 +384,7 @@ MainForm::MainForm(
 	
 	setUpdatesEnabled(true);
 
-    show();
+//    show();
 
 	// Command line options:
 	//
@@ -421,6 +421,52 @@ MainForm::MainForm(
 
 	_controlExec->SetSaveStateEnabled(true);
 	_controlExec->RebaseStateSave();
+}
+
+int MainForm::RenderAndExit(int start, int end, const std::string &baseFile, int width, int height)
+{
+    start = std::max(0, start);
+    
+    if (_sessionNewFlag) {
+        fprintf(stderr, "No session loaded\n");
+        return -1;
+    }
+    
+    QString dir = QString::fromStdString(FileUtils::Dirname(baseFile));
+    QFileInfo dirInfo(dir);
+    if (!dirInfo.isWritable()) {
+        fprintf(stderr, "Do not have write permissions\n");
+        return -1;
+    }
+    
+    
+    auto baseFileWithTS = FileUtils::RemoveExtension(baseFile) + "-" + to_string(start) + "." + FileUtils::Extension(baseFile);
+    
+    auto ap = GetAnimationParams();
+    auto vpp = _paramsMgr->GetViewpointParams(GetStateParams()->GetActiveVizName());
+    
+    _paramsMgr->BeginSaveStateGroup("test");
+    startAnimCapture(baseFileWithTS);
+    ap->SetStartTimestep(start);
+    ap->SetEndTimestep(end);
+    
+    vpp->SetValueLong(vpp->UseCustomFramebufferTag, "", true);
+    vpp->SetValueLong(vpp->CustomFramebufferWidthTag, "", width);
+    vpp->SetValueLong(vpp->CustomFramebufferHeightTag, "", height);
+    
+    _tabMgr->AnimationPlayForward();
+    _paramsMgr->EndSaveStateGroup();
+    
+    connect(_tabMgr, &TabManager::AnimationOnOffSignal, this, [this](){
+        endAnimCapture();
+        close();
+    });
+    
+    connect(_tabMgr, &TabManager::AnimationDrawSignal, this, [this]() {
+        printf("Rendering timestep %li\n", GetAnimationParams()->GetCurrentTimestep());
+    });
+    
+    return 0;
 }
 
 /*
@@ -2327,25 +2373,25 @@ void MainForm::_setTimeStep()
 void MainForm::captureJpegSequence() {
     string filter = "JPG (*.jpg *.jpeg)";
     string defaultSuffix = "jpg";
-    startAnimCapture( filter, defaultSuffix);
+    selectAnimCatureOutput( filter, defaultSuffix);
 }
 
 void MainForm::capturePngSequence() {
     string filter = "PNG (*.png)";
     string defaultSuffix = "png";
-    startAnimCapture( filter, defaultSuffix);
+    selectAnimCatureOutput( filter, defaultSuffix);
 }
 
 void MainForm::captureTiffSequence() {
     string filter = "TIFF (*.tif *.tiff)";
     string defaultSuffix = "tiff";
-    startAnimCapture( filter, defaultSuffix);
+    selectAnimCatureOutput( filter, defaultSuffix);
 }
 
 //Begin capturing animation images.
 //Launch a file save dialog to specify the names
 //Then start file saving mode.
-void MainForm::startAnimCapture(
+void MainForm::selectAnimCatureOutput(
     string filter,
     string defaultSuffix
 ) {
@@ -2367,6 +2413,13 @@ void MainForm::startAnimCapture(
 	if (qsl.isEmpty()) 
         return;
     QString fileName = qsl[0];
+    
+    startAnimCapture(fileName.toStdString(), defaultSuffix);
+}
+
+void MainForm::startAnimCapture(string baseFile, string defaultSuffix)
+{
+    QString fileName = QString::fromStdString(baseFile);
 	QFileInfo fileInfo = QFileInfo( fileName );
 
 	QString suffix = fileInfo.suffix();

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -425,6 +425,8 @@ MainForm::MainForm(
 
 int MainForm::RenderAndExit(int start, int end, const std::string &baseFile, int width, int height)
 {
+    if (start == 0 && end == 0)
+        end = INT_MAX;
     start = std::max(0, start);
     
     if (_sessionNewFlag) {

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -73,6 +73,8 @@ public:
  );
  ~MainForm();
 
+    int RenderAndExit(int start, int end, const std::string &baseFile, int width, int height);
+    
 protected:
  bool eventFilter(QObject *obj, QEvent *event);
 
@@ -340,10 +342,8 @@ private slots:
  void captureJpegSequence();
  void captureTiffSequence();
  void capturePngSequence();
- void startAnimCapture(
-    string filter,
-    string defaultSuffix
- );
+ void selectAnimCatureOutput(string filter, string defaultSuffix);
+ void startAnimCapture(string baseFile, string defaultSuffix="tiff");
  void endAnimCapture();
  void captureSingleImage( 
     string filter,

--- a/apps/vaporgui/main.cpp
+++ b/apps/vaporgui/main.cpp
@@ -76,20 +76,23 @@ FILE *OpenLog(string path_var) {
 
 struct opt_t {
     OptionParser::Boolean_T    help;
+    OptionParser::Boolean_T    render;
     OptionParser::IntRange_    renderRange;
     OptionParser::Dimension2D_ resolution;
     char*                      outputPath;
 } opt;
 OptionParser::OptDescRec_T    set_opts[] = {
     {"help",       0,    "",           "Print this message and exit"},
-    {"render",     1,    "0:0",        "Render timesteps a:b for a given session file and exit"},
+    {"render",     0,    "",           "Render a given session file and exit"},
+    {"timesteps",  1,    "0:0",        "Timesteps to render when using -render. Defaults to all timesteps."},
     {"resolution", 1,    "1920x1080",  "Output resolution when using -render"},
     {"output",     1,    "vapor.tiff", "Output image file when using -render. This will be suffixed with the timestep number. Supports tiff, jpg"},
     {NULL}
 };
 OptionParser::Option_T    get_options[] = {
     {"help",       Wasp::CvtToBoolean,     &opt.help, sizeof(opt.help)},
-    {"render",     Wasp::CvtToIntRange,    &opt.renderRange, sizeof(opt.renderRange)},
+    {"render",     Wasp::CvtToBoolean,     &opt.render, sizeof(opt.render)},
+    {"timesteps",  Wasp::CvtToIntRange,    &opt.renderRange, sizeof(opt.renderRange)},
     {"resolution", Wasp::CvtToDimension2D, &opt.resolution, sizeof(opt.resolution)},
     {"output",     Wasp::CvtToString,      &opt.outputPath, sizeof(opt.outputPath)},
     {NULL}
@@ -213,7 +216,7 @@ if (getenv("VAPOR_DEBUG"))
     a.connect( &a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()) );
     
     int estatus = 0;
-    if (opt.renderRange.min != 0 || opt.renderRange.max != 0) {
+    if (opt.render) {
         estatus = mw->RenderAndExit(opt.renderRange.min, opt.renderRange.max, opt.outputPath, opt.resolution.nx, opt.resolution.ny);
     }
     

--- a/include/vapor/FileUtils.h
+++ b/include/vapor/FileUtils.h
@@ -22,6 +22,7 @@ COMMON_API std::string HomeDir();
 COMMON_API std::string Basename(const std::string &path);
 COMMON_API std::string Dirname(const std::string &path);
 COMMON_API std::string Extension(const std::string &path);
+COMMON_API std::string RemoveExtension(const std::string &path);
 COMMON_API std::string POSIXPathToWindows(std::string path);
 COMMON_API std::string POSIXPathToCurrentOS(const std::string &path);
 COMMON_API std::string CleanupPath(std::string path);

--- a/lib/common/FileUtils.cpp
+++ b/lib/common/FileUtils.cpp
@@ -110,6 +110,14 @@ std::string FileUtils::Extension(const std::string &path)
     return basename.substr(index + 1);
 }
 
+std::string FileUtils::RemoveExtension(const std::string &path)
+{
+    const string extension = Extension(path);
+    if (extension.empty())
+        return path;
+    return path.substr(0, path.size()-Extension(path).size() - 1);
+}
+
 std::string FileUtils::POSIXPathToWindows(std::string path)
 {
     std::replace(path.begin(), path.end(), '/', '\\');


### PR DESCRIPTION
Fix #2322

```
> vapor -help
Usage: vapor [options] [session.vs3] [data files...]
    OPTION        NUM_ARGS    DEFAULT
    ------        --------    -------
    -help         0           false
        Print this message and exit
    -output       1           vapor.tiff
        Output image file when using -render. This will be suffixed with the
        timestep number. Supports tiff, jpg
    -render       0           false
        Render a given session file and exit
    -resolution   1           1920x1080
        Output resolution when using -render
    -timesteps    1           0:0
        Timesteps to render when using -render. Defaults to all timesteps.
```