### PR TITLE
Fix #2418 Flow: Streamline data file can only be written once

### DIFF
--- a/apps/vaporgui/FlowEventRouter.cpp
+++ b/apps/vaporgui/FlowEventRouter.cpp
@@ -66,8 +66,7 @@ FlowEventRouter::FlowEventRouter(QWidget *parent, ControlExec *ce)
         
         new PSection("Write Flowlines to File", {
             new PFileOpenSelector(FP::_flowlineOutputFilenameTag, "Target file"),
-            new PButton("Write to file", 
-                [](ParamsBase *p){p->SetValueLong(FP::_needFlowlineOutputTag, "", true);}),
+            (new PButton("Write to file", [](ParamsBase *p){p->SetValueLong(FP::_needFlowlineOutputTag, "", true);}))->DisableUndo(),
             new PLabel("Specify variables to sample and output along the flowlines"),
             new PMultiVarSelector(FP::_flowOutputMoreVariablesTag)
         }),

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -2230,7 +2230,6 @@ bool MainForm::eventFilter(QObject *obj, QEvent *event) {
 	//
 	if (event->type() == ParamsChangeEvent)
     {
-        _paramsEventQueued = false;
 		QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 		
 		if (_stats) 
@@ -2263,13 +2262,14 @@ bool MainForm::eventFilter(QObject *obj, QEvent *event) {
 		update();
 
 		QApplication::restoreOverrideCursor();
+        
+        _paramsEventQueued = false;
 		return(false);
 
 	}
     
     if (event->type() == ParamsIntermediateChangeEvent)
     {
-        _paramsEventQueued = false;
         // Rendering the GUI becomes a bottleneck
 //        _tabMgr->Update();
         
@@ -2285,6 +2285,7 @@ bool MainForm::eventFilter(QObject *obj, QEvent *event) {
         
 //        update();
         
+        _paramsEventQueued = false;
         return(false);
         
     }

--- a/apps/vaporgui/PButton.cpp
+++ b/apps/vaporgui/PButton.cpp
@@ -1,5 +1,6 @@
 #include "PButton.h"
 #include "VPushButton.h"
+#include <vapor/ParamsMgr.h>
 
 PButton::PButton(std::string label, Callback cb)
 : PWidget("", _button = new VPushButton(label)), _cb(cb)
@@ -7,7 +8,21 @@ PButton::PButton(std::string label, Callback cb)
     QObject::connect(_button, &VPushButton::ButtonClicked, this, &PButton::clicked);
 }
 
+PButton *PButton::DisableUndo()
+{
+    _disableUndo = true;
+    return this;
+}
+
 void PButton::clicked()
 {
-    _cb(getParams());
+    if (_disableUndo) {
+        auto pm = getParamsMgr();
+        bool state = pm->GetSaveStateUndoEnabled();
+        pm->SetSaveStateUndoEnabled(false);
+        _cb(getParams());
+        pm->SetSaveStateUndoEnabled(state);
+    } else {
+        _cb(getParams());
+    }
 }

--- a/apps/vaporgui/PButton.h
+++ b/apps/vaporgui/PButton.h
@@ -19,6 +19,7 @@ class PButton : public PWidget {
     bool _disableUndo = false;
 public:
     PButton(std::string label, Callback cb);
+    // @copydoc VAPoR::ParamsMgr::SetSaveStateUndoEnabled(bool)
     PButton *DisableUndo();
 protected:
     void updateGUI() const override {}

--- a/apps/vaporgui/PButton.h
+++ b/apps/vaporgui/PButton.h
@@ -16,10 +16,13 @@ class PButton : public PWidget {
     typedef std::function<void(VAPoR::ParamsBase*)> Callback;
     VPushButton *_button;
     const Callback _cb;
+    bool _disableUndo = false;
 public:
     PButton(std::string label, Callback cb);
+    PButton *DisableUndo();
 protected:
     void updateGUI() const override {}
+    bool requireParamsMgr() const override { return _disableUndo; }
 private:
     void clicked();
 };

--- a/include/vapor/ParamsMgr.h
+++ b/include/vapor/ParamsMgr.h
@@ -509,10 +509,16 @@ public:
 
  bool GetSaveStateEnabled() const { return (_ssave.GetEnabled()); }
     
+    
+    //! Enable/Disable adding params changes to the undo list.
+    //! When enabled, behaves as normal.
+    //! When disabled, params are saved as normal, however the undo list is not updated.
+    //! An example use case is to store a computed value in the params database.
     void SetSaveStateUndoEnabled( bool enabled) {
        _ssave.SetUndoEnabled(enabled);
     }
 
+    //! Get whether updating the undo list is enabled.
     bool GetSaveStateUndoEnabled() const { return (_ssave.GetUndoEnabled()); }
 
  //! Restore state to previously saved state

--- a/include/vapor/ParamsMgr.h
+++ b/include/vapor/ParamsMgr.h
@@ -508,6 +508,12 @@ public:
  }
 
  bool GetSaveStateEnabled() const { return (_ssave.GetEnabled()); }
+    
+    void SetSaveStateUndoEnabled( bool enabled) {
+       _ssave.SetUndoEnabled(enabled);
+    }
+
+    bool GetSaveStateUndoEnabled() const { return (_ssave.GetUndoEnabled()); }
 
  //! Restore state to previously saved state
  //!
@@ -628,6 +634,12 @@ private:
   }
 
   bool GetEnabled() const { return (_enabled); }
+     
+     void SetUndoEnabled(bool b) {
+         if (! _groups.empty()) return;    // Can't change inside group
+         _addToUndoEnabled = b;
+     }
+     bool GetUndoEnabled() const { return _addToUndoEnabled; }
 
   const XmlNode *GetTopUndo(string &description) const;
   const XmlNode *GetTopRedo(string &description) const;
@@ -660,6 +672,7 @@ private:
  private:
 
   bool _enabled;
+  bool _addToUndoEnabled = true;
   int _stackSize;
   const XmlNode *_rootNode;
   const XmlNode *_state0;

--- a/lib/params/ParamsMgr.cpp
+++ b/lib/params/ParamsMgr.cpp
@@ -1414,7 +1414,9 @@ void ParamsMgr::PMgrStateSave::Save(
 
 	// It not inside a group push this element onto the stack
 	//
-	_undoStack.push_back(make_pair(description, new XmlNode(*_rootNode)));
+    if (GetUndoEnabled())
+        _undoStack.push_back(make_pair(description, new XmlNode(*_rootNode)));
+    
 //#define DEBUG
 #ifdef	DEBUG
 	cout << "ParamsMgr::PMgrStateSave::Save() : saving node " << 

--- a/lib/render/ControlExecutive.cpp
+++ b/lib/render/ControlExecutive.cpp
@@ -160,12 +160,12 @@ int ControlExec::Paint(string winName, bool fast){
 
 	// Disable state saving when generating the transfer function
 	//
-	bool enabled = _paramsMgr->GetSaveStateEnabled();
-	_paramsMgr->SetSaveStateEnabled(false);
+	bool enabled = _paramsMgr->GetSaveStateUndoEnabled();
+	_paramsMgr->SetSaveStateUndoEnabled(false);
 
 	int rc =  v->paintEvent(fast);
 
-	_paramsMgr->SetSaveStateEnabled(enabled);
+	_paramsMgr->SetSaveStateUndoEnabled(enabled);
 
 
 	if(rc) SetErrMsg("Error performing paint event");


### PR DESCRIPTION
Fix #2418

Fixed the bug by removing code that prevented changes to the params database from occurring from within a paint event. This would in the past have caused other bugs but I previously put checks in place that prevent paint events from queueing recursively.

Also added a mechanism for non-undoable actions which the write to file button now uses. This is also now automatically applied to all params changes from within a paint event since these are only supposed to be a side effect of an action the user performed in the GUI which will be undoable.