### PR TITLE
Closes Issue #1377 - Undo open dataset doesn't fully close it

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1848,6 +1848,10 @@ void MainForm::closeData(string fileName) {
 	// Close data can't be undone
 	//
 	_controlExec->UndoRedoClear();
+
+	if (! _controlExec->GetDataNames().size()) {
+		sessionNew();
+	}
 }
 	
 //import WRF data into current session

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1416,6 +1416,10 @@ void MainForm::sessionOpenHelper(string fileName) {
 
 	_vizWinMgr->Restart();
 	_tabMgr->Restart();
+
+	// Close data can't be undone
+	//
+	_controlExec->UndoRedoClear();
 }
 
 void MainForm::sessionOpen(QString qfileName)
@@ -1496,7 +1500,7 @@ void MainForm::sessionOpen(QString qfileName)
 
 	// Session load can't currently be undone
 	//
-	_paramsMgr->UndoRedoClear();
+	_controlExec->UndoRedoClear();
 
     _stateChangeCB();
 }
@@ -1682,6 +1686,10 @@ void MainForm::closeDataHelper(string dataSetName) {
 	p->RemoveOpenDateSet(dataSetName);
 
 	_controlExec->CloseData(dataSetName);
+
+	// Close data can't be undone
+	//
+	_controlExec->UndoRedoClear();
 }
 
 // Open a data set and remove from database. If data with same name 
