### PR TITLE
Flow Density Rendering

### DIFF
--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -172,6 +172,8 @@ set (SRCS
 	PDisplay.cpp
 	PDisplay.h
 	PDisplayHLI.h
+	PLabel.cpp
+	PLabel.h
 	PLineItem.cpp
 	PLineItem.h
 	PEnumDropdown.cpp

--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -138,7 +138,7 @@ FlowAppearanceSubtab::FlowAppearanceSubtab(QWidget* parent) : QVaporSubtab(paren
     PSection *ps;
     
     _pw->Add(ps = new PSection("Appearance"));
-    ps->Add(new PEnumDropdown(FlowParams::RenderTypeTag, {"Tubes", "Samples", "Density"}, {FlowParams::RenderTypeStream, FlowParams::RenderTypeSamples, FlowParams::RenderTypeDensity}, "Render Type"));
+    ps->Add(new PEnumDropdown(FlowParams::RenderTypeTag, {"Tubes", "Samples", "KLGWTH"}, {FlowParams::RenderTypeStream, FlowParams::RenderTypeSamples, FlowParams::RenderTypeDensity}, "Render Type"));
     ps->Add((new PLabel("May not render correctly with other renderers"))->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeDensity));
     ps->Add((new PEnumDropdown(FlowParams::RenderGlyphTypeTag, {"Circle", "Arrow"}, {FlowParams::GlpyhTypeSphere, FlowParams::GlpyhTypeArrow}, "Glyph Type"))->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeSamples));
     ps->Add((new PCheckbox(FlowParams::RenderGeom3DTag, "3D Geometry"))->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeStream));
@@ -181,8 +181,8 @@ FlowAppearanceSubtab::FlowAppearanceSubtab(QWidget* parent) : QVaporSubtab(paren
     PGroup *densityGroup = new PGroup;
     densityGroup->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeDensity);
     ps->Add(densityGroup);
-    densityGroup->Add((new PDoubleSliderEdit(FlowParams::RenderDensityFalloffTag, "Density Falloff"))->SetRange(0.5, 10)->EnableDynamicUpdate());
-    densityGroup->Add((new PDoubleSliderEdit(FlowParams::RenderDensityToneMappingTag, "Tone Mapping"))->SetRange(0, 1)->EnableDynamicUpdate());
+    densityGroup->Add((new PDoubleSliderEdit(FlowParams::RenderDensityFalloffTag, "Density Falloff"))->SetRange(0.5, 10)->EnableDynamicUpdate()->SetTooltip("The exponential factor at which the intensity falls off along the width of the line"));
+    densityGroup->Add((new PDoubleSliderEdit(FlowParams::RenderDensityToneMappingTag, "Tone Mapping"))->SetRange(0, 1)->EnableDynamicUpdate()->SetTooltip("The overall color intensity of the line"));
     densityGroup->Add((new PCheckbox("invert"))->SetTooltip("For rendering on light backgrounds"));
     densityGroup->Add(fadeTailWidget());
     

--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -182,6 +182,7 @@ FlowAppearanceSubtab::FlowAppearanceSubtab(QWidget* parent) : QVaporSubtab(paren
     densityGroup->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeDensity);
     ps->Add(densityGroup);
     densityGroup->Add((new PDoubleSliderEdit(FlowParams::RenderDensityFalloffTag, "Density Falloff"))->SetRange(0.5, 10)->EnableDynamicUpdate());
+    densityGroup->Add((new PDoubleSliderEdit(FlowParams::RenderDensityToneMappingTag, "Tone Mapping"))->SetRange(0, 1)->EnableDynamicUpdate());
     densityGroup->Add((new PCheckbox("invert"))->SetTooltip("For rendering on light backgrounds"));
     densityGroup->Add(fadeTailWidget());
     

--- a/apps/vaporgui/FlowSubtabs.cpp
+++ b/apps/vaporgui/FlowSubtabs.cpp
@@ -21,6 +21,7 @@
 #include "PGroup.h"
 #include "PSection.h"
 #include "PDoubleInput.h"
+#include "PLabel.h"
 
 #include <QScrollArea>
 
