### PR TITLE
close #2396 - Improve performance of Grid::GetValue()

### DIFF
--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -1415,8 +1415,8 @@ protected:
 private:
 
  std::vector <size_t> _dims;	// dimensions of grid arrays
- Size_tArr3 _bs = {1,1,1};      // dimensions of each block
- Size_tArr3 _bdims = {1,1,1};   // dimensions (specified in blocks) of ROI
+ Size_tArr3 _bs = {{1,1,1}};      // dimensions of each block
+ Size_tArr3 _bdims = {{1,1,1}};   // dimensions (specified in blocks) of ROI
  std::vector <size_t> _bsDeprecated;	// legacy API
  std::vector <size_t> _bdimsDeprecated;	// legacy API
  std::vector <float *> _blks;

--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -135,8 +135,8 @@ public:
  //!
  //! \sa GetBlockSize();
  //
- const std::vector <size_t> &GetDimensionInBlks() const {
-    return(_bdims);
+ const std::vector <size_t> GetDimensionInBlks() const {
+    return(_bdimsDeprecated);
  }
 
  //! Return the internal blocking factor
@@ -145,7 +145,7 @@ public:
  //! to the constructor.
  //
  const std::vector <size_t> &GetBlockSize() const {
-	return(_bs);
+	return(_bsDeprecated);
  }
 
  //! Return the internal data structure containing a copy of the blocks
@@ -1373,9 +1373,10 @@ protected:
 	const Size_tArr3 indices,
 	Size_tArr3 &cIndices
  ) const {
-	cIndices = indices;
+	cIndices = {0,0,0};	
 
 	for (int i=0; i<dims.size(); i++) {
+		cIndices[i] = indices[i];
 		if (cIndices[i] >= dims[i]) {
 			cIndices[i] = dims[i] - 1;
 		}
@@ -1414,8 +1415,10 @@ protected:
 private:
 
  std::vector <size_t> _dims;	// dimensions of grid arrays
- std::vector <size_t> _bs;      // dimensions of each block
- std::vector <size_t> _bdims;   // dimensions (specified in blocks) of ROI
+ Size_tArr3 _bs = {1,1,1};      // dimensions of each block
+ Size_tArr3 _bdims = {1,1,1};   // dimensions (specified in blocks) of ROI
+ std::vector <size_t> _bsDeprecated;	// legacy API
+ std::vector <size_t> _bdimsDeprecated;	// legacy API
  std::vector <float *> _blks;
  std::vector <bool> _periodic;	// periodicity of boundaries
  std::vector <size_t> _minAbs;	// Offset to start of grid 

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -651,8 +651,8 @@ bool CurvilinearGrid::_insideGridHelperTerrain(
 	//
 	double lambda[3];
 	double pt[] = {x,y};
-	vector <size_t> iv = {i, i+1, i+1};
-	vector <size_t> jv = {j, j, j+1};
+	Size_tArr3 iv = {i, i+1, i+1};
+	Size_tArr3 jv = {j, j, j+1};
 	double tverts0[] = {
 		_xrg.AccessIJK(iv[0], jv[0], 0),
 		_yrg.AccessIJK(iv[0], jv[0], 0),
@@ -697,9 +697,8 @@ bool CurvilinearGrid::_insideGridHelperTerrain(
 
 		// Find k index of cell containing z. Already know i and j indices
 		//
-		vector <double> zcoords;
-
 		size_t nz = GetDimensions()[2];
+		vector <double> zcoords(nz);
 		for (int kk=0; kk<nz; kk++) {
 
 			// Interpolate Z coordinate across triangle
@@ -709,7 +708,7 @@ bool CurvilinearGrid::_insideGridHelperTerrain(
 				_zrg.AccessIJK(iv[1], jv[1], kk) * lambda[1] +
 				_zrg.AccessIJK(iv[2], jv[2], kk) * lambda[2];
 
-				zcoords.push_back(zk);
+				zcoords[kk] = zk;
 		}
 
 		if (! Wasp::BinarySearchRange(zcoords, z, k)) return(false);


### PR DESCRIPTION
close #2396 

This PR improves the performance of Grid::GetValuePtrAtIndex (used by Grid::GetValue) by removing all conditionals from the computation. The command 

% test_datamgr -tgetvalue -ftype cf Data/ROMS/jsmall/*nc

was used to evaluate performance. In the original version the run time for GetValuePtrAtIndex was about 10 seconds (~33% of total). In the new version the run time is less than one second.