@@ -1694,21 +1702,8 @@ bool MainForm::openDataHelper(
 	const vector <string> &options
 ) {
 
-	_paramsMgr->BeginSaveStateGroup("Load data");
-
 	GUIStateParams *p = GetStateParams();
 	vector <string> dataSetNames =  p->GetOpenDataSetNames();
-
-#ifdef	VAPOR3_0_0_ALPHA
-	// If data set with this name already exists, close it
-	//
-	for (int i=0; i<dataSetNames.size(); i++) {
-		if (dataSetNames[i] == dataSetName) {
-			closeDataHelper(dataSetName);
-		}
-	}
-#endif
-
 
 	// Open the data set
 	//
@@ -1717,7 +1712,6 @@ bool MainForm::openDataHelper(
 	);
 	if (rc<0) {
 		MSG_ERR("Failed to load data");
-		_paramsMgr->EndSaveStateGroup();
 		return (false);;
 	}
 
@@ -1728,7 +1722,9 @@ bool MainForm::openDataHelper(
 
 	_tabMgr->LoadDataNotify(dataSetName);
 
-	_paramsMgr->EndSaveStateGroup();
+	// Opening data is not an undoable event :-(
+	//
+	_controlExec->UndoRedoClear();
 	return(true);
 }
 
@@ -1779,11 +1775,8 @@ void MainForm::loadDataHelper(
         options.push_back(p->GetProjectionString());
     }
     
-	_paramsMgr->BeginSaveStateGroup("Load data");
-
 	bool status = openDataHelper(dataSetName, format, myFiles, options);
 	if (! status) {
-		_paramsMgr->EndSaveStateGroup();
 		return;
 	}
 
@@ -1807,7 +1800,9 @@ void MainForm::loadDataHelper(
 
 	_timeStepEditValidator->setRange(0,ds->GetTimeCoordinates().size()-1);
 
-	_paramsMgr->EndSaveStateGroup();
+	// Opening data is not an undoable event :-(
+	//
+	_controlExec->UndoRedoClear();
 
 }
 
@@ -1849,6 +1844,10 @@ void MainForm::closeData(string fileName) {
 
 	_tabMgr->Update();
 	_vizWinMgr->Reinit();
+
+	// Close data can't be undone
+	//
+	_controlExec->UndoRedoClear();
 }
 	
 //import WRF data into current session
@@ -1977,7 +1976,7 @@ void MainForm::sessionNew()
 
 	// Session load can't currently be undone
 	//
-	_paramsMgr->UndoRedoClear();
+	_controlExec->UndoRedoClear();
 
     _stateChangeFlag = false;
 	_sessionNewFlag = true;
@@ -2179,7 +2178,7 @@ void MainForm::_setProj4String(string proj4String) {
 
 	// Map projection changes can't currently be undone
 	//
-	_paramsMgr->UndoRedoClear();
+	_controlExec->UndoRedoClear();
 
 	_App->installEventFilter(this);
 }

--- a/include/vapor/ParamsMgr.h
+++ b/include/vapor/ParamsMgr.h
@@ -749,6 +749,7 @@ private:
  void delete_ren_containers(string winName, string dataSetName);
  void delete_ren_containers(string winName);
  void delete_ren_containers();
+ void delete_datasets(string dataSetName);
 
  RenParamsContainer *make_ren_container(
 	string winName, string dataSetName, string renderName

--- a/lib/params/ParamsMgr.cpp
+++ b/lib/params/ParamsMgr.cpp
@@ -182,9 +182,10 @@ void ParamsMgr::LoadState(const XmlNode *node) {
 
 	// If data loaded set up data dependent parameters from new state.
 	//
-	map <string, DataMgr *>::const_iterator itr;
-	for (itr = _dataMgrMap.begin(); itr != _dataMgrMap.end(); ++itr) {
-		addDataMgrMerge(itr->first);
+	vector <string> dataSetNames = GetDataMgrNames();
+	for (auto dataSetName : dataSetNames) {
+		map <string, DataMgr *>::const_iterator itr = _dataMgrMap.find(dataSetName);
+		if (itr != _dataMgrMap.end()) addDataMgrMerge(itr->first);
 	}
 	EndSaveStateGroup();
 }
@@ -308,6 +309,17 @@ void ParamsMgr::AddDataMgr(string dataSetName, DataMgr *dataMgr) {
 		addDataMgrNew();
 	}
 
+	ParamsSeparator windowsSep(_rootSeparator, _windowsTag);
+	XmlNode *winSepNode = windowsSep.GetNode();
+	for (int i=0; i<winSepNode->GetNumChildren(); i++) {
+		string winName = winSepNode->GetChild(i)->GetTag();
+
+		ParamsSeparator windowSep(&windowsSep, winName);
+
+		ParamsSeparator renderSep(&windowSep, _renderersTag);
+
+		ParamsSeparator dataSep(&renderSep, dataSetName);
+	}
 }
 
 void ParamsMgr::RemoveVisualizer(string winName) {
@@ -342,16 +354,36 @@ void ParamsMgr::RemoveDataMgr(string dataSetName) {
 
 	_dataMgrMap.erase(itr);
 
+	delete_datasets(dataSetName);
 }
 
 vector <string> ParamsMgr::GetDataMgrNames() const {
 
 	vector <string> dataMgrNames;
 
-	map <string, DataMgr *>::const_iterator itr;
-	for (itr=_dataMgrMap.begin(); itr!=_dataMgrMap.end(); ++itr) {
-		dataMgrNames.push_back(itr->first);
+	ParamsSeparator windowsSep(_rootSeparator, _windowsTag);
+
+	XmlNode *winSepNode = windowsSep.GetNode();
+	for (int i=0; i<winSepNode->GetNumChildren(); i++) {
+		XmlNode *winNode = winSepNode->GetChild(i);
+		string winName = winNode->GetTag();
+
+		if (winNode->HasChild(_renderersTag)) {
+			XmlNode *renderersNode = winNode->GetChild(_renderersTag);
+
+			for (int j=0; j<renderersNode->GetNumChildren(); j++) {
+
+				XmlNode *dataSepNode = renderersNode->GetChild(j);
+				string s = dataSepNode->GetTag();
+
+				dataMgrNames.push_back(s);
+			}
+		}
 	}
+
+	sort( dataMgrNames.begin(), dataMgrNames.end() );
+	dataMgrNames.erase(unique(dataMgrNames.begin(), dataMgrNames.end()),dataMgrNames.end());
+
 
 	return(dataMgrNames);
 }
@@ -1071,7 +1103,30 @@ void ParamsMgr::delete_ren_containers() {
 	}
 }
 
-	
+void ParamsMgr::delete_datasets(string dataSetName) {
+
+	ParamsSeparator windowsSep( _rootSeparator, _windowsTag);
+
+	XmlNode *winSepNode = windowsSep.GetNode();
+	for (int i=0; i<winSepNode->GetNumChildren(); i++) {
+		XmlNode *winNode = winSepNode->GetChild(i);
+		string winName = winNode->GetTag();
+
+		delete_ren_containers(winName, dataSetName);
+
+		XmlNode *renderersNode = winNode->GetChild(_renderersTag);
+		for (int j=0; j<renderersNode->GetNumChildren(); j++) {
+
+			XmlNode *dataSepNode = renderersNode->GetChild(j);
+			string s = dataSepNode->GetTag();
+
+			if (s == dataSetName) {
+				dataSepNode->SetParent(NULL);
+				break;
+			}
+		}
+	}
+}
 
 
 

--- a/lib/render/ControlExecutive.cpp
+++ b/lib/render/ControlExecutive.cpp
@@ -572,6 +572,7 @@ int ControlExec::OpenData(
 	int rc = _dataStatus->Open(files, options, dataSetName, typ);
 	if (rc < 0) {
 		SetErrMsg("Failure to open data set of type \"%s\"", typ.c_str());
+		UndoRedoClear();
 		return -1;
 	}
 
@@ -592,6 +593,7 @@ int ControlExec::OpenData(
 				"Failure to initialize application renderer \"%s\"",
 				appRenderParams[i]->GetName().c_str()
 			);
+			UndoRedoClear();
 			return(-1);
 		}
 	}
@@ -600,6 +602,7 @@ int ControlExec::OpenData(
 	//
 	rc = openDataHelper(true);
 
+	UndoRedoClear();
 	return(rc);
 }
 
@@ -634,6 +637,7 @@ void ControlExec::CloseData(string dataSetName) {
 		
 	_paramsMgr->RemoveDataMgr(dataSetName);
 
+	UndoRedoClear();
 }
 
 

--- a/lib/render/Visualizer.cpp
+++ b/lib/render/Visualizer.cpp
@@ -97,7 +97,7 @@ int Visualizer::resizeGL( int wid, int ht )
 }
 
 int Visualizer::_getCurrentTimestep() const {
-	vector <string> dataSetNames = _dataStatus->GetDataMgrNames();
+	vector <string> dataSetNames = _paramsMgr->GetDataMgrNames();
 
 	bool first = true;
 	size_t min_ts = 0;
@@ -168,7 +168,7 @@ int Visualizer::paintEvent(bool fast)
     MatrixManager *mm = _glManager->matrixManager;
 
 	//Do not proceed if there is no DataMgr
-	if (! _dataStatus->GetDataMgrNames().size()) return(0);
+	if (! _paramsMgr->GetDataMgrNames().size()) return(0);
     
     // Do not proceed with invalid viewport
     // This can occur sometimes on Qt startup
@@ -584,7 +584,7 @@ int Visualizer:: _captureImage(std::string path)
         goto captureImageEnd;
     
     if (geoTiffOutput) {
-        string projString = _dataStatus->GetDataMgr(_dataStatus->GetDataMgrNames()[0])->GetMapProjection();
+        string projString = _dataStatus->GetDataMgr(_paramsMgr->GetDataMgrNames()[0])->GetMapProjection();
         
         vector<double> dataMinExtents, dataMaxExtents;
         _dataStatus->GetActiveExtents(_paramsMgr, _winName, _getCurrentTimestep(), dataMinExtents, dataMaxExtents);


### PR DESCRIPTION
Closed #1377 - Undo open dataset doesn't fully close it
Fixed #1233 - Incorrect behavior after closing/opening datasets 

Supporting undo/redo for open/close of data sets is not possible with the current architecture. This PR disables undo/redo for these operations. It also ensures that data sets are properly removed from the database when they are closed. As a byproduct it also fixes #1233