@@ -137,9 +138,11 @@ FlowAppearanceSubtab::FlowAppearanceSubtab(QWidget* parent) : QVaporSubtab(paren
     PSection *ps;
     
     _pw->Add(ps = new PSection("Appearance"));
-    ps->Add(new PEnumDropdown(FlowParams::RenderTypeTag, {"Tubes", "Samples"}, {FlowParams::RenderTypeStream, FlowParams::RenderTypeSamples}, "Render Type"));
+    ps->Add(new PEnumDropdown(FlowParams::RenderTypeTag, {"Tubes", "Samples", "Density"}, {FlowParams::RenderTypeStream, FlowParams::RenderTypeSamples, FlowParams::RenderTypeDensity}, "Render Type"));
+    ps->Add((new PLabel("May not render correctly with other renderers"))->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeDensity));
     ps->Add((new PEnumDropdown(FlowParams::RenderGlyphTypeTag, {"Circle", "Arrow"}, {FlowParams::GlpyhTypeSphere, FlowParams::GlpyhTypeArrow}, "Glyph Type"))->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeSamples));
-    ps->Add(new PCheckbox(FlowParams::RenderGeom3DTag, "3D Geometry"));
+    ps->Add((new PCheckbox(FlowParams::RenderGeom3DTag, "3D Geometry"))->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeStream));
+    ps->Add((new PCheckbox(FlowParams::RenderGeom3DTag, "3D Geometry"))->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeSamples));
 //    ps->Add((new PCheckbox(FlowParams::RenderLightAtCameraTag, "Light From Camera"))->ShowBasedOnParam(FlowParams::RenderGeom3DTag));
 //    ps->Add((new PDoubleInput(FlowParams::RenderRadiusBaseTag, "Radius")));
     ps->Add((new PDoubleSliderEdit(FlowParams::RenderRadiusScalarTag, "Radius Scalar"))->SetRange(0.1, 5)->EnableDynamicUpdate());
@@ -155,13 +158,19 @@ FlowAppearanceSubtab::FlowAppearanceSubtab(QWidget* parent) : QVaporSubtab(paren
     streamGroup->Add(showDirGroup);
     showDirGroup->Add((new PIntegerSliderEdit(FlowParams::RenderGlyphStrideTag, "Every N Samples"))->SetRange(1, 20)->EnableDynamicUpdate());
     
-    streamGroup->Add((new PCheckbox(FlowParams::RenderFadeTailTag, "Fade Flow Tails")));
-    PGroup *fadeGroup = new PSubGroup;
-    fadeGroup->ShowBasedOnParam(FlowParams::RenderFadeTailTag);
-    streamGroup->Add(fadeGroup);
-    fadeGroup->Add((new PIntegerSliderEdit(FlowParams::RenderFadeTailStartTag, "Fade Start Sample"))->SetRange(0, 100)->EnableDynamicUpdate()->SetTooltip("How far behind leading sample fade begins."));
-    fadeGroup->Add((new PIntegerSliderEdit(FlowParams::RenderFadeTailLengthTag, "Fade Over N Samples"))->SetRange(1, 100)->EnableDynamicUpdate()->SetTooltip("Number of samples from opaque to transparent."));
-    fadeGroup->Add((new PIntegerSliderEdit(FlowParams::RenderFadeTailStopTag, "Animate Steady"))->SetRange(0, 200)->EnableDynamicUpdate()->SetTooltip("Temporary solution for animating steady flow particles."));
+    auto fadeTailWidget = [](){
+        PGroup *g = new PGroup;
+        g->Add(new PCheckbox(FlowParams::RenderFadeTailTag, "Fade Flow Tails"));
+        PGroup *fadeGroup = new PSubGroup;
+        fadeGroup->ShowBasedOnParam(FlowParams::RenderFadeTailTag);
+        g->Add(fadeGroup);
+        fadeGroup->Add((new PIntegerSliderEdit(FlowParams::RenderFadeTailStartTag, "Fade Start Sample"))->SetRange(0, 100)->EnableDynamicUpdate()->SetTooltip("How far behind leading sample fade begins."));
+        fadeGroup->Add((new PIntegerSliderEdit(FlowParams::RenderFadeTailLengthTag, "Fade Over N Samples"))->SetRange(1, 100)->EnableDynamicUpdate()->SetTooltip("Number of samples from opaque to transparent."));
+        fadeGroup->Add((new PIntegerSliderEdit(FlowParams::RenderFadeTailStopTag, "Animate Steady"))->SetRange(0, 200)->EnableDynamicUpdate()->SetTooltip("Temporary solution for animating steady flow particles."));
+        return g;
+    };
+    
+    streamGroup->Add(fadeTailWidget());
     
     PGroup *sampleGroup = new PGroup;
     sampleGroup->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeSamples);
