### PR TITLE
Fixed #2225 - Broken Image Renderer

### DIFF
--- a/include/vapor/GeoTile.h
+++ b/include/vapor/GeoTile.h
@@ -246,7 +246,7 @@ public:
 
  //! Compute the size of a map in pixels at a specified lod and coordinates
  //!
- //! Given a rectangular boundary described to two points (the north-west and
+ //! Given a rectangular boundary described by two points (the north-west and
  //! south-east corner) in pixel coordinates, and a level of detail, this 
  //! method computes the size of the map (width and height) in pixels.
  //!
@@ -276,6 +276,23 @@ public:
 	w = _tile_width;
 	h = _tile_height;
  }
+
+ //! Map a rectanular region described by lat-lon coordinates to pixel coordinates
+ //!
+ //!
+ //! \param[in] geoSW A two-element array containing the longitude, and latitude coordinate, respectively, 
+ //! of the south-west corner of the region
+ //! \param[in] geoNE A two-element array containing the longitude, and latitude coordinate, respectively, 
+ //! of the north-east corner of the region
+ //! \param[in] lod The level of detail
+ //! \param[out] pixelSW Returns a two-element array containing the X, and Y pixel coordinates, respectively, 
+ //! of the south-west corner of the region
+ //! \param[out] pixelNE Returns a two-element array containing the X, and Y pixel coordinates, respectively, 
+ //! of the north-east corner of the region
+ //
+ void LatLongRectToPixelRect(
+	const double geoSW[2], const double geoNE[2], int lod, size_t pixelSW[2], size_t pixelNE[2]
+ ) const;
 
 private:
  size_t _pixel_size;

