### PR TITLE
Partial support for 3D WRF variables with dimension length of one

### DIFF
--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -2198,15 +2198,15 @@ int DerivedCoordVarStandardWRF_Terrain::GetDimLensAtLevel(
 	if (rc<0) return(-1);
 
 	if (_derivedVarName == "Elevation") {
-		dims[2]--;
+		if (dims[2] > 1) dims[2]--;
 	}
 	else if (_derivedVarName == "ElevationU") {
 		dims[0]++;
-		dims[2]--;
+		if (dims[2] > 1) dims[2]--;
 	}
 	else if (_derivedVarName == "ElevationV") {
 		dims[1]++;
-		dims[2]--;
+		if (dims[2] > 1) dims[2]--;
 	}
 	else if (_derivedVarName == "ElevationW") {
 	}
@@ -2330,37 +2330,36 @@ int DerivedCoordVarStandardWRF_Terrain::ReadRegion(
 	size_t nElements = std::max(numElements(wMin, wMax), numElements(min, max));
 
 
-	float *buf1 = new float[nElements];
+	vector <float> buf1(nElements);
 	rc = _getVar(
 		_dc, f->GetTS(), _PHVar, f->GetLevel(), f->GetLOD(),
-		wMin, wMax, buf1
+		wMin, wMax, buf1.data()
 	);
 	if (rc<0) {
-		delete [] buf1;
 		return(rc);
 	}
 
-	float *buf2 = new float[nElements];
+	vector <float> buf2(nElements);
 	rc = _getVar(
 		_dc, f->GetTS(), _PHBVar, f->GetLevel(), f->GetLOD(),
-		wMin, wMax, buf2
+		wMin, wMax, buf2.data()
 	);
 	if (rc<0) {
-		delete [] buf1;
-		delete [] buf2;
 		return(rc);
 	}
 
 	float *dst = region;
-	if (varname != "ElevationW") {
-		dst = buf1;
+	if (varname != "ElevationW" && wDims[2] > 1) {
+		dst = buf1.data();
 	}
 	
 	// Compute elevation on the W grid
 	//
     for (size_t i=0; i<nElements; i++) {
-        dst[i] = (buf1[i] + buf2[i]) / _grav;
+        dst[i] = (buf1.data()[i] + buf2.data()[i]) / _grav;
     }
+
+	if (wDims[2] < 2) return(0);
 
 	// Elevation is correct for W grid. If we want Elevation, ElevationU, or 
 	// Elevation V grid we need to interpolate
@@ -2371,7 +2370,7 @@ int DerivedCoordVarStandardWRF_Terrain::ReadRegion(
 		// Resample stagged W grid to base grid
 		//
 		resampleToUnStaggered(
-			buf1, wMin, wMax, region, min, max, 2
+			buf1.data(), wMin, wMax, region, min, max, 2
 		);
 	}
 	else if (varname == "ElevationU") {
@@ -2379,11 +2378,11 @@ int DerivedCoordVarStandardWRF_Terrain::ReadRegion(
 		// Resample stagged W grid to base grid
 		//
 		resampleToUnStaggered(
-			buf1, wMin, wMax, buf2, bMin, bMax, 2
+			buf1.data(), wMin, wMax, buf2.data(), bMin, bMax, 2
 		);
 
 		resampleToStaggered(
-			buf2, bMin, bMax, region, min, max, 0
+			buf2.data(), bMin, bMax, region, min, max, 0
 		);
 	}
 	else if (varname == "ElevationV") {
@@ -2391,16 +2390,13 @@ int DerivedCoordVarStandardWRF_Terrain::ReadRegion(
 		// Resample stagged W grid to base grid
 		//
 		resampleToUnStaggered(
-			buf1, wMin, wMax, buf2, bMin, bMax, 2
+			buf1.data(), wMin, wMax, buf2.data(), bMin, bMax, 2
 		);
 
 		resampleToStaggered(
-			buf2, bMin, bMax, region, min, max, 1
+			buf2.data(), bMin, bMax, region, min, max, 1
 		);
 	}
-
-	delete [] buf1;
-	delete [] buf2;
 
 	return(0);
 }


### PR DESCRIPTION
This change allows the calculation of the WRF vertical coordinate when the
vertical dimension of all 3D varibles is of length one. This includes the 
staggered variables (e.g. W, PH, and PHB).