### PR TITLE
Fix #2407: VDoubleSliderEdit broken

### DIFF
--- a/apps/vaporgui/PSliderEdit.cpp
+++ b/apps/vaporgui/PSliderEdit.cpp
@@ -43,8 +43,6 @@ void PDoubleSliderEdit::updateGUI() const
     auto p = getParams();
     _sliderEdit->SetMinimum(p->GetValueDouble(getTag() + USER_RANGE_MIN_TAG, _defaultRangeMin));
     _sliderEdit->SetMaximum(p->GetValueDouble(getTag() + USER_RANGE_MAX_TAG, _defaultRangeMax));
-    if (getParamsDouble() == .11)
-        std::cout << "foo" << std::endl;
     _sliderEdit->SetValue(getParamsDouble());
 }
 

--- a/apps/vaporgui/PSliderEdit.cpp
+++ b/apps/vaporgui/PSliderEdit.cpp
@@ -43,6 +43,8 @@ void PDoubleSliderEdit::updateGUI() const
     auto p = getParams();
     _sliderEdit->SetMinimum(p->GetValueDouble(getTag() + USER_RANGE_MIN_TAG, _defaultRangeMin));
     _sliderEdit->SetMaximum(p->GetValueDouble(getTag() + USER_RANGE_MAX_TAG, _defaultRangeMax));
+    if (getParamsDouble() == .11)
+        std::cout << "foo" << std::endl;
     _sliderEdit->SetValue(getParamsDouble());
 }
 

--- a/apps/vaporgui/VDoubleLineEdit.cpp
+++ b/apps/vaporgui/VDoubleLineEdit.cpp
@@ -38,8 +38,15 @@ void VDoubleLineEdit::_valueChanged() {
     double value;
     try {
         value = std::stod( str );
-        SetValueDouble( value );
-        emit ValueChanged( _value );
+
+        // If value changed, update and emit, otherwiese revert to old value
+        if ( value != _value ) {
+            SetValueDouble( value );
+            emit ValueChanged( _value );
+        }
+        else {
+            SetValueDouble( _value );
+        }
     } catch (const std::invalid_argument&) {
         SetValueDouble( _value );
     } catch (const std::out_of_range&) {

--- a/apps/vaporgui/VDoubleRangeMenu.h
+++ b/apps/vaporgui/VDoubleRangeMenu.h
@@ -29,7 +29,7 @@ protected:
     VDoubleLineEditAction* _minRangeAction;
     VDoubleLineEditAction* _maxRangeAction;
 
-public:
+public slots:
     //! Set the minimum value that the current widget can use 
     void SetMinimum( double min );
 

--- a/apps/vaporgui/VDoubleSliderEdit.cpp
+++ b/apps/vaporgui/VDoubleSliderEdit.cpp
@@ -99,10 +99,8 @@ void VDoubleSliderEdit::SetValue( double value ) {
 
     _value = value;
 
-    blockSignals( true );
     _lineEdit->SetValueDouble( _value );
     _slider->SetValue( _value );
-    blockSignals( false );
 
     if ( QObject::sender() != nullptr &&   
          QObject::sender() != this ) {     
@@ -124,10 +122,8 @@ void VDoubleSliderEdit::SetMinimum( double min ) {
         return;
     }
 
-    blockSignals( true );
     _slider->SetMinimum( min );
     _menu->SetMinimum( min );
-    blockSignals( false );
     
     // If sender() is a nullptr, then this fuction is being called from Update().
     // Don't emit anythong.  Otherwise, emit our signal.

--- a/apps/vaporgui/VDoubleSliderEdit.cpp
+++ b/apps/vaporgui/VDoubleSliderEdit.cpp
@@ -69,7 +69,6 @@ void VDoubleSliderEdit::SetSciNotation( bool value ) {
         return;
     }
     _lineEdit->SetSciNotation( value );
-    std::cout << "VDSEdit::FormatChanged() sci " << value << std::endl;
     emit FormatChanged();
 }
 
@@ -82,7 +81,6 @@ void VDoubleSliderEdit::SetNumDigits( int digits ) {
         return;
     }
     _lineEdit->SetNumDigits( digits );
-    std::cout << "VDSEdit::FormatChanged() dig " << digits<< std::endl;
     emit FormatChanged();
 }
 
@@ -108,7 +106,6 @@ void VDoubleSliderEdit::SetValue( double value ) {
 
     if ( QObject::sender() != nullptr &&   
          QObject::sender() != this ) {     
-        std::cout << "VDSEdit::ValueChanged() val " << _value << std::endl;
         emit ValueChanged( _value );
     }
 }
@@ -135,7 +132,6 @@ void VDoubleSliderEdit::SetMinimum( double min ) {
     // If sender() is a nullptr, then this fuction is being called from Update().
     // Don't emit anythong.  Otherwise, emit our signal.
     if ( QObject::sender() != nullptr ) {
-        std::cout << "VDSEdit::MinimumChanged " << min << std::endl;
         emit MinimumChanged( min );
     }
 }
@@ -160,7 +156,6 @@ void VDoubleSliderEdit::SetMaximum( double max ) {
     // If sender() is a nullptr, then this fuction is being called from Update().
     // Don't emit anythong.  Otherwise, emit our signal.
     if ( QObject::sender() != nullptr ) {
-        std::cout << "VDSEdit::MaximumChanged " << max << std::endl;
         emit MaximumChanged( max );
     }
 }

--- a/apps/vaporgui/VDoubleSliderEdit.cpp
+++ b/apps/vaporgui/VDoubleSliderEdit.cpp
@@ -54,8 +54,10 @@ void VDoubleSliderEdit::_makeContextMenu() {
         this, &VDoubleSliderEdit::SetNumDigits );
     connect( _menu, &VNumericFormatMenu::SciNotationChanged,
         this, &VDoubleSliderEdit::SetSciNotation );
-    connect( _menu, &VDoubleRangeMenu::MinChanged,
-        this, &VDoubleSliderEdit::SetMinimum );
+    //connect( _menu, &VDoubleRangeMenu::MinChanged,
+    //    this, &VDoubleSliderEdit::SetMinimum );
+    connect( _menu, SIGNAL( MinChanged( double )  ),
+        this, SLOT( SetMinimum( double ) ) );
     connect( _menu, &VDoubleRangeMenu::MaxChanged,
         this, &VDoubleSliderEdit::SetMaximum );
 }
@@ -69,6 +71,7 @@ void VDoubleSliderEdit::SetSciNotation( bool value ) {
         return;
     }
     _lineEdit->SetSciNotation( value );
+    std::cout << "VDSEdit::FormatChanged() sci " << value << std::endl;
     emit FormatChanged();
 }
 
