### PR TITLE
Install eventFilter on VSlider

### DIFF
--- a/apps/vaporgui/VSlider.cpp
+++ b/apps/vaporgui/VSlider.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <cmath>
 
+#include <QScrollEvent>
 #include <vapor/VAssert.h>
 #include "VSlider.h"
 
@@ -25,6 +26,8 @@ VSlider::VSlider( double min, double max )
 
     connect( _slider, &QSlider::sliderReleased,
         this, &VSlider::_sliderChanged );
+   
+    _slider->installEventFilter( new ScrollWheelEater );
 }
 
 void VSlider::SetValue( double value ) {
@@ -96,4 +99,13 @@ void VSlider::_sliderChanged() {
 void VSlider::_sliderChangedIntermediate( int position ) {
     double value = GetValue();
     emit ValueChangedIntermediate( value );
+}
+
+bool ScrollWheelEater::eventFilter( QObject* object, QEvent* event ) {
+    if (event->type() == QEvent::Wheel) {
+        QScrollEvent *scrollEvent = static_cast<QScrollEvent*>(event);
+        return true;
+    } else {
+        return QObject::eventFilter( object, event );
+    }
 }

--- a/apps/vaporgui/VSlider.cpp
+++ b/apps/vaporgui/VSlider.cpp
@@ -103,7 +103,6 @@ void VSlider::_sliderChangedIntermediate( int position ) {
 
 bool ScrollWheelEater::eventFilter( QObject* object, QEvent* event ) {
     if (event->type() == QEvent::Wheel) {
-        QScrollEvent *scrollEvent = static_cast<QScrollEvent*>(event);
         return true;
     } else {
         return QObject::eventFilter( object, event );

--- a/apps/vaporgui/VSlider.h
+++ b/apps/vaporgui/VSlider.h
@@ -43,3 +43,10 @@ signals:
     void ValueChanged( double value );
     void ValueChangedIntermediate( double value );
 };
+
+class ScrollWheelEater : public QObject {
+    Q_OBJECT
+
+protected:
+    bool eventFilter( QObject* obj, QEvent* event) override;
+};


### PR DESCRIPTION
This PR prevents the mouse scroll wheel from interacting with the VSlider, fixing #2382