### PR TITLE
Issue 927: Add support for vertical coordinate transforms 

### DIFF
--- a/include/vapor/DerivedVar.h
+++ b/include/vapor/DerivedVar.h
@@ -976,6 +976,97 @@ private:
  
 };
 
+//! \class DerivedCoordVarStandardAHSPC
+//!
+//! \brief Convert a CF parameterless vertical coordinate to an Ocean
+//! s-coordinate, generic form 1 or 2
+//!
+//! This derived class converts a dimensionless sigma coordinate variable
+//! to either a Ocean s-coordinate, generic form 1 or 2
+//!
+//! \sa http://cfconventions.org/
+//
+class VDF_API DerivedCoordVarStandardAHSPC : public DerivedCFVertCoordVar {
+public:
+ DerivedCoordVarStandardAHSPC(
+	DC *dc, string mesh, string formula
+ );
+ virtual ~DerivedCoordVarStandardAHSPC() {}
+
+ virtual int Initialize();
+
+ virtual bool GetBaseVarInfo(DC::BaseVar &var) const;
+
+ virtual bool GetCoordVarInfo(DC::CoordVar &cvar) const;
+
+ virtual std::vector <string> GetInputs() const;
+
+ virtual int GetDimLensAtLevel(
+	int level, std::vector <size_t> &dims_at_level,
+	std::vector <size_t> &bs_at_level
+ ) const;
+
+ virtual size_t GetNumRefLevels() const {
+    return(_dc->GetNumRefLevels(_psVar));
+ } 
+
+ virtual std::vector <size_t> GetCRatios() const {
+    return(_dc->GetCRatios(_psVar));
+ }
+
+ virtual int OpenVariableRead(
+	size_t ts, int level=0, int lod=0
+ );
+
+ virtual int CloseVariable(int fd);
+ 
+ virtual int ReadRegionBlock(
+	int fd,
+	const std::vector <size_t> &min, const std::vector <size_t> &max,
+	float *region
+ ) {
+	return(ReadRegion(fd, min, max, region));
+ }
+
+ virtual int ReadRegion(
+	int fd,
+	const std::vector <size_t> &min, const std::vector <size_t> &max,
+	float *region
+ );
+
+ virtual bool VariableExists(
+	size_t ts,
+	int reflevel,
+	int lod
+ ) const;
+
+ static bool ValidFormula(string formula);
+
+private:
+ string _standard_name;
+ string _aVar;
+ string _apVar;
+ string _bVar;
+ string _p0Var;
+ string _psVar;
+ double _psVarMV;
+
+ DC::CoordVar _coordVarInfo;
+
+ int initialize_missing_values();
+ void compute_a(
+	const vector <size_t> &min, const vector <size_t> &max,
+	const float *a, const float *b, const float *ps, float p0,
+	float *region
+ ) const;
+ void compute_ap(
+	const vector <size_t> &min, const vector <size_t> &max,
+	const float *ap, const float *b, const float *ps,
+	float *region
+ ) const;
+ 
+};
+
 };
 
 #endif

--- a/include/vapor/DerivedVar.h
+++ b/include/vapor/DerivedVar.h
@@ -1059,11 +1059,6 @@ private:
 	const float *a, const float *b, const float *ps, float p0,
 	float *region
  ) const;
- void compute_ap(
-	const vector <size_t> &min, const vector <size_t> &max,
-	const float *ap, const float *b, const float *ps,
-	float *region
- ) const;
  
 };
 

--- a/include/vapor/DerivedVar.h
+++ b/include/vapor/DerivedVar.h
@@ -1007,11 +1007,11 @@ public:
  ) const;
 
  virtual size_t GetNumRefLevels() const {
-    return(_dc->GetNumRefLevels(_psVar));
+    return(1);
  } 
 
  virtual std::vector <size_t> GetCRatios() const {
-    return(_dc->GetCRatios(_psVar));
+	return(std::vector <size_t> (1,1));
  }
 
  virtual int OpenVariableRead(

--- a/include/vapor/StretchedGrid.h
+++ b/include/vapor/StretchedGrid.h
@@ -92,10 +92,23 @@ public:
 
  //! \copydoc Grid::GetIndicesCell
  //!
+ //! Returns resampling weights if point is found
+ //
+ virtual bool GetIndicesCell(
+	const DblArr3 &coords,
+	Size_tArr3 &indices,
+	double wgts[3]
+ ) const ;
+
+ //! \copydoc Grid::GetIndicesCell
+ //!
  virtual bool GetIndicesCell(
 	const DblArr3 &coords,
 	Size_tArr3 &indices
- ) const override;
+ ) const override {
+	double dummy[3];
+	return(GetIndicesCell(coords, indices, dummy));
+ };
 
  // \copydoc GetGrid::InsideGrid()
  //