@@ -169,6 +178,12 @@ FlowAppearanceSubtab::FlowAppearanceSubtab(QWidget* parent) : QVaporSubtab(paren
     sampleGroup->Add((new PIntegerSliderEdit(FlowParams::RenderGlyphStrideTag, "Every N Samples"))->SetRange(1, 20)->EnableDynamicUpdate()->EnableBasedOnParam(FlowParams::RenderGlyphOnlyLeadingTag, false));
     sampleGroup->Add(new PCheckbox(FlowParams::RenderGlyphOnlyLeadingTag, "Only Show Leading Sample"));
     
+    PGroup *densityGroup = new PGroup;
+    densityGroup->ShowBasedOnParam(FlowParams::RenderTypeTag, FlowParams::RenderTypeDensity);
+    ps->Add(densityGroup);
+    densityGroup->Add((new PDoubleSliderEdit(FlowParams::RenderDensityFalloffTag, "Density Falloff"))->SetRange(0.5, 10)->EnableDynamicUpdate());
+    densityGroup->Add((new PCheckbox("invert"))->SetTooltip("For rendering on light backgrounds"));
+    densityGroup->Add(fadeTailWidget());
     
     _pw->Add(ps = new PSection("Lighting"));
     ps->ShowBasedOnParam(FlowParams::RenderGeom3DTag);

--- a/apps/vaporgui/PLabel.cpp
+++ b/apps/vaporgui/PLabel.cpp
@@ -1,0 +1,6 @@
+#include "PLabel.h"
+#include <QLabel>
+
+PLabel::PLabel(const std::string &text)
+: PWidget("", new QLabel(QString::fromStdString(text)))
+{}

--- a/apps/vaporgui/PLabel.h
+++ b/apps/vaporgui/PLabel.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "PWidget.h"
+
+class PLabel : public PWidget {
+public:
+    PLabel(const std::string &text);
+    void updateGUI() const override {}
+};

--- a/include/vapor/FlowParams.h
+++ b/include/vapor/FlowParams.h
@@ -33,7 +33,7 @@ class PARAMS_API FlowParams : public RenderParams
 {
 public:
     
-    enum RenderType { RenderTypeStream, RenderTypeSamples};
+    enum RenderType { RenderTypeStream, RenderTypeSamples, RenderTypeDensity};
     enum GlpyhType { GlpyhTypeSphere, GlpyhTypeArrow };
 
     // Constructors
@@ -138,6 +138,8 @@ public:
     static const std::string RenderGlyphTypeTag;
     static const std::string RenderGlyphStrideTag;
     static const std::string RenderGlyphOnlyLeadingTag;
+    
+    static const std::string RenderDensityFalloffTag;
     
     static const std::string RenderFadeTailTag;
     static const std::string RenderFadeTailStartTag;

--- a/include/vapor/FlowParams.h
+++ b/include/vapor/FlowParams.h
@@ -140,6 +140,7 @@ public:
     static const std::string RenderGlyphOnlyLeadingTag;
     
     static const std::string RenderDensityFalloffTag;
+    static const std::string RenderDensityToneMappingTag;
     
     static const std::string RenderFadeTailTag;
     static const std::string RenderFadeTailStartTag;

--- a/lib/params/FlowParams.cpp
+++ b/lib/params/FlowParams.cpp
@@ -11,6 +11,7 @@ const std::string FlowParams::RenderShowStreamDirTag = "RenderShowStreamDirTag";
 const std::string FlowParams::RenderGlyphTypeTag     = "RenderGlyphTypeTag";
 const std::string FlowParams::RenderGlyphStrideTag   = "RenderGlyphStrideTag";
 const std::string FlowParams::RenderGlyphOnlyLeadingTag = "RenderGlyphOnlyLeadingTag";
+const std::string FlowParams::RenderDensityFalloffTag= "RenderDensityFalloffTag";
 const std::string FlowParams::RenderFadeTailTag      = "RenderFadeTailTag";
 const std::string FlowParams::RenderFadeTailStartTag = "RenderFadeTailStartTag";
 const std::string FlowParams::RenderFadeTailStopTag  = "RenderFadeTailStopTag";
@@ -61,6 +62,8 @@ FlowParams::FlowParams(   DataMgr*                 dataManager,
     SetValueLong(RenderGlyphTypeTag, "", GlpyhTypeSphere);
     SetValueLong(RenderGlyphStrideTag, "", 5);
     SetValueLong(RenderGlyphOnlyLeadingTag, "", false);
+    
+    SetValueDouble(RenderDensityFalloffTag, "", 1);
     
     SetValueLong(RenderFadeTailTag, "", false);
     SetValueLong(RenderFadeTailStartTag, "", 10);

--- a/lib/params/FlowParams.cpp
+++ b/lib/params/FlowParams.cpp
@@ -12,6 +12,7 @@ const std::string FlowParams::RenderGlyphTypeTag     = "RenderGlyphTypeTag";
 const std::string FlowParams::RenderGlyphStrideTag   = "RenderGlyphStrideTag";
 const std::string FlowParams::RenderGlyphOnlyLeadingTag = "RenderGlyphOnlyLeadingTag";
 const std::string FlowParams::RenderDensityFalloffTag= "RenderDensityFalloffTag";
+const std::string FlowParams::RenderDensityToneMappingTag= "RenderDensityToneMappingTag";
 const std::string FlowParams::RenderFadeTailTag      = "RenderFadeTailTag";
 const std::string FlowParams::RenderFadeTailStartTag = "RenderFadeTailStartTag";
 const std::string FlowParams::RenderFadeTailStopTag  = "RenderFadeTailStopTag";
@@ -64,6 +65,7 @@ FlowParams::FlowParams(   DataMgr*                 dataManager,
     SetValueLong(RenderGlyphOnlyLeadingTag, "", false);
     
     SetValueDouble(RenderDensityFalloffTag, "", 1);
+    SetValueDouble(RenderDensityToneMappingTag, "", 1);
     
     SetValueLong(RenderFadeTailTag, "", false);
     SetValueLong(RenderFadeTailStartTag, "", 10);

--- a/lib/render/FlowRenderer.cpp
+++ b/lib/render/FlowRenderer.cpp
@@ -577,6 +577,7 @@ int  FlowRenderer::_renderAdvectionHelper(bool renderDirection)
     
     shader->SetUniform("density", renderType == FlowParams::RenderTypeDensity);
     shader->SetUniform("falloff", (float)rp->GetValueDouble(FlowParams::RenderDensityFalloffTag, 1));
+    shader->SetUniform("tone", (float)rp->GetValueDouble(FlowParams::RenderDensityToneMappingTag, 1));
     
 //    Features supported by shaders but not implemented in GUI/not finished
 //

--- a/lib/render/FlowRenderer.cpp
+++ b/lib/render/FlowRenderer.cpp
@@ -524,7 +524,7 @@ int  FlowRenderer::_renderAdvectionHelper(bool renderDirection)
                 shader = _glManager->shaderManager->GetShader("FlowGlyphsLineDirArrow2D");
             else
                 shader = _glManager->shaderManager->GetShader("FlowLines");
-    } else {
+    } else if (renderType == FlowParams::RenderTypeSamples) {
         if (glyphType == FlowParams::GlpyhTypeSphere)
             if (geom3d)
                 shader = _glManager->shaderManager->GetShader("FlowGlyphsSphereSplat");
@@ -535,6 +535,8 @@ int  FlowRenderer::_renderAdvectionHelper(bool renderDirection)
                 shader = _glManager->shaderManager->GetShader("FlowGlyphsArrow");
             else
                 shader = _glManager->shaderManager->GetShader("FlowGlyphsArrow2D");
+    } else {
+        shader = _glManager->shaderManager->GetShader("FlowLines");
     }
     
     if (!shader) return -1;
@@ -573,6 +575,9 @@ int  FlowRenderer::_renderAdvectionHelper(bool renderDirection)
     shader->SetUniform("fade_length", (int)rp->GetValueLong(FlowParams::RenderFadeTailLengthTag, 10));
     shader->SetUniform("fade_stop", (int)rp->GetValueLong(FlowParams::RenderFadeTailStopTag, 0));
     
+    shader->SetUniform("density", renderType == FlowParams::RenderTypeDensity);
+    shader->SetUniform("falloff", (float)rp->GetValueDouble(FlowParams::RenderDensityFalloffTag, 1));
+    
 //    Features supported by shaders but not implemented in GUI/not finished
 //
 //    shader->SetUniform("constantColorEnabled", false);
@@ -594,6 +599,15 @@ int  FlowRenderer::_renderAdvectionHelper(bool renderDirection)
     glEnable(GL_BLEND);
     glBindVertexArray(_VAO);
     
+    if (renderType == FlowParams::RenderTypeDensity) {
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+        if (rp->GetValueLong("invert", false))
+            glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
+        else
+            glBlendEquation(GL_FUNC_ADD);
+        glDepthMask(GL_FALSE);
+    }
+    
     size_t offset = 0;
     for (int n : _streamSizes) {
         shader->SetUniform("nVertices", n);
@@ -601,6 +615,9 @@ int  FlowRenderer::_renderAdvectionHelper(bool renderDirection)
         offset += n;
     }
 
+    glDepthMask(GL_TRUE);
+    glDisable(GL_BLEND);
+    glBlendEquation(GL_FUNC_ADD);
     glBindVertexArray(0);
     glDisable(GL_CULL_FACE);
     shader->UnBind();

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory (Doxygen)
 
 if (BUILD_VDC)
-	file (GLOB SHADERS_SRC shaders/*.vert shaders/*.frag)
+	file (GLOB SHADERS_SRC shaders/*.vert shaders/*.frag shaders/*.geom)
 	add_custom_target (
 		shaders ALL
 		SOURCES ${SHADERS_SRC}

--- a/share/shaders/FlowLines.frag
+++ b/share/shaders/FlowLines.frag
@@ -10,6 +10,7 @@ uniform float border = 0.f;
 uniform vec3 borderColor = vec3(1.0f);
 uniform bool antiAlias = false;
 uniform float falloff = 1.0f;
+uniform float tone = 1.0f;
 uniform bool density = false;
 
 uniform sampler1D LUT;
@@ -45,8 +46,11 @@ void main()
         color = c;
     }
     
-    if (density)
+    if (density) {
         color.rgb *= vec3(pow(1-abs(t), falloff));
+        // Not exactly correct but will do for now
+        color.rgb = 1-exp(-tone * color.rgb);
+    }
 
     color.a *= fFade;
     if (fFade < 0.05)

--- a/share/shaders/FlowLines.frag
+++ b/share/shaders/FlowLines.frag
@@ -9,6 +9,8 @@ uniform float radius = 0.05f;
 uniform float border = 0.f;
 uniform vec3 borderColor = vec3(1.0f);
 uniform bool antiAlias = false;
+uniform float falloff = 1.0f;
+uniform bool density = false;
 
 uniform sampler1D LUT;
 uniform vec2 mapRange;
@@ -42,6 +44,9 @@ void main()
 
         color = c;
     }
+    
+    if (density)
+        color.rgb *= vec3(pow(1-abs(t), falloff));
 
     color.a *= fFade;
     if (fFade < 0.05)


### PR DESCRIPTION
Implemented the technique in [Trajectory Density Projection for Vector Field Visualization](https://www.researchgate.net/publication/261329939_Trajectory_Density_Projection_for_Vector_Field_Visualization).

After doing so, however, I do not know if it is something we want to add.
- The rendering method means it won't work well (if at all) combined with other renderers
- It requires many particles to look good (from my testing)
- It introduces additional colors outside the colormap
- It can be finicky to get it looking right
- Its appearance is dependent on the background color (i.e. no matter the color of a flow line, it will be completely transparent when passing over a light background. The inverted option fixes this but then it inverts the colors. If you have changing background colors, (e.g. with other renderers present) this will not work).

That being said, as can be seen in the paper, there are scenarios where this technique can be useful.

### Tube Rendering
<img width="532" alt="b" src="https://user-images.githubusercontent.com/2772687/89066892-7b113080-d32b-11ea-9ba4-7652b6084931.png">

### Tube Rendering With Transparency
<img width="529" alt="a" src="https://user-images.githubusercontent.com/2772687/89066898-7e0c2100-d32b-11ea-8b60-39b9d07a7fd4.png">

### Density Rendering
<img width="531" alt="c" src="https://user-images.githubusercontent.com/2772687/89066910-82383e80-d32b-11ea-8907-c34d344630a9.png">

### Another Density Example
<img width="420" alt="d" src="https://user-images.githubusercontent.com/2772687/89066916-85332f00-d32b-11ea-97d1-e49d5485f605.png">
