### PR TITLE
more locks so no simultaneous grid queries to the DataManager

### DIFF
--- a/include/vapor/VaporField.h
+++ b/include/vapor/VaporField.h
@@ -118,6 +118,8 @@ private:
     mutable cacheType           _recentGrids;   // so this variable can be 
                                                 // modified by a const function.
     const std::string           _constantGridZero = "ConstantGrid with zeros";
+    mutable std::mutex          _grid_operation_mutex;  // Use `mutable` qualifier so this
+                                                        // mutex can be used in const methods.
 
     // Member functions
     std::string _paramsToString(  size_t currentTS, const std::string& var, int refLevel, 

--- a/include/vapor/unique_ptr_cache.hpp
+++ b/include/vapor/unique_ptr_cache.hpp
@@ -95,7 +95,7 @@ public:
     // 
     auto query( const Key& key ) -> const std::unique_ptr<const BigObj>&
     {
-        const std::lock_guard<std::mutex> lock( _element_array_mutex );
+        const std::lock_guard<std::mutex> lock_gd( _element_array_mutex );
 
         auto it = std::find_if( _element_array.begin(), _element_array.end(), 
                                 [&key](element_type& e){return e.first == key;} );
@@ -113,7 +113,7 @@ public:
 
     void insert( Key key, const BigObj* ptr )
     {
-        const std::lock_guard<std::mutex> lock( _element_array_mutex );
+        const std::lock_guard<std::mutex> lock_gd( _element_array_mutex );
 
         auto it = std::find_if( _element_array.begin(), _element_array.end(), 
                                 [&key](element_type& e){return e.first == key;} );

--- a/include/vapor/unique_ptr_cache.hpp
+++ b/include/vapor/unique_ptr_cache.hpp
@@ -95,7 +95,7 @@ public:
     // 
     auto query( const Key& key ) -> const std::unique_ptr<const BigObj>&
     {
-        const std::lock_guard<std::mutex> lock( __element_array_mutex );
+        const std::lock_guard<std::mutex> lock( _element_array_mutex );
 
         auto it = std::find_if( _element_array.begin(), _element_array.end(), 
                                 [&key](element_type& e){return e.first == key;} );
@@ -113,7 +113,7 @@ public:
 
     void insert( Key key, const BigObj* ptr )
     {
-        const std::lock_guard<std::mutex> lock( __element_array_mutex );
+        const std::lock_guard<std::mutex> lock( _element_array_mutex );
 
         auto it = std::find_if( _element_array.begin(), _element_array.end(), 
                                 [&key](element_type& e){return e.first == key;} );
@@ -146,7 +146,7 @@ private:
     std::array< element_type, CacheCapacity >   _element_array;
     size_t                                      _current_size = 0;
     const std::unique_ptr<const BigObj>         _local_nullptr = {nullptr};
-    std::mutex                                  __element_array_mutex;
+    std::mutex                                  _element_array_mutex;
 };
 
 }   // End of VAPoR namespace

--- a/lib/flow/VaporField.cpp
+++ b/lib/flow/VaporField.cpp
@@ -475,7 +475,7 @@ const VAPoR::Grid* VaporField::_getAGrid( size_t timestep, const std::string& va
     std::string key = _paramsToString( timestep, varName, refLevel, compLevel, extMin, extMax );
 
     // Use a lock here, so no two threads querying grids simultaneously.
-    const std::lock_guard<std::mutex> lock( _grid_operation_mutex );
+    const std::lock_guard<std::mutex> lock_gd( _grid_operation_mutex );
 
     const auto& grid_wrapper = _recentGrids.query( key );
 

--- a/lib/flow/VaporField.cpp
+++ b/lib/flow/VaporField.cpp
@@ -474,6 +474,9 @@ const VAPoR::Grid* VaporField::_getAGrid( size_t timestep, const std::string& va
     int compLevel   = _params->GetCompressionLevel();
     std::string key = _paramsToString( timestep, varName, refLevel, compLevel, extMin, extMax );
 
+    // Use a lock here, so no two threads querying grids simultaneously.
+    const std::lock_guard<std::mutex> lock( _grid_operation_mutex );
+
     const auto& grid_wrapper = _recentGrids.query( key );
 
     if( grid_wrapper != nullptr ) {


### PR DESCRIPTION
This PR introduces one more use of `mutex` so that there will be no simultaneous query of grids to a DataManager. 