--- a/lib/common/utils.cpp
+++ b/lib/common/utils.cpp
@@ -210,48 +210,51 @@ bool Wasp::BinarySearchRange(
 ) {
 	i = 0;
 
-	if (sorted.size() < 2) return(false);
+	if (sorted.size() == 1) return(sorted[0] == x);
 
-	// See if above or below the array
+	// if sorted in ascending order
 	//
-	if (sorted[0] < sorted[1]) {	// increasing
-		if (x<sorted[0]) return(false);
-		if (x>sorted[sorted.size()-1]) return(false);
-	}
-	else {	// decreasing
-		if (x>sorted[0]) return(false);
-		if (x<sorted[sorted.size()-1]) return(false);
-	}
-	
+	if (sorted[0] <= sorted[sorted.size()-1]) { 
+		if (x < sorted[0]) return(false); 
 
-	// Binary search for starting index of cell containing x
-	//
-	size_t i0 = 0;
-	size_t i1 = sorted.size()-1;
-	double x0 = sorted[i0];
-	double x1 = sorted[i1];
-	while (i1-i0>1) {
-
-		x1 = sorted[(i0+i1)>>1];
-		if (x1 == x) {  // pathological case
-			i0 = (i0+i1)>>1;
-			break;
+		if (x == sorted[sorted.size()-1]) {
+			i = sorted.size()-2;
+			return(true);
 		}
 
-		// if the signs of differences change then the coordinate
-		// is between x0 and x1
-		//
-		if ((x-x0) * (x-x1) <= 0.0) {
-			i1 = (i0+i1)>>1;
+		vector <double>::const_iterator itr;
+		itr = std::upper_bound(sorted.begin(), sorted.end(), x);
+		if (itr == sorted.end()) {
+			return(false);
 		}
-		else {
-			i0 = (i0+i1)>>1;
-			x0 = x1;
+		if (itr != sorted.begin()) {
+			--itr;
 		}
+		i = itr - sorted.begin();
+
 	}
-	i = i0;
+	else {
+		if (x < sorted[sorted.size()-1]) return(false); 
+
+		if (x == sorted[sorted.size()-1]) {
+			i = sorted.size()-2;
+			return(true);
+		}
+
+		vector <double>::const_reverse_iterator itr;
+		itr = std::lower_bound(sorted.rbegin(), sorted.rend(), x);
+		if (itr == sorted.rend()) {
+			return(false);
+		}
+		if (itr != sorted.rbegin()) {
+			++itr;
+		}
+		i = sorted.rend() - itr;
+	}
+
 	return(true);
 }
+
 
 
 bool Wasp::NearlyEqual(float a, float b, float epsilon) {

--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -3160,24 +3160,19 @@ int DerivedCoordVarStandardAHSPC::ReadRegion(
 	if (rc<0) return(rc);
 
 
+	float p0 = 1.0;
 	if (! _aVar.empty()) {
-		float p0;
 		myMin = {};
 		myMax = {};
 		rc = _getVar(
 			_dc, f->GetTS(), _p0Var, f->GetLevel(), f->GetLOD(),
 			myMin, myMax, &p0
 		);
+	}
 
-		compute_a(
-			min, max, a.data(), b.data(), ps.data(), p0, region
-		);
-	}
-	else {
-		compute_ap(
-			min, max, a.data(), b.data(), ps.data(), region
-		);
-	}
+	compute_a(
+		min, max, a.data(), b.data(), ps.data(), p0, region
+	);
 
 	return(0);
 }
@@ -3239,41 +3234,6 @@ void DerivedCoordVarStandardAHSPC::compute_a(
 		if (l_ps == _psVarMV) l_ps = 0;
 
 		float pressure = (a[k]*p0) + (b[k]*l_ps);
-
-		// Convert from pressure to meters above the ground:
-		// [1] "A Quick Derivation relating altitude to air pressure" from
-		// Portland State Aerospace Society, Version 1.03, 12/22/2004.
-		//
-		region[k*rDims[0]*rDims[1] + j*rDims[0] + i] = 
-			44331.5 - (4946.62 * std::pow(pressure, 0.190263));
-		
-    }
-	}
-	}
-}
-
-void DerivedCoordVarStandardAHSPC::compute_ap(
-	const vector <size_t> &min, const vector <size_t> &max,
-	const float *ap, const float *b, const float *ps, 
-	float *region
-) const {
-
-	vector <size_t> rDims;
-	for (int i=0; i<3; i++) {
-		rDims.push_back(max[i]-min[i]+1);
-	}
-
-    for (size_t k=0; k<max[2]-min[2]+1; k++) {
-    for (size_t j=0; j<max[1]-min[1]+1; j++) {
-    for (size_t i=0; i<max[0]-min[0]+1; i++) {
-
-		// We are deriving coordinate values from data values, so missing
-		// values may be present
-		//
-		float l_ps = ps[j*rDims[0]+i];
-		if (l_ps == _psVarMV) l_ps = 0;
-
-		float pressure = ap[k] + b[k]*l_ps;
 
 		// Convert from pressure to meters above the ground:
 		// [1] "A Quick Derivation relating altitude to air pressure" from

--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -2899,3 +2899,393 @@ void DerivedCoordVarStandardOceanSCoordinate::compute_g2(
 	}
 }
 
+////////////////////////////////////////////////////////////////////////////// 
+//
+//	DerivedCoordVarStandardAHSPC
+//
+//	Atmosphere Hybrid Sigma Pressure Coordinate
+//
+////////////////////////////////////////////////////////////////////////////// 
+
+//
+// Register class with object factory!!!
+//
+
+static DerivedCFVertCoordVarFactoryRegistrar<DerivedCoordVarStandardAHSPC> registrar_atmosphere_hybrid_sigma_pressure_coordinate("atmosphere_hybrid_sigma_pressure_coordinate");
+
+DerivedCoordVarStandardAHSPC::DerivedCoordVarStandardAHSPC(
+	DC *dc, string mesh, string formula
+) : DerivedCFVertCoordVar(
+	"", dc, mesh, formula
+) {
+
+	_standard_name = "atmosphere_hybrid_sigma_pressure_coordinate";
+	_aVar.clear();
+	_apVar.clear();
+	_bVar.clear();
+	_p0Var.clear();
+	_psVar.clear();
+
+	_psVarMV = std::numeric_limits<double>::infinity();
+
+}
+
+int DerivedCoordVarStandardAHSPC::initialize_missing_values() {
+
+	DC::DataVar dataInfo;
+	bool status = _dc->GetDataVarInfo(_psVar, dataInfo);
+	if (! status) {
+		SetErrMsg("Invalid variable \"%s\"", _psVar.c_str());
+		return(-1);
+	}
+	if (dataInfo.GetHasMissing()) _psVarMV = dataInfo.GetMissingValue();
+
+
+	return(0);
+}
+
+
+int DerivedCoordVarStandardAHSPC::Initialize() {
+
+	map <string, string> formulaMap;
+	if (! ParseFormula(_formula, formulaMap)) {
+		SetErrMsg("Invalid conversion formula \"%s\"", _formula.c_str());
+		return(-1);
+	}
+
+
+	// There are two possible formulations, one with 'ap', and one
+	// with 'a' and 'p0'
+	//
+	map <string, string>::const_iterator itr;
+	VAssert((itr = formulaMap.find("a")) != formulaMap.end());
+	if (itr != formulaMap.end()) {
+		_aVar = itr->second;
+		VAssert((itr = formulaMap.find("p0")) != formulaMap.end());
+		_p0Var = itr->second;
+	}
+	else {
+		VAssert((itr = formulaMap.find("ap")) != formulaMap.end());
+		_apVar = itr->second;
+	}
+
+	VAssert((itr = formulaMap.find("b")) != formulaMap.end());
+	_bVar = itr->second;
+
+	VAssert((itr = formulaMap.find("ps")) != formulaMap.end());
+	_psVar = itr->second;
+
+	if (initialize_missing_values() < 0) return(-1);
+
+	// Use the 'b' and 'ps' variables to set up metadata for the derived 
+	// variable
+	//
+	DC::DataVar bInfo;
+	bool status = _dc->GetDataVarInfo(_bVar, bInfo);
+	if (! status) {
+		SetErrMsg("Invalid variable \"%s\"", _bVar.c_str());
+		return(-1);
+	}
+
+	DC::DataVar psInfo;
+	status = _dc->GetDataVarInfo(_psVar, psInfo);
+	if (! status) {
+		SetErrMsg("Invalid variable \"%s\"", _psVar.c_str());
+		return(-1);
+	}
+
+
+	// Construct spatial and temporal dimensions from the 1D 'b' 
+	// variable and 2D, time-varying 'ps' variable
+	//
+	DC::Mesh m;
+	status = _dc->GetMesh(psInfo.GetMeshName(), m);
+	if (! status) {
+		SetErrMsg("Invalid mesh \"%s\"", _mesh.c_str());
+		return(-1);
+	}
+	vector <string> dimnames = m.GetDimNames();
+
+
+	status = _dc->GetMesh(bInfo.GetMeshName(), m);
+	if (! status) {
+		SetErrMsg("Invalid mesh \"%s\"", _mesh.c_str());
+		return(-1);
+	}
+	dimnames.push_back(m.GetDimNames()[0]);
+
+	string timeCoordVar = psInfo.GetTimeCoordVar();
+	string timeDimName;
+	if (! timeCoordVar.empty()) {
+		DC::CoordVar cvarInfo;
+		bool status = _dc->GetCoordVarInfo(timeCoordVar, cvarInfo);
+		if (! status) {
+			SetErrMsg("Invalid variable \"%s\"", timeCoordVar.c_str());
+			return(-1);
+		}
+		timeDimName = cvarInfo.GetTimeDimName();
+	}
+
+
+	// We're deriving a 3D varible from 1D and 2D varibles. We arbitarily
+	// use one of the 2D variables to configure metadata such as the
+	// available compression ratios
+	//
+	_derivedVarName = "Z_" + _bVar;
+    _coordVarInfo = DC::CoordVar(
+        _derivedVarName, "m", DC::XType::FLOAT, psInfo.GetWName(),
+        psInfo.GetCRatios(), vector <bool> (3, false), 
+        dimnames, timeDimName, 2, false
+	);
+
+
+    return(0);
+}
+
+bool DerivedCoordVarStandardAHSPC::GetBaseVarInfo(
+	DC::BaseVar &var
+) const {
+	var = _coordVarInfo;
+	return(true);
+}
+
+bool DerivedCoordVarStandardAHSPC::GetCoordVarInfo(
+	DC::CoordVar &cvar
+) const {
+	cvar = _coordVarInfo;
+	return(true);
+}
+
+vector <string> DerivedCoordVarStandardAHSPC::GetInputs() const {
+
+    map <string, string> formulaMap;
+    bool ok = ParseFormula(_formula, formulaMap);
+	VAssert(ok);
+
+	vector <string> inputs;
+	for (auto it = formulaMap.begin(); it != formulaMap.end(); ++it) {
+		inputs.push_back(it->second);
+	}
+	return(inputs);
+}
+
+
+int DerivedCoordVarStandardAHSPC::GetDimLensAtLevel(
+    int level, std::vector <size_t> &dims_at_level,
+    std::vector <size_t> &bs_at_level
+) const {
+	dims_at_level.clear();
+	bs_at_level.clear();
+
+	vector <size_t> dims2d, bs2d;
+	int rc = _dc->GetDimLensAtLevel(_psVar, -1, dims2d, bs2d);
+	if (rc<0) return(-1);
+
+	vector <size_t> dims1d, bs1d;
+	rc = _dc->GetDimLensAtLevel(_bVar, -1, dims1d, bs1d);
+	if (rc<0) return(-1);
+
+	vector <size_t> dims = {dims2d[0], dims2d[1], dims1d[0]};
+	vector <size_t> bs = {bs2d[0], bs2d[1], bs1d[0]};
+
+	int nlevels = _dc->GetNumRefLevels(_psVar);
+	if (level < 0) level = nlevels + level;
+
+	WASP::InqDimsAtLevel(
+		_coordVarInfo.GetWName(), level, dims, bs, dims_at_level, bs_at_level
+	);
+
+	return(0);
+}
+
+int DerivedCoordVarStandardAHSPC::OpenVariableRead(
+    size_t ts, int level, int lod
+) {
+
+	DC::FileTable::FileObject *f = new DC::FileTable::FileObject(
+		ts, _derivedVarName, level, lod
+	);
+
+	return(_fileTable.AddEntry(f));
+}
+
+int DerivedCoordVarStandardAHSPC::CloseVariable(int fd) {
+	DC::FileTable::FileObject *f = _fileTable.GetEntry(fd);
+
+	if (! f) {
+		SetErrMsg("Invalid file descriptor : %d", fd);
+		return(-1);
+	}
+
+	_fileTable.RemoveEntry(fd);
+	delete f;
+
+	return(0);
+}
+
+int DerivedCoordVarStandardAHSPC::ReadRegion(
+	int fd,
+    const vector <size_t> &min, const vector <size_t> &max, float *region
+) {
+
+	DC::FileTable::FileObject *f = _fileTable.GetEntry(fd);
+
+	vector <size_t> dims, dummy;
+	int rc = GetDimLensAtLevel(f->GetLevel(), dims, dummy);
+	if (rc<0) return(-1);
+
+	string aVar = _aVar.empty() ? _apVar : _aVar;
+	vector <float> a(dims[2]);
+	vector <size_t> myMin = {min[2]};
+	vector <size_t> myMax = {max[2]};
+	rc = _getVar(
+		_dc, f->GetTS(), aVar, f->GetLevel(), f->GetLOD(),
+		myMin, myMax, a.data()
+	);
+	if (rc<0) return(rc);
+
+	vector <float> b(dims[2]);
+	myMin = {min[2]};
+	myMax = {max[2]};
+	rc = _getVar(
+		_dc, f->GetTS(), _bVar, f->GetLevel(), f->GetLOD(),
+		myMin, myMax, b.data()
+	);
+	if (rc<0) return(rc);
+
+	vector <float> ps(dims[0]*dims[1]);
+	myMin = {min[0], min[1]};
+	myMax = {max[0], max[1]};
+	rc = _getVar(
+		_dc, f->GetTS(), _psVar, f->GetLevel(), f->GetLOD(),
+		myMin, myMax, ps.data()
+	);
+	if (rc<0) return(rc);
+
+
+	if (! _aVar.empty()) {
+		float p0;
+		myMin = {};
+		myMax = {};
+		rc = _getVar(
+			_dc, f->GetTS(), _p0Var, f->GetLevel(), f->GetLOD(),
+			myMin, myMax, &p0
+		);
+
+		compute_a(
+			min, max, a.data(), b.data(), ps.data(), p0, region
+		);
+	}
+	else {
+		compute_ap(
+			min, max, a.data(), b.data(), ps.data(), region
+		);
+	}
+
+	return(0);
+}
+
+bool DerivedCoordVarStandardAHSPC::VariableExists(
+	size_t ts,
+	int reflevel,
+	int lod
+) const {
+
+	if (! _aVar.empty()) {
+		return(
+			_dc->VariableExists(ts, _aVar, reflevel, lod) &&
+			_dc->VariableExists(ts, _bVar, reflevel, lod) &&
+			_dc->VariableExists(ts, _psVar, reflevel, lod) 
+		);
+	}
+	else {
+		return(
+			_dc->VariableExists(ts, _apVar, reflevel, lod) &&
+			_dc->VariableExists(ts, _bVar, reflevel, lod) &&
+			_dc->VariableExists(ts, _psVar, reflevel, lod) &&
+			_dc->VariableExists(ts, _p0Var, reflevel, lod) 
+		);
+	}
+}
+
+bool DerivedCoordVarStandardAHSPC::ValidFormula(string formula) {
+
+	return(
+		DerivedCFVertCoordVar::ValidFormula(
+			vector <string> {"a", "b", "p0", "ps"}, formula
+		) ||
+		DerivedCFVertCoordVar::ValidFormula(
+			vector <string> {"ap", "b", "ps"}, formula
+		)
+	);
+}
+
+void DerivedCoordVarStandardAHSPC::compute_a(
+	const vector <size_t> &min, const vector <size_t> &max,
+	const float *a, const float *b, const float *ps, float p0,
+	float *region
+) const {
+
+	vector <size_t> rDims;
+	for (int i=0; i<3; i++) {
+		rDims.push_back(max[i]-min[i]+1);
+	}
+
+    for (size_t k=0; k<max[2]-min[2]+1; k++) {
+    for (size_t j=0; j<max[1]-min[1]+1; j++) {
+    for (size_t i=0; i<max[0]-min[0]+1; i++) {
+
+		// We are deriving coordinate values from data values, so missing
+		// values may be present
+		//
+		float l_ps = ps[j*rDims[0]+i];
+		if (l_ps == _psVarMV) l_ps = 0;
+
+		float pressure = (a[k]*p0) + (b[k]*l_ps);
+
+		// Convert from pressure to meters above the ground:
+		// [1] "A Quick Derivation relating altitude to air pressure" from
+		// Portland State Aerospace Society, Version 1.03, 12/22/2004.
+		//
+		region[k*rDims[0]*rDims[1] + j*rDims[0] + i] = 
+			44331.5 - (4946.62 * std::pow(pressure, 0.190263));
+		
+    }
+	}
+	}
+}
+
+void DerivedCoordVarStandardAHSPC::compute_ap(
+	const vector <size_t> &min, const vector <size_t> &max,
+	const float *ap, const float *b, const float *ps, 
+	float *region
+) const {
+
+	vector <size_t> rDims;
+	for (int i=0; i<3; i++) {
+		rDims.push_back(max[i]-min[i]+1);
+	}
+
+    for (size_t k=0; k<max[2]-min[2]+1; k++) {
+    for (size_t j=0; j<max[1]-min[1]+1; j++) {
+    for (size_t i=0; i<max[0]-min[0]+1; i++) {
+
+		// We are deriving coordinate values from data values, so missing
+		// values may be present
+		//
+		float l_ps = ps[j*rDims[0]+i];
+		if (l_ps == _psVarMV) l_ps = 0;
+
+		float pressure = ap[k] + b[k]*l_ps;
+
+		// Convert from pressure to meters above the ground:
+		// [1] "A Quick Derivation relating altitude to air pressure" from
+		// Portland State Aerospace Society, Version 1.03, 12/22/2004.
+		//
+		region[k*rDims[0]*rDims[1] + j*rDims[0] + i] = 
+			44331.5 - (4946.62 * std::pow(pressure, 0.190263));
+		
+    }
+	}
+	}
+}

--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -3033,9 +3033,8 @@ int DerivedCoordVarStandardAHSPC::Initialize() {
 	//
 	_derivedVarName = "Z_" + _bVar;
     _coordVarInfo = DC::CoordVar(
-        _derivedVarName, "m", DC::XType::FLOAT, psInfo.GetWName(),
-        psInfo.GetCRatios(), vector <bool> (3, false), 
-        dimnames, timeDimName, 2, false
+        _derivedVarName, "m", DC::XType::FLOAT, vector <bool> (3, false),
+		2, false, dimnames, timeDimName
 	);
 
 
@@ -3085,15 +3084,8 @@ int DerivedCoordVarStandardAHSPC::GetDimLensAtLevel(
 	rc = _dc->GetDimLensAtLevel(_bVar, -1, dims1d, bs1d);
 	if (rc<0) return(-1);
 
-	vector <size_t> dims = {dims2d[0], dims2d[1], dims1d[0]};
-	vector <size_t> bs = {bs2d[0], bs2d[1], bs1d[0]};
-
-	int nlevels = _dc->GetNumRefLevels(_psVar);
-	if (level < 0) level = nlevels + level;
-
-	WASP::InqDimsAtLevel(
-		_coordVarInfo.GetWName(), level, dims, bs, dims_at_level, bs_at_level
-	);
+	dims_at_level = {dims2d[0], dims2d[1], dims1d[0]};
+	bs_at_level = {bs2d[0], bs2d[1], bs1d[0]};
 
 	return(0);
 }
@@ -3101,6 +3093,11 @@ int DerivedCoordVarStandardAHSPC::GetDimLensAtLevel(
 int DerivedCoordVarStandardAHSPC::OpenVariableRead(
     size_t ts, int level, int lod
 ) {
+
+	// We don't support compressed data
+	//
+	level = -1;
+	lod = -1;
 
 	DC::FileTable::FileObject *f = new DC::FileTable::FileObject(
 		ts, _derivedVarName, level, lod

--- a/lib/vdc/GridHelper.cpp
+++ b/lib/vdc/GridHelper.cpp
@@ -101,9 +101,11 @@ bool isLayered(
 
 	if (cdimnames.size() != 3) return(false);
 
-	if (! (cvarsinfo[0].GetUniform() && cvarsinfo[1].GetUniform())) {
-		return(false);
-	} 
+	for (int i=0; i<2; i++) {
+		if (! (cdimnames[i].size() == 1)) { 
+			return(false);
+		}
+	}
 
 	if (! (cdimnames[2].size() == 3)) return(false);
 
@@ -276,12 +278,11 @@ LayeredGrid *GridHelper::_make_grid_layered(
 
 	// Get horizontal dimensions
 	//
-	vector <double> hminu, hmaxu;
-	for (int i = 0; i<2; i++) { 
-		float *coords = blkvec[i+1];
-		hminu.push_back(coords[0]);
-		hmaxu.push_back(coords[dims[i]-1]);
-	}
+	vector <double> xcoords;
+	for (int i=0; i<dims[0]; i++) xcoords.push_back(blkvec[1][i]);
+
+	vector <double> ycoords;
+	for (int i=0; i<dims[1]; i++) ycoords.push_back(blkvec[2][i]);
 
 	// Data blocks
 	//
@@ -317,7 +318,7 @@ LayeredGrid *GridHelper::_make_grid_layered(
 		dims, bs, zcblkptrs, vector <double> (3,0.0), vector <double> (3,1.0)
 	);
 
-	LayeredGrid *lg = new LayeredGrid(dims, bs, blkptrs, hminu, hmaxu, rg);
+	LayeredGrid *lg = new LayeredGrid(dims, bs, blkptrs, xcoords, ycoords, rg);
 
 	return(lg);
 }

--- a/lib/vdc/LayeredGrid.cpp
+++ b/lib/vdc/LayeredGrid.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <cmath>
 #include <cfloat>
+#include <vapor/vizutil.h>
 #include "vapor/utils.h"
 #include "vapor/LayeredGrid.h"
 #define INCLUDE_DEPRECATED_LEGACY_VECTOR_MATH
@@ -11,50 +12,43 @@
 using namespace std;
 using namespace VAPoR;
 
-void LayeredGrid::_layeredGrid(
-    const vector <double> &minu,
-    const vector <double> &maxu,
-	const RegularGrid &rg
-) {
-	VAssert(GetDimensions().size() == 3);
-	VAssert(minu.size() == maxu.size());
-	VAssert(minu.size() == 2);
-
-
-	_delta.clear();
-	_interpolationOrder = 1;
-
-	_rg = rg;
-	CopyToArr3(minu, _minu);
-	CopyToArr3(maxu, _maxu);
-
-	// Coordinates for horizontal dimensions
-	//
-	vector <size_t> dims = GetDimensions();
-	for (int i=0; i<_minu.size(); i++) {
-		if (dims[i] < 2) _delta.push_back(0.0);
-		else _delta.push_back((_maxu[i] - _minu[i])/(double) (dims[i] - 1));
-	}
-
-	// Get extents of layered dimension
-	//
-	float range[2];
-	_rg.GetRange(range);
-	_minu[2] = range[0];
-	_maxu[2] = range[1];
-
-}
-
 LayeredGrid::LayeredGrid(
 	const vector <size_t> &dims,
 	const vector <size_t> &bs,
 	const vector <float *> &blks,
-	const vector <double> &minu,
-	const vector <double> &maxu,
-	const RegularGrid &rg
- ) : StructuredGrid(dims, bs, blks) {
+	const std::vector <double> &xcoords,
+	const std::vector <double> &ycoords,
+	const RegularGrid &zrg
+ ) : 
+	StructuredGrid(dims, bs, blks),
+	_sg2d(
+		vector <size_t> (dims.begin(), dims.begin()+2),
+		vector <size_t> (bs.begin(), bs.begin()+2),
+		vector <float *> (),
+		xcoords, ycoords, vector <double> ()
+	),
+	_zrg(zrg), _xcoords(xcoords), _ycoords(ycoords)
+{
 
-	_layeredGrid(minu, maxu, rg);
+	VAssert(GetDimensions().size() == 3);
+	VAssert(xcoords.size() == GetDimensions()[0]);
+	VAssert(ycoords.size() == GetDimensions()[1]);
+	VAssert(zrg.GetDimensions()[0] == xcoords.size());
+	VAssert(zrg.GetDimensions()[1] == ycoords.size());
+
+	_interpolationOrder = 1;
+
+
+	// Set horizontal extents from sg2d
+	//
+	_sg2d.GetUserExtents(_minu,_maxu);
+
+	// Get extents of layered dimension
+	//
+	float range[2];
+	_zrg.GetRange(range);
+	_minu[2] = (double) range[0];
+	_maxu[2] = (double) range[1];
 }
 
 vector <size_t> LayeredGrid::GetCoordDimensions(size_t dim) const {
@@ -65,7 +59,7 @@ vector <size_t> LayeredGrid::GetCoordDimensions(size_t dim) const {
 		return(vector <size_t> (1,GetDimensions()[1]));
 	}
 	else if (dim == 2) {
-		return(_rg.GetDimensions());
+		return(_zrg.GetDimensions());
 	}
 	else {
 		return(vector <size_t> (1,1));
@@ -102,14 +96,14 @@ void LayeredGrid::GetBoundingBox(
 	// varying dimension are stored as values of a scalar function
 	// sampling the coordinate space.
 	//
-	float mincoord = _rg.GetValueAtIndex(cMin);
-	float maxcoord = _rg.GetValueAtIndex(cMax);
+	float mincoord = _zrg.GetValueAtIndex(cMin);
+	float maxcoord = _zrg.GetValueAtIndex(cMax);
 
 	// Now find the extreme values of the varying dimension's coordinates
 	//
 	for (int j = cMin[1]; j<=cMax[1]; j++) {
 	for (int i = cMin[0]; i<=cMax[0]; i++) {
-		float v = _rg.AccessIJK( i,j,cMin[2]);
+		float v = _zrg.AccessIJK( i,j,cMin[2]);
 
 		if (v<mincoord) mincoord = v;
 	}
@@ -117,7 +111,7 @@ void LayeredGrid::GetBoundingBox(
 
 	for (int j = cMin[1]; j<=cMax[1]; j++) {
 	for (int i = cMin[0]; i<=cMax[0]; i++) {
-		float v = _rg.AccessIJK( i,j,cMax[2]);
+		float v = _zrg.AccessIJK( i,j,cMax[2]);
 
 		if (v>maxcoord) maxcoord = v;
 	}
@@ -129,71 +123,121 @@ void LayeredGrid::GetBoundingBox(
 
 
 
-bool LayeredGrid::_getCellAndWeights(
-	const double coords[3],
-	size_t indices0[3],
+bool LayeredGrid::_insideGrid(
+	const DblArr3 &coords,
+	Size_tArr3 &indices,
 	double wgts[3]
 ) const {
 
-	// Get the indecies of the cell containing the point. No raw pointer
-	// version of GetIndicesCell()
+	// Get indices and weights for horizontal slice
 	//
-	if (! GetIndicesCell(coords, indices0)) return(false);
+	bool found = _sg2d.GetIndicesCell(coords, indices, wgts);
+	if (! found) return(found);
 
-	size_t indices1[3];
-	for (int i=0; i<3; i++) {
-		indices1[i] = indices0[i] + 1;
+
+	// XZ and YZ cell sides are planar, but XY sides may not be. We divide
+	// the XY faces into two triangles (changing hexahedrals into prims)
+	// and figure out which triangle (prism) the point is in (first or 
+	// second). Then we search the stack of first (or second) prism in Z
+	//
+	//
+
+	// Check if point is in "first" triangle (0,0), (1,0), (1,1)
+	//
+	double lambda[3];
+	double pt[] = {coords[0],coords[1]};
+	Size_tArr3 iv = {indices[0], indices[0]+1, indices[0]+1};
+	Size_tArr3 jv = {indices[1], indices[1], indices[1]+1};
+	double tverts[] = {
+		_xcoords[iv[0]], _ycoords[jv[0]],
+		_xcoords[iv[1]], _ycoords[jv[1]],
+		_xcoords[iv[2]], _ycoords[jv[2]]
+	};
+	
+	bool inside = VAPoR::BarycentricCoordsTri(tverts, pt, lambda);
+	if (! inside) {
+
+		// Not in first triangle. 
+		// Now check if point is in "second" triangle (0,0), (1,1), (0,1)
+		//
+		iv = {indices[0], indices[0]+1, indices[0]};
+		jv = {indices[1], indices[1]+1, indices[1]+1};
+		double tverts[] = {
+			_xcoords[iv[0]], _ycoords[jv[0]],
+			_xcoords[iv[1]], _ycoords[jv[1]],
+			_xcoords[iv[2]], _ycoords[jv[2]]
+		};
+
+		inside = VAPoR::BarycentricCoordsTri(tverts, pt, lambda);
+
+		// Mathematically this shouldn't happen if _sg2d.GetIndicesCell() 
+		// returns true, but have to contend with floating point roundoff
+		//
+		if (! inside) return(false);
 	}
 
+	float z0, z1;
 
-	// Get user coordinates of cell containing point
+	// Check cached z values from last search first
 	//
-	double coords0[3], coords1[3];
-	GetUserCoordinates(indices0, coords0);
-	GetUserCoordinates(indices1, coords1);
+	if (((coords[2]-_insideGridCache.z0) * (coords[2]-_insideGridCache.z1)) < 0.0) {
+		indices[2] = _insideGridCache.k;
+		z0 = _insideGridCache.z0;
+		z1 = _insideGridCache.z1;
+	}
+	else {
+		 
 
+		// Find k index of cell containing z. Already know i and j indices
+		//
+		vector <double> zcoords;
 
-	double x = coords[0];
-	double y = coords[1];
-	double z = coords[2];
-	double x0 = coords0[0];
-	double y0 = coords0[1];
-	double z0 = coords0[2];
-	double x1 = coords1[0];
-	double y1 = coords1[1];
-	double z1 = coords1[2];
+		size_t nz = GetDimensions()[2];
+		for (int kk=0; kk<nz; kk++) {
 
-	//
-	// Calculate interpolation weights. We always interpolate along
-	// the varying dimension last (the kwgt)
-	//
-	z0 = _interpolateVaryingCoord(indices0[0],indices0[1],indices0[2],x,y);
-	z1 = _interpolateVaryingCoord(indices0[0],indices0[1],indices1[2],x,y);
+			// Interpolate Z coordinate across triangle
+			//
+			float zk = 
+				_zrg.AccessIJK(iv[0], jv[0], kk) * lambda[0] +
+				_zrg.AccessIJK(iv[1], jv[1], kk) * lambda[1] +
+				_zrg.AccessIJK(iv[2], jv[2], kk) * lambda[2];
 
-	if (x1!=x0) wgts[0] = fabs((x-x0) / (x1-x0));
-	else wgts[0] = 0.0;
-	if (y1!=y0) wgts[1] = fabs((y-y0) / (y1-y0));
-	else wgts[1] = 0.0;
-	if (z1!=z0) wgts[2] = fabs((z-z0) / (z1-z0));
-	else wgts[2] = 0.0;
+				zcoords.push_back(zk);
+		}
+
+		if (! Wasp::BinarySearchRange(zcoords, coords[2], indices[2])) return(false);
+
+		VAssert(indices[2] < nz-1);
+
+		z0 = zcoords[indices[2]];
+		z1 = zcoords[indices[2]+1];
+
+		_insideGridCache.k = indices[2];
+		_insideGridCache.z0 = z0;
+		_insideGridCache.z1 = z1;
+
+	}
+
+	wgts[2] = 1.0 - (coords[2] - z0) / (z1 - z0);
 
 	return(true);
+
 }
 
 float LayeredGrid::GetValueNearestNeighbor(
 	const DblArr3 &coords
 ) const {
 
-	size_t indices[3];
+	Size_tArr3 indices;
 	double wgts[3];
-	bool found = _getCellAndWeights(coords.data(), indices, wgts);
+	bool found = _insideGrid(coords, indices, wgts);
 	if (! found) return(GetMissingValue());
 
-	if (wgts[0] > 0.5) indices[0] += 1;
-	if (wgts[1] > 0.5) indices[1] += 1;
-	if (wgts[2] > 0.5) indices[2] += 1;
+	if (wgts[0] < 0.5) indices[0] += 1;
+	if (wgts[1] < 0.5) indices[1] += 1;
+	if (wgts[2] < 0.5) indices[2] += 1;
 
-	return(AccessIJK(indices[0],indices[1],indices[2])); 
+	return(AccessIJK(indices[0], indices[1], indices[2]));
 }
 
 
@@ -201,26 +245,26 @@ float LayeredGrid::GetValueLinear (
 	const DblArr3 &coords
 ) const {
 
-	size_t indices0[3];
+	Size_tArr3 indices;
 	double wgts[3];
-	bool found = _getCellAndWeights(coords.data(), indices0, wgts);
+	bool found = _insideGrid(coords, indices, wgts);
 	if (! found) return(GetMissingValue());
 
 
-	size_t i0 = indices0[0];
-	size_t j0 = indices0[1];
-	size_t k0 = indices0[2];
-	size_t i1 = indices0[0]+1;
-	size_t j1 = indices0[1]+1;
-	size_t k1 = indices0[2]+1;
+	size_t i0 = indices[0];
+	size_t j0 = indices[1];
+	size_t k0 = indices[2];
+	size_t i1 = indices[0]+1;
+	size_t j1 = indices[1]+1;
+	size_t k1 = indices[2]+1;
 
 	//
 	// perform tri-linear interpolation
 	//
 	double p0,p1,p2,p3,p4,p5,p6,p7;
-	double iwgt = wgts[0];
-	double jwgt = wgts[1];
-	double kwgt = wgts[2];
+	double iwgt = 1.0 - wgts[0];	// Oops. Weights reversed.
+	double jwgt = 1.0 - wgts[1];
+	double kwgt = 1.0 - wgts[2];
 
 	p0 = AccessIJK(i0,j0,k0); 
 	if (p0 == GetMissingValue()) return (GetMissingValue());
@@ -283,8 +327,6 @@ float LayeredGrid::GetValue(const DblArr3 &coords) const {
 	DblArr3 cCoords;
 	ClampCoord(coords, cCoords);
 
-	if (! LayeredGrid::InsideGrid(cCoords)) return(GetMissingValue());
-
 	const vector <size_t> &dims = GetDimensions();
 
 	// Figure out interpolation order
@@ -318,23 +360,13 @@ void LayeredGrid::GetUserCoordinates(
     Size_tArr3 cIndices;
     ClampIndex(indices, cIndices); 
 	
-	// First get coordinates of non-varying (horizontal) dimensions
+	// First get coordinates of (horizontal) dimensions
 	//
-	vector <size_t> dims = GetDimensions();
+	_sg2d.GetUserCoordinates(indices, coords);
 
-	for (int i=0; i<2; i++) {
-		size_t index = cIndices[i];
-
-		if (index >= dims[i]) {
-			index = dims[i] - 1;
-		}
-
-		coords[i] = cIndices[i] * _delta[i] + _minu[i];
-	}
-
-	// Now get coordinates of varying dimension
+	// Now get coordinates of z dimension
 	//
-	coords[2] = _rg.GetValueAtIndex(cIndices);
+	coords[2] = _zrg.GetValueAtIndex(cIndices);
 }
 
 
@@ -346,36 +378,8 @@ bool LayeredGrid::GetIndicesCell(
 	DblArr3 cCoords;
 	ClampCoord(coords, cCoords);
 
-	vector <size_t> dims = GetDimensions();
-
-	// Get horizontal indices from regular grid
-	//
-	for (int i=0; i<2; i++) {
-
-		if (cCoords[i] < _minu[i] || cCoords[i] > _maxu[i]) {
-			return(false);
-		}
-
-		if (_delta[i] != 0.0) {
-			indices[i] = (size_t) floor (
-				(cCoords[i]-_minu[i]) / _delta[i]
-			);
-
-			// Edge case
-			//
-			if (indices[i] == dims[i]-1) indices[i]--;
-		}
-
-		VAssert((indices[i]<dims[i]-1) || (indices[i] == 0 && dims[i] == 1));
-	}
-
-	// Now find index for layered grid
-	//
-	size_t k;
-	int rc = _bsearchKIndexCell(indices[0],indices[1],cCoords[2], k);
-	if (rc != 0) return (false);
-
-	indices[2] = k;
+	double dummy[3];
+	return(_insideGrid(coords, indices, dummy));
 
 	return(true);
 }
@@ -399,18 +403,20 @@ bool LayeredGrid::InsideGrid(const DblArr3 &coords) const {
 LayeredGrid::ConstCoordItrLayered::ConstCoordItrLayered(
 	const LayeredGrid *lg, bool begin
 ) : ConstCoordItrAbstract() {
-	_dims = lg->GetDimensions();
-	_delta = lg->_delta;
 
-	Grid::CopyFromArr3(lg->_minu, _minu);
-	Grid::CopyFromArr3(lg->_minu, _coords);
+	_lg = lg;
+	_nElements2D = lg->GetDimensions()[0] * lg->GetDimensions()[1];
+	_coords = vector <double> (3, 0.0);
 
-    _index = vector<size_t> (_dims.size(), 0);
-	_zCoordItr = lg->_rg.cbegin();
-
-    if (! begin) {
-        _index[_dims.size()-1] = _dims[_dims.size()-1];
-		_zCoordItr = lg->_rg.cend();
+    if (begin) {
+		_index2D = 0;
+		_zCoordItr = lg->_zrg.cbegin();
+		_itr2D = lg->_sg2d.ConstCoordBegin();
+	}
+	else {
+		_index2D = _nElements2D - 1;
+		_zCoordItr = lg->_zrg.cend();
+		_itr2D = lg->_sg2d.ConstCoordEnd();
     }
 }
 
@@ -418,77 +424,59 @@ LayeredGrid::ConstCoordItrLayered::ConstCoordItrLayered(
 LayeredGrid::ConstCoordItrLayered::ConstCoordItrLayered(
 	const ConstCoordItrLayered &rhs
 ) : ConstCoordItrAbstract() {
-	_index = rhs._index;
-	_dims = rhs._dims;
-	_minu = rhs._minu;
-	_delta = rhs._delta;
+	_lg = rhs._lg;
+	_nElements2D = rhs._nElements2D;
 	_coords = rhs._coords;
+	_index2D = rhs._index2D;
 	_zCoordItr = rhs._zCoordItr;
+	_itr2D = rhs._itr2D;
 }
 
 LayeredGrid::ConstCoordItrLayered::ConstCoordItrLayered() : ConstCoordItrAbstract() {
-	_index.clear();
-	_dims.clear();
-	_minu.clear();
-	_delta.clear();
 	_coords.clear();
 }
 
 
 void LayeredGrid::ConstCoordItrLayered::next() {
 
-	_index[0]++;
+	++_index2D;
+	++_itr2D;
 	++_zCoordItr;
-	_coords[0] += _delta[0];
-	if (_index[0] < _dims[0]) {
-		_coords[2] = *_zCoordItr; 
-		return;
+
+	// Check for overflow
+	//
+	if (_index2D == _nElements2D) {
+		_itr2D = _lg->_sg2d.ConstCoordBegin();
+		_index2D = 0;
 	}
 
-	_index[0] = 0;
-	_coords[0] = _minu[0];
-	_index[1]++;
-	_coords[1] += _delta[1];
+	_coords[0] = (*_itr2D)[0];
+	_coords[1] = (*_itr2D)[1];
 
-	if (_index[1] < _dims[1]) {
-		_coords[2] = *_zCoordItr; 
-		return;
-	}
+	_coords[2] = *_zCoordItr;
 
-	_index[1] = 0;
-	_coords[1] = _minu[1];
-	_index[2]++;
-	if (_index[2] < _dims[2]) {
-		_coords[2] = *_zCoordItr; 
-		return;
-	}
 }
 
 void LayeredGrid::ConstCoordItrLayered::next(const long &offset) {
 
 
-	if (! _index.size()) return;
+	long offset2D = offset % _nElements2D;
 
-    vector <size_t> maxIndex; ;
-    for (int i=0; i<_dims.size(); i++) maxIndex.push_back(_dims[i]-1);
-
-	long maxIndexL = Wasp::LinearizeCoords(maxIndex, _dims);
-	long newIndexL = Wasp::LinearizeCoords(_index, _dims) + offset;
-	if (newIndexL < 0) {
-		newIndexL = 0;
+	if (offset2D + _index2D < _nElements2D) {
+		_itr2D += offset;
+		_index2D += offset;
 	}
-	if (newIndexL > maxIndexL) {
-		_index = vector<size_t> (_dims.size(), 0);
-		_index[_dims.size()-1] = _dims[_dims.size()-1];
-		return;
+	else {
+		size_t o = (offset2D + _index2D) % _nElements2D;
+		_itr2D = _lg->_sg2d.ConstCoordBegin() + o;
+		_index2D = o;
 	}
 
-	_index = Wasp::VectorizeCoords(newIndexL, _dims);
+	_coords[0] = (*_itr2D)[0];
+	_coords[1] = (*_itr2D)[1];
+
 	_zCoordItr += offset;
-
-	_coords[0] = _index[0] * _delta[0] + _minu[0];
-	_coords[1] = _index[1] * _delta[1] + _minu[1];
-	_coords[2] = *_zCoordItr; 
+	_coords[2] = *_zCoordItr;
 }
 
 void LayeredGrid::_getBilinearWeights(const double coords[3],
@@ -670,10 +658,10 @@ double LayeredGrid::_interpolateVaryingCoord(
 	GetUserCoordinates(i1,j1,k1, x1, y1, z1);
 	double iwgt, jwgt;
 
-	c00 = _rg.AccessIJK( i0, j0, k0);
-	c01 = _rg.AccessIJK( i1, j0, k0);
-	c10 = _rg.AccessIJK( i0, j1, k0);
-	c11 = _rg.AccessIJK( i1, j1, k0);
+	c00 = _zrg.AccessIJK( i0, j0, k0);
+	c01 = _zrg.AccessIJK( i1, j0, k0);
+	c10 = _zrg.AccessIJK( i0, j1, k0);
+	c11 = _zrg.AccessIJK( i1, j1, k0);
 
 	if (x1!=x0) iwgt = fabs((x-x0) / (x1-x0));
 	else iwgt = 0.0;
@@ -684,108 +672,3 @@ double LayeredGrid::_interpolateVaryingCoord(
 	return(z);
 }
 
-namespace {
-double pointDotPlane(
-	const vector <double> &v1,
-	const vector <double> &v2,
-	const vector <double> &v3,
-	const vector <double> &p
-) {
-	double vec1_2[3] = {v2[0] - v1[0], v2[1] - v1[1], v2[2] - v1[2]};
-	double vec1_3[3] = {v3[0] - v1[0], v3[1] - v1[1], v3[2] - v1[2]};
-	double vp[3] = {p[0] - v1[0], p[1] - v1[1], p[2] - v1[2]};
-	double normal[3];
-
-	vcross(vec1_2, vec1_3, normal);
-
-	return(vdot(normal, vp));
-}
-};
-
-int LayeredGrid::_bsearchKIndexCell(
-	size_t i, size_t j, double z,
-	size_t &k
-) const {
-	k = 0;
-
-	vector <size_t> dims = GetDimensions();
-	
-    // Binary search for starting index of cell containing z
-    //
-
-	// Indices of bottom level triangle inside of column containing point
-	//
-	vector <size_t> v1idx = {i,j,0};
-	vector <size_t> v2idx = {i+1,j,0};
-	vector <size_t> v3idx = {i,j+1,0};
-
-	// Coordinates of bottom level triangle inside column containing point
-	// The horizontal coordinates (X & Y) don't change for the search
-	//
-	vector <double> v1;
-	vector <double> v2;
-	vector <double> v3;
-	vector <double> pt;
-
-	Grid::GetUserCoordinates(v1idx, v1);
-	Grid::GetUserCoordinates(v2idx, v2);
-	Grid::GetUserCoordinates(v3idx, v3);
-
-	// Coordinates of point we're looking for. X & Y are meaningless. Just
-	// use first triangle vertex.
-	//
-	pt = v1;
-	pt[2] = z;
-
-    size_t k0 = 0;
-    size_t k1 = dims[2]-1;
-
-	// See if point is below or above the column
-	//
-	v1[2] = _rg.AccessIJK(i, j, k0);
-	v2[2] = _rg.AccessIJK(i+1, j, k0);
-	v3[2] = _rg.AccessIJK(i, j+1, k0);
-	double d = pointDotPlane(v1, v2, v3, pt);
-	if (d<0.0) return(-1);
-
-	v1[2] = _rg.AccessIJK(i, j, k1);
-	v2[2] = _rg.AccessIJK(i+1, j, k1);
-	v3[2] = _rg.AccessIJK(i, j+1, k1);
-	d = pointDotPlane(v1, v2, v3, pt);
-	if (d>0.0) return(1);
-
-
-	// point is inside column. Now find it
-	//
-	while (k1-k0>1) {
-
-		// Update Z coordinate only for search
-		//
-		v1[2] = _rg.AccessIJK(i, j, (k0+k1)>>1);
-		v2[2] = _rg.AccessIJK(i+1, j, (k0+k1)>>1);
-		v3[2] = _rg.AccessIJK(i, j+1, (k0+k1)>>1);
-
-		// d is signed distance from plane. Sign determines if it is
-		// above triangle (positive) or below (negative)
-		//
-		double d = pointDotPlane(v1, v2, v3, pt);
-
-		// Pathlogical case. Point is on triangle.
-		//
-		if (d == 0.0) {
-			k0 = (k0+k1)>>1;
-			break;
-		}
-
-		if (d < 0.0) {
-			k1 = (k0+k1)>>1;
-		}
-		else {
-			k0 = (k0+k1)>>1;
-		}
-
-	}
-	k = k0;
-
-    return(0);
-}

--- a/lib/vdc/StretchedGrid.cpp
+++ b/lib/vdc/StretchedGrid.cpp
@@ -134,7 +134,8 @@ void StretchedGrid::GetUserCoordinates(
 
 bool StretchedGrid::GetIndicesCell(
 	const DblArr3 &coords,
-	Size_tArr3 &indices
+	Size_tArr3 &indices,
+	double wgts[3]
 ) const {
 
 	// Clamp coordinates on periodic boundaries to grid extents
@@ -151,6 +152,8 @@ bool StretchedGrid::GetIndicesCell(
 	bool inside = _insideGrid(x,y,z,i,j,k, xwgt, ywgt, zwgt);
 
 	if (! inside) return (false);
+	wgts[0] = xwgt[0];
+	wgts[1] = ywgt[0];
 
 	indices[0] = i;
 	indices[1] = j;
@@ -158,6 +161,7 @@ bool StretchedGrid::GetIndicesCell(
 	if (GetGeometryDim() == 2) return(true);
 
 	indices[2] = k;
+	wgts[2] = zwgt[0];
 
 	return(true);
 }

--- a/test_apps/grid_iter/test_grid_iter.cpp
+++ b/test_apps/grid_iter/test_grid_iter.cpp
@@ -199,10 +199,20 @@ VAPoR::LayeredGrid *make_layered_grid() {
 
 	vector <float *> blks = alloc_blocks(opt.bs, opt.dims);
 
-	vector <double> minu2d = {opt.minu[0], opt.minu[1]};
-	vector <double> maxu2d = {opt.maxu[0], opt.maxu[1]};
+	double deltax = opt.maxu[0] - opt.minu[0] / (opt.dims[0] - 1);
+	vector <double> xcoords;
+	for (int i=0; i<opt.dims[0]; i++) {
+		xcoords.push_back(opt.minu[0] + (i*deltax));
+	}
+
+	double deltay = opt.maxu[1] - opt.minu[1] / (opt.dims[1] - 1);
+	vector <double> ycoords;
+	for (int i=0; i<opt.dims[1]; i++) {
+		ycoords.push_back(opt.minu[1] + (i*deltay));
+	}
+
 	LayeredGrid *lg = new LayeredGrid(
-		opt.dims, opt.bs, blks, minu2d, maxu2d, *rg
+		opt.dims, opt.bs, blks, xcoords, ycoords, *rg
 	);
 
 	return(lg);

--- a/test_apps/smokeTests/gridTools.cpp
+++ b/test_apps/smokeTests/gridTools.cpp
@@ -574,18 +574,28 @@ LayeredGrid* MakeLayeredGrid(
     const std::vector<double> &minu,
     const std::vector<double> &maxu
 ) {
-    // Get horizontal dimensions
-    //
-    std::vector <double> hminu = { minu[X], minu[Y] };
-    std::vector <double> hmaxu = { maxu[X], maxu[Y] };
 
     std::vector< float* > zCoordBlocks = AllocateBlocks( bs, dims );
 
     RegularGrid rg( dims, bs, zCoordBlocks, minu, maxu );
     MakeRampOnAxis( &rg, minu[Z], maxu[Z], Z );
 
+    double deltax = maxu[0] - minu[0] / (dims[0] - 1);
+    vector <double> xcoords;
+    for (int i=0; i<dims[0]; i++) {
+        xcoords.push_back(minu[0] + (i*deltax));
+    }
+
+    // Get horizontal dimensions
+    //
+    double deltay = maxu[1] - minu[1] / (dims[1] - 1);
+    vector <double> ycoords;
+    for (int i=0; i<dims[1]; i++) {
+        ycoords.push_back(minu[1] + (i*deltay));
+    }
+
     std::vector< float* > dataBlocks = AllocateBlocks( bs, dims );
-    LayeredGrid *lg = new LayeredGrid(dims, bs, dataBlocks, hminu, hmaxu, rg);
+    LayeredGrid *lg = new LayeredGrid(dims, bs, dataBlocks, xcoords, ycoords, rg);
 
     return(lg);
 }

--- a/test_apps/smokeTests/testGrid.cpp
+++ b/test_apps/smokeTests/testGrid.cpp
@@ -20,8 +20,8 @@
 //    const std::vector <size_t> &dims,
 //    const std::vector <size_t> &bs,
 //    const std::vector <float *> &blks,
-//    const std::vector <double> &minu,
-//    const std::vector <double> &maxu,
+//    const std::vector <double> &xcoords,
+//    const std::vector <double> &ycoords,
 //    const RegularGrid &rg
 //  )
 //  RegularGrid::RegularGrid(


### PR DESCRIPTION
Closes #927 

This PR closes #1927, Add support for vertical coordinate transforms. Specifically, it adds for Atmosphere hybrid sigma pressure coordinates used by CAM (e.g. AdamPhilips/F2000C5_new120_025) and other data. 

This PR also generalizes the LayeredGrid class so that it supports non-uniformly sampled (stretched) horizontal coordinates. This was necessary to support the grid resulting from the conversion of Atmospheric hybrid coordinates to meters.