### PR TITLE
Enable CentOS build test on submitted PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,15 +174,6 @@ jobs:
       - store_artifacts:
           path: /tmp/output.txt
 
-      - run:
-          name: check for warnings
-          command: |
-            if grep -q warning /tmp/output.txt; then
-               exit 1
-            else
-               exit 0
-            fi
-
   build_centos7_installer:
     docker:
       - image: sgpearse/vapor3-centos7:latest
@@ -474,8 +465,8 @@ workflows:
   build:
     jobs:
       - build_ubuntu18
+      - build_centos7
       #- build_ubuntu16
-      #- build_centos7
       #- build_osx
       #- build_win10_installer
       #- test_win10_workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,10 +169,7 @@ jobs:
             git checkout $CIRCLE_BRANCH
             cd build
             cmake3 ..
-            make -j7 &> /tmp/output.txt
-
-      - store_artifacts:
-          path: /tmp/output.txt
+            make -j7
 
   build_centos7_installer:
     docker:


### PR DESCRIPTION
This adds the compilation of Vapor on CentOS7 to the tests run on submitted PR's.  With this change, the following checks will be run on CircleCI:

- Build on Ubuntu18
- Check for warnings on Ubuntu18
- Build on CentOS7