--- a/lib/render/GeoImageGeoTiff.cpp
+++ b/lib/render/GeoImageGeoTiff.cpp
@@ -492,12 +492,7 @@ bool GeoImageGeoTiff::_extractSubtexture(
 	//
 	// Get GeoTile's pixel coordinates of subregion. 
 	//
-	geotile->LatLongToPixelXY(
-		myGeoExtentsData[0], myGeoExtentsData[1], 0, pixelSW[0], pixelSW[1]
-	);
-	geotile->LatLongToPixelXY(
-		myGeoExtentsData[2], myGeoExtentsData[3], 0, pixelNE[0], pixelNE[1]
-	);
+	geotile->LatLongRectToPixelRect(myGeoExtentsData, myGeoExtentsData+2, 0, pixelSW, pixelNE);
 
 	int rc = geotile->MapSize(
 		pixelSW[0],pixelSW[1],pixelNE[0],pixelNE[1],0,nx, ny

--- a/lib/render/GeoImageTMS.cpp
+++ b/lib/render/GeoImageTMS.cpp
@@ -177,14 +177,7 @@ unsigned char *GeoImageTMS::GetImage(
 	size_t pixelSW[2];
 	size_t pixelNE[2];
 	size_t nx,ny;
-	_geotile->LatLongToPixelXY(
-		myGeoExtentsData[0], myGeoExtentsData[1], lod, 
-		pixelSW[0], pixelSW[1]
-	);
-	_geotile->LatLongToPixelXY(
-		myGeoExtentsData[2], myGeoExtentsData[3], lod, 
-		pixelNE[0], pixelNE[1]
-	);
+	_geotile->LatLongRectToPixelRect(myGeoExtentsData, myGeoExtentsData+2, lod, pixelSW, pixelNE);
 
 	int rc = _geotile->MapSize(
 		pixelSW[0],pixelSW[1],pixelNE[0],pixelNE[1],lod,nx, ny
@@ -337,14 +330,7 @@ int GeoImageTMS::_getBestLOD(
 		//
 		// Get GeoTile's pixel coordinates of subregion. 
 		//
-		_geotile->LatLongToPixelXY(
-			myGeoExtentsData[0], myGeoExtentsData[1], lod, 
-			pixelSW[0], pixelSW[1]
-		);
-		_geotile->LatLongToPixelXY(
-			myGeoExtentsData[2], myGeoExtentsData[3], lod, 
-			pixelNE[0], pixelNE[1]
-		);
+		_geotile->LatLongRectToPixelRect(myGeoExtentsData, myGeoExtentsData+2, lod, pixelSW, pixelNE);
 
 		int rc = _geotile->MapSize(
 			pixelSW[0],pixelSW[1],pixelNE[0],pixelNE[1],lod,nx, ny

--- a/lib/render/GeoTile.cpp
+++ b/lib/render/GeoTile.cpp
@@ -94,13 +94,6 @@ int GeoTile::GetMap(
 	size_t nx_global, ny_global;
 	MapSize(lod, nx_global, ny_global);
 
-	if (pixelX0 == pixelX1) {
-		pixelX1 = pixelX0 == 0 ? nx_global-1 : pixelX1-1;
-	}
-	if (pixelY0 == pixelY1) {	// Needed?
-		pixelY1 = pixelY0 == 0 ? ny_global-1 : pixelY1-1;
-	}
-
 	//
 	// resolution of requested sub region (map). Need to handle periodicity.
 	//
@@ -289,10 +282,6 @@ int GeoTile::MapSize(
 	size_t nx_global, ny_global;
 	MapSize(lod, nx_global, ny_global);
 
-	if (pixelX0 == pixelX1) {
-		pixelX1 = pixelX0 == 0 ? nx_global-1 : pixelX1-1;
-	}
-
 	if (pixelX0>nx_global-1) return(-1);
 	if (pixelY0>ny_global-1) return(-1);
 	if (pixelX1>nx_global-1) return(-1);
@@ -303,7 +292,7 @@ int GeoTile::MapSize(
 	//
 	// resolution of requested sub region (map). Need to handle periodicity.
 	//
-	if (pixelX1 > pixelX0) {
+	if (pixelX1 >= pixelX0) {
 		nx = pixelX1-pixelX0+1;
 	}
 	else {
@@ -343,6 +332,44 @@ void GeoTile::_CopyTileToMap(
 
 			mapptr += _pixel_size;
 			tileptr += _pixel_size;
+		}
+	}
+}
+
+void GeoTile::LatLongRectToPixelRect(
+    const double geoSW[2], const double geoNE[2], int lod, size_t pixelSW[2], size_t pixelNE[2]
+) const {
+
+	LatLongToPixelXY(geoSW[0], geoSW[1], lod, pixelSW[0], pixelSW[1]);
+	LatLongToPixelXY(geoNE[0], geoNE[1], lod, pixelNE[0], pixelNE[1]);
+
+	// Handle wraparound for longitude. I.e. if the S.W. and N.E. longitudes map to 
+	// same pixel coordinate, the region may span the entire globe, or they may simply span
+	// a small region contained within a single pixel. To determine the case we pick a longitude point
+	// between the geographic SW and NE corners, convert to pixels, and see if the midpoint is still
+	// in the same pixel.
+	//
+	if (pixelSW[0] == pixelNE[0]) {
+
+		// X pixel coordinate for SW and NE corners are the same. Determine if 
+		// longitude wraps around, or simply defines a small region residing entirely
+		// within a single pixel.
+		//
+		double midpointGeo[2] = {(geoNE[0]+geoSW[0])/2.0, (geoNE[1]+geoSW[1])/2.0};
+		size_t midpointPixel[2];
+		LatLongToPixelXY(midpointGeo[0], midpointGeo[1], lod, midpointPixel[0], midpointPixel[1]);
+
+		// If geographic midpoint resuls in a different pixel the region wraps around. 
+		// Correct the NE (or SW) pixel so we
+		// don't have identical pixel coordinates for both corners
+		//
+		size_t nx_global, ny_global;
+		MapSize(lod, nx_global, ny_global);
+		if (pixelSW[0] != midpointPixel[0]) {
+
+
+			if (pixelSW[0] == 0) pixelNE[0] = nx_global-1;
+			else pixelNE[0] = pixelSW[0]-1;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2225. Note that the problematic data set has a very small geographic region that maps to a single pixel in the NaturalEarth image bundled with VAPOR. The image renderer was not handling this edge case. Even though this PR fixes the problem, the image map still only covers a single pixel, so the results are not very thrilling.