### PR TITLE
Pop up message on zero-valued velocity fields.

### DIFF
--- a/include/vapor/Particle.h
+++ b/include/vapor/Particle.h
@@ -13,6 +13,7 @@ namespace flow
 {
 enum FLOW_ERROR_CODE    // these enum values are available in the flow namespace.
 {
+    FIELD_ALL_ZERO       =  4,
     MISSING_VAL          =  3,
     NO_ADVECT_HAPPENED   =  2,
     ADVECT_HAPPENED      =  1,

--- a/lib/flow/Advection.cpp
+++ b/lib/flow/Advection.cpp
@@ -99,10 +99,21 @@ int Advection::AdvectSteps( Field* velocity, double deltaT, size_t maxSteps, ADV
                     rv = _advectRK4(   velocity, past0, dt, p1 ); break;
            }
 
-           if( rv == 0 ){  // Advection successful, keep the new particle.
-                happened = true;
-                s.emplace_back( p1 );
-                numberOfSteps++;
+           if( rv == 0 ){  // Advection successful!
+                // The new particle *may* be the same as the old particle in case 
+                // there's a sink, meaning the velocity is zero.
+                // In that case, we mark p1 as "special" and terminate the current stream.
+                if( p1.location == past0.location ) {
+                    p1.SetSpecial( true );
+                    s.emplace_back( p1 );
+                    _separatorCount[streamIdx]++;
+                    break;
+                }
+                else {
+                    happened = true;
+                    s.emplace_back( p1 );
+                    numberOfSteps++;
+                }
             }
             else if( rv == MISSING_VAL ) {
 

--- a/lib/flow/VaporField.cpp
+++ b/lib/flow/VaporField.cpp
@@ -608,6 +608,13 @@ int VaporField::CalcDeltaTFromCurrentTimeStep( double& delT ) const
         }
     }
 
+    // If all sampled locations are missing values or zero values,
+    //   we give deltaT an arbitrary value and return a special value.
+    if( maxmag == 0.0 ) {
+        delT = glm::distance( minxyz, maxxyz ) / 1000.0;
+        return flow::FIELD_ALL_ZERO;
+    }
+
     // Let's dictate that using the maximum velocity FROM OUR SAMPLES
     // a particle needs 500 steps to travel the entire space.
     const float desiredNum = 500.0f;

--- a/lib/render/FlowRenderer.cpp
+++ b/lib/render/FlowRenderer.cpp
@@ -252,8 +252,11 @@ int FlowRenderer::_paintGL( bool fast )
     {
         // First step is to re-calculate deltaT
         rv = _velocityField.CalcDeltaTFromCurrentTimeStep( _cache_deltaT );
-        if( rv != 0 )
-        {
+        if( rv == flow::FIELD_ALL_ZERO ) {
+            MyBase::SetErrMsg("The velocity field seems to contain only zero values!");
+            return flow::PARAMS_ERROR;
+        }
+        else if( rv != 0 ) {
             MyBase::SetErrMsg("Update deltaT failed!");
             return rv;
         }

--- a/lib/render/FlowRenderer.cpp
+++ b/lib/render/FlowRenderer.cpp
@@ -239,6 +239,14 @@ int FlowRenderer::_paintGL( bool fast )
         MyBase::SetErrMsg("Please provide at least 1 field variables for advection!");
         return flow::PARAMS_ERROR;
     }
+    // In case a color mapping variable wasn't specified, it's also considered an ill-formed
+    //   parameter. That is because, the color mapping variable is required in private method
+    //   _renderAdvectionHelper() and there isn't an obvious way to satisfy it without a
+    //   color mapping variable.
+    if( _colorField.ScalarName.empty() ) {
+        MyBase::SetErrMsg("Please provide a color mapping variable!");
+        return flow::PARAMS_ERROR;
+    }
 
     if( _velocityStatus == FlowStatus::SIMPLE_OUTOFDATE )
     {
@@ -377,7 +385,6 @@ int FlowRenderer::_paintGL( bool fast )
 
         _advectionComplete = true;
     }
-
 
     if( !_coloringComplete )
     {


### PR DESCRIPTION
This PR handles zero valued velocity fields a little better, and also pops up a message box to inform users what's going on. It mitigates #2487 .

Note: this PR should only be merged after #2502 is fixed. 