@@ -81,6 +84,7 @@ void VDoubleSliderEdit::SetNumDigits( int digits ) {
         return;
     }
     _lineEdit->SetNumDigits( digits );
+    std::cout << "VDSEdit::FormatChanged() dig " << digits<< std::endl;
     emit FormatChanged();
 }
 
@@ -89,9 +93,9 @@ double VDoubleSliderEdit::GetValue() const {
 }
 
 void VDoubleSliderEdit::SetValue( double value ) {
-    // If the new value is unchanged or illegal, reset _lineEdit's text and return
-    if ( value == _value                ||
-         value <  _slider->GetMinimum() ||
+    // If the new value is illegal, reset _lineEdit's text and return
+    //if ( value == _value ||
+    if ( value <  _slider->GetMinimum() ||
          value >  _slider->GetMaximum()
     ) {
         _lineEdit->SetValueDouble( _value );
@@ -100,10 +104,26 @@ void VDoubleSliderEdit::SetValue( double value ) {
 
     _value = value;
 
+    blockSignals( true );
     _lineEdit->SetValueDouble( _value );
     _slider->SetValue( _value );
+    blockSignals( false );
 
-    if ( QObject::sender() != nullptr ) {
+    if ( _value == .91 ) {
+        //std::cout << "Test " << this << std::endl;
+        if ( QObject::sender() != nullptr)
+            std::cout << "QObject::sender() != nullptr " << QObject::sender() << " " << this << std::endl;
+        if ( QObject::sender() != this ) 
+            std::cout << "QObject::sender() != this " << QObject::sender() << " " << this << std::endl;
+        if ( QObject::sender() == this ) {
+            std::cout << "QObject::sender() == this " << QObject::sender() << " " << this << std::endl;
+            std::cout << "menu " << _menu << " " << this << std::endl;
+        }
+    }
+    //if ( QObject::sender() != nullptr &&   // if VDoubleLineEdit or VSlider are sending the signal
+    //     QObject::sender() != this ) {      // if not performing updateGUI()
+    if ( QObject::sender() != nullptr ) {   // if VDoubleLineEdit or VSlider are sending the signal
+        std::cout << "Emitting ValueChanged() " << _value << std::endl;
         emit ValueChanged( _value );
     }
 }
@@ -122,12 +142,15 @@ void VDoubleSliderEdit::SetMinimum( double min ) {
         return;
     }
 
+    blockSignals( true );
     _slider->SetMinimum( min );
     _menu->SetMinimum( min );
+    blockSignals( false );
     
     // If sender() is a nullptr, then this fuction is being called from Update().
     // Don't emit anythong.  Otherwise, emit our signal.
     if ( QObject::sender() != nullptr ) {
+        std::cout << "VDSEdit::MinimumChanged " << min << std::endl;
         emit MinimumChanged( min );
     }
 }
@@ -152,6 +175,7 @@ void VDoubleSliderEdit::SetMaximum( double max ) {
     // If sender() is a nullptr, then this fuction is being called from Update().
     // Don't emit anythong.  Otherwise, emit our signal.
     if ( QObject::sender() != nullptr ) {
+        std::cout << "VDSEdit::MaximumChanged " << max << std::endl;
         emit MaximumChanged( max );
     }
 }

--- a/apps/vaporgui/VDoubleSliderEdit.cpp
+++ b/apps/vaporgui/VDoubleSliderEdit.cpp
@@ -54,10 +54,8 @@ void VDoubleSliderEdit::_makeContextMenu() {
         this, &VDoubleSliderEdit::SetNumDigits );
     connect( _menu, &VNumericFormatMenu::SciNotationChanged,
         this, &VDoubleSliderEdit::SetSciNotation );
-    //connect( _menu, &VDoubleRangeMenu::MinChanged,
-    //    this, &VDoubleSliderEdit::SetMinimum );
-    connect( _menu, SIGNAL( MinChanged( double )  ),
-        this, SLOT( SetMinimum( double ) ) );
+    connect( _menu, &VDoubleRangeMenu::MinChanged,
+        this, &VDoubleSliderEdit::SetMinimum );
     connect( _menu, &VDoubleRangeMenu::MaxChanged,
         this, &VDoubleSliderEdit::SetMaximum );
 }
@@ -94,7 +92,6 @@ double VDoubleSliderEdit::GetValue() const {
 
 void VDoubleSliderEdit::SetValue( double value ) {
     // If the new value is illegal, reset _lineEdit's text and return
-    //if ( value == _value ||
     if ( value <  _slider->GetMinimum() ||
          value >  _slider->GetMaximum()
     ) {
@@ -109,21 +106,9 @@ void VDoubleSliderEdit::SetValue( double value ) {
     _slider->SetValue( _value );
     blockSignals( false );
 
-    if ( _value == .91 ) {
-        //std::cout << "Test " << this << std::endl;
-        if ( QObject::sender() != nullptr)
-            std::cout << "QObject::sender() != nullptr " << QObject::sender() << " " << this << std::endl;
-        if ( QObject::sender() != this ) 
-            std::cout << "QObject::sender() != this " << QObject::sender() << " " << this << std::endl;
-        if ( QObject::sender() == this ) {
-            std::cout << "QObject::sender() == this " << QObject::sender() << " " << this << std::endl;
-            std::cout << "menu " << _menu << " " << this << std::endl;
-        }
-    }
-    //if ( QObject::sender() != nullptr &&   // if VDoubleLineEdit or VSlider are sending the signal
-    //     QObject::sender() != this ) {      // if not performing updateGUI()
-    if ( QObject::sender() != nullptr ) {   // if VDoubleLineEdit or VSlider are sending the signal
-        std::cout << "Emitting ValueChanged() " << _value << std::endl;
+    if ( QObject::sender() != nullptr &&   
+         QObject::sender() != this ) {     
+        std::cout << "VDSEdit::ValueChanged() val " << _value << std::endl;
         emit ValueChanged( _value );
     }
 }

--- a/apps/vaporgui/VDoubleSliderEdit.cpp
+++ b/apps/vaporgui/VDoubleSliderEdit.cpp
@@ -102,8 +102,9 @@ void VDoubleSliderEdit::SetValue( double value ) {
     _lineEdit->SetValueDouble( _value );
     _slider->SetValue( _value );
 
-    if ( QObject::sender() != nullptr &&   
-         QObject::sender() != this ) {     
+    if ( QObject::sender() != nullptr &&
+         QObject::sender() != this
+    ) {
         emit ValueChanged( _value );
     }
 }

--- a/apps/vaporgui/VDoubleSliderEdit.h
+++ b/apps/vaporgui/VDoubleSliderEdit.h
@@ -26,6 +26,12 @@ public:
         bool rangeChangable = false
     );
 
+    //! Set the minimum allowable value for the VSlider and VDoubleLineEdit
+    void SetMinimum( double min );
+
+    //! Set the maximum allowable value for the VSlider and VDoubleLineEdit
+    void SetMaximum( double max );
+    
     void AllowUserRange(bool allowed=true);
 
     //! Get the value associated with the VSlider and VDoubleLineEdit
@@ -40,8 +46,14 @@ public:
     //! Get the number of digits displayed by the VDoubleLineEdit 
     virtual int GetNumDigits() const;
 
+    //! Set the number of digits displayed by the VDoubleLineEdit
+    virtual void SetNumDigits( int numDigits );
+
     //! Get whether the VDoubleLineEdit is being displayed with scientific notation
     virtual bool GetSciNotation() const;
+
+    //! Set whether the VDoubleLineEdit is being displayed with scientific notation
+    virtual void SetSciNotation( bool sciNotation );
 
     //! Show the context menu options for the entire widget, triggered on right-click
     virtual void ShowContextMenu( const QPoint& pos );
@@ -49,18 +61,6 @@ public:
 public slots:
     //! Set the current value displayed by the slider and line edit
     void SetValue( double value );
-    
-    //! Set the minimum allowable value for the VSlider and VDoubleLineEdit
-    void SetMinimum( double min );
-
-    //! Set the maximum allowable value for the VSlider and VDoubleLineEdit
-    void SetMaximum( double max );
-    
-    //! Set the number of digits displayed by the VDoubleLineEdit
-    virtual void SetNumDigits( int numDigits );
-
-    //! Set whether the VDoubleLineEdit is being displayed with scientific notation
-    virtual void SetSciNotation( bool sciNotation );
 
 protected:
     virtual void _makeContextMenu();

--- a/apps/vaporgui/VDoubleSliderEdit.h
+++ b/apps/vaporgui/VDoubleSliderEdit.h
@@ -46,21 +46,21 @@ public:
     //! Get the number of digits displayed by the VDoubleLineEdit 
     virtual int GetNumDigits() const;
 
-    //! Set the number of digits displayed by the VDoubleLineEdit
-    virtual void SetNumDigits( int numDigits );
-
     //! Get whether the VDoubleLineEdit is being displayed with scientific notation
     virtual bool GetSciNotation() const;
+
+public slots:
+    //! Set the current value displayed by the slider and line edit
+    void SetValue( double value );
+    
+    //! Set the number of digits displayed by the VDoubleLineEdit
+    virtual void SetNumDigits( int numDigits );
 
     //! Set whether the VDoubleLineEdit is being displayed with scientific notation
     virtual void SetSciNotation( bool sciNotation );
 
     //! Show the context menu options for the entire widget, triggered on right-click
     virtual void ShowContextMenu( const QPoint& pos );
-
-public slots:
-    //! Set the current value displayed by the slider and line edit
-    void SetValue( double value );
 
 protected:
     virtual void _makeContextMenu();

--- a/apps/vaporgui/VDoubleSliderEdit.h
+++ b/apps/vaporgui/VDoubleSliderEdit.h
@@ -26,12 +26,6 @@ public:
         bool rangeChangable = false
     );
 
-    //! Set the minimum allowable value for the VSlider and VDoubleLineEdit
-    void SetMinimum( double min );
-
-    //! Set the maximum allowable value for the VSlider and VDoubleLineEdit
-    void SetMaximum( double max );
-    
     void AllowUserRange(bool allowed=true);
 
     //! Get the value associated with the VSlider and VDoubleLineEdit
@@ -46,14 +40,8 @@ public:
     //! Get the number of digits displayed by the VDoubleLineEdit 
     virtual int GetNumDigits() const;
 
-    //! Set the number of digits displayed by the VDoubleLineEdit
-    virtual void SetNumDigits( int numDigits );
-
     //! Get whether the VDoubleLineEdit is being displayed with scientific notation
     virtual bool GetSciNotation() const;
-
-    //! Set whether the VDoubleLineEdit is being displayed with scientific notation
-    virtual void SetSciNotation( bool sciNotation );
 
     //! Show the context menu options for the entire widget, triggered on right-click
     virtual void ShowContextMenu( const QPoint& pos );
@@ -61,6 +49,18 @@ public:
 public slots:
     //! Set the current value displayed by the slider and line edit
     void SetValue( double value );
+    
+    //! Set the minimum allowable value for the VSlider and VDoubleLineEdit
+    void SetMinimum( double min );
+
+    //! Set the maximum allowable value for the VSlider and VDoubleLineEdit
+    void SetMaximum( double max );
+    
+    //! Set the number of digits displayed by the VDoubleLineEdit
+    virtual void SetNumDigits( int numDigits );
+
+    //! Set whether the VDoubleLineEdit is being displayed with scientific notation
+    virtual void SetSciNotation( bool sciNotation );
 
 protected:
     virtual void _makeContextMenu();

--- a/apps/vaporgui/VIntLineEdit.cpp
+++ b/apps/vaporgui/VIntLineEdit.cpp
@@ -47,8 +47,15 @@ void VIntLineEdit::_valueChanged() {
         }
         
         value = (int)std::stod( str );
-        SetValueInt( value );
-        emit ValueChanged( _value );
+
+        // If value changed, update and emit, otherwiese revert to old value
+        if ( value != _value ) {
+            SetValueInt( value );
+            emit ValueChanged( _value );
+        }
+        else {
+            SetValueInt( _value );
+        }
     } catch (const std::invalid_argument&) {
         SetValueInt( _value );
     } catch (const std::out_of_range&) {

--- a/apps/vaporgui/VIntSliderEdit.cpp
+++ b/apps/vaporgui/VIntSliderEdit.cpp
@@ -101,7 +101,7 @@ void VIntSliderEdit::SetValue( int value ) {
     _lineEdit->SetValueInt( _value );
     _slider->SetValue( _value );
 
-    if ( QObject::sender() != nullptr ||
+    if ( QObject::sender() != nullptr &&
          QObject::sender() != this ) 
     {
         emit ValueChanged( _value );

--- a/apps/vaporgui/VIntSliderEdit.cpp
+++ b/apps/vaporgui/VIntSliderEdit.cpp
@@ -101,7 +101,9 @@ void VIntSliderEdit::SetValue( int value ) {
     _lineEdit->SetValueInt( _value );
     _slider->SetValue( _value );
 
-    if ( QObject::sender() != nullptr ) {
+    if ( QObject::sender() != nullptr ||
+         QObject::sender() != this ) 
+    {
         emit ValueChanged( _value );
     }
 }


### PR DESCRIPTION
This fixes #2407, which showed the slider setting the wrong value when moved and released quickly.  It also ensures that #2390 is not reintroduced, which regarded the V*SliderEdit emitting multiple signals.

Note that this PR does contain a workaround for a bug that appears to be related to Qt's context menus.  When the P*SliderEdit calls V*SliderEdit's::SetValue() during updateGUI(), the QObject::sender() function should always return nullptr since SetValue() is not being triggered by a signal.  

However when the PWidget calls SetValue() after the V*SliderEdit's _minimum range value_ is changed, QObject::sender() returns a 'this' pointer, which should never happen.

The workaround is to catch when "QObject::sender == this" and not emit a signal in this circumstance.  This is found in VDoubleSliderEdit.cpp:106 and VIntSliderEdit.cpp:105.