### PR TITLE
Reproduce ImageRenderer Crash

### DIFF
--- a/lib/render/ImageRenderer.cpp
+++ b/lib/render/ImageRenderer.cpp
@@ -509,8 +509,8 @@ unsigned char *ImageRenderer::_getImage(  GeoImage *geoimage,
 
 	// Ugh. Hardcode maximum image size request
 	//
-	const int maxWidthReq = 1024;
-	const int maxHeightReq = 1024;
+	const int maxWidthReq = 10240;
+	const int maxHeightReq = 10240;
 
 	double pcsExtentsData[4];
 	for (int i=0; i<4; i++) {


### PR DESCRIPTION
This demonstrates the crash we are currently seeing in the [Allow the user to specify when TMS images are downsampled](https://github.com/NCAR/VAPOR/pull/2358) PR, with 2 lines of code changed from our master branch's ImageRenderer.cpp file.