### PR TITLE
Improve usability when replacing a dataset in a session file from the command line

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -469,8 +469,14 @@ MainForm::MainForm(
 	//
     
 	if (files.size() && files[0].endsWith(".vs3")) {
-		sessionOpen(files[0]);
+        bool loadDatasetsFromSession = files.size() == 1;
+		sessionOpen(files[0], loadDatasetsFromSession);
 		files.erase(files.begin());
+        
+        if (!loadDatasetsFromSession && _controlExec->GetDataNames().size() > 1) {
+            fprintf(stderr, "Cannot replace dataset from command line in session which contains multiple open datasets.");
+            exit(1);
+        }
 	}
 	else {
 		sessionNew();
@@ -484,7 +490,7 @@ MainForm::MainForm(
         
         string fmt;
         if (determineDatasetFormat(paths, &fmt)) {
-            loadDataHelper(paths, "", "", fmt, true);
+            loadDataHelper(paths, "", "", fmt, true, ReplaceFirst);
         } else {
             MSG_ERR("Could not determine dataset format for command line parameters");
         }
@@ -1375,7 +1381,7 @@ void MainForm::createMenus(){
 #endif
 }
 
-void MainForm::sessionOpenHelper(string fileName) {
+void MainForm::sessionOpenHelper(string fileName, bool loadDatasets) {
 
 	// Clear out the current session:
 
@@ -1409,15 +1415,20 @@ void MainForm::sessionOpenHelper(string fileName) {
 	GUIStateParams *newP = GetStateParams();
 	dataSetNames = newP->GetOpenDataSetNames();
 
-	for (int i=0; i<dataSetNames.size(); i++) {
-        string name = dataSetNames[i];
-        vector<string> paths = newP->GetOpenDataSetPaths(name);
-        if (std::all_of(paths.begin(), paths.end(), [](string path){ return FileUtils::Exists(path); })) {
-            loadDataHelper(paths, "", "", newP->GetOpenDataSetFormat(name), true, false);
-        } else {
-            newP->RemoveOpenDateSet(name);
+    if (loadDatasets) {
+        for (int i=0; i<dataSetNames.size(); i++) {
+            string name = dataSetNames[i];
+            vector<string> paths = newP->GetOpenDataSetPaths(name);
+            if (std::all_of(paths.begin(), paths.end(), [](string path){ return FileUtils::Exists(path); })) {
+                loadDataHelper(paths, "", "", newP->GetOpenDataSetFormat(name), true, DatasetExistsAction::AddNew);
+            } else {
+                newP->RemoveOpenDateSet(name);
+            }
         }
-	}
+    } else {
+        for (auto name : dataSetNames)
+            newP->RemoveOpenDateSet(name);
+    }
 
 	_vizWinMgr->Restart();
 	_tabMgr->Restart();
@@ -1427,7 +1438,7 @@ void MainForm::sessionOpenHelper(string fileName) {
 	_controlExec->UndoRedoClear();
 }
 
-void MainForm::sessionOpen(QString qfileName)
+void MainForm::sessionOpen(QString qfileName, bool loadDatasets)
 {
     // Disable "Are you sure?" popup in debug build
 #ifdef NDEBUG
@@ -1478,7 +1489,7 @@ void MainForm::sessionOpen(QString qfileName)
 
 	string fileName = qfileName.toStdString();
     _sessionNewFlag = false;
-	sessionOpenHelper(fileName);
+	sessionOpenHelper(fileName, loadDatasets);
 
 	GUIStateParams *p = GetStateParams();
 	p->SetCurrentSessionFile(fileName);
@@ -1735,7 +1746,7 @@ bool MainForm::openDataHelper(
 
 void MainForm::loadDataHelper(
 	const vector <string> &files, string prompt, string filter, string format,
-	bool multi, bool promptToReplaceExistingDataset
+	bool multi, DatasetExistsAction existsAction
 ) {
 
 	vector <string> myFiles = files;
@@ -1769,7 +1780,7 @@ void MainForm::loadDataHelper(
 
 	// Generate data set name 
 	//
-	string dataSetName = _getDataSetName(myFiles[0], promptToReplaceExistingDataset);
+	string dataSetName = _getDataSetName(myFiles[0], existsAction);
 	if (dataSetName.empty()) return;
 	
 
@@ -2840,12 +2851,14 @@ void MainForm::endAnimCapture(){
 	_captureSingleTiffAction->setEnabled(true);
 }
 
-string MainForm::_getDataSetName(string file, bool promptToReplaceExistingDataset) {
+string MainForm::_getDataSetName(string file, DatasetExistsAction existsAction) {
 
 	vector <string> names = _controlExec->GetDataNames();
-	if (names.empty() || !promptToReplaceExistingDataset) {
+	if (names.empty() || existsAction == AddNew) {
 		return(makename(file));
-	}
+    } else if (existsAction == ReplaceFirst) {
+        return names[0];
+    }
 
 	string newSession = "New Dataset";
 

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -304,10 +304,11 @@ private:
 	const vector <string> &options = vector <string> ()
  );
 
+ enum DatasetExistsAction { Prompt, AddNew, ReplaceFirst };
  void loadDataHelper(
 	const std::vector <string> &files, string prompt, 
                      string filter, string format, bool multi,
-                     bool promptToReplaceExistingDataset = true
+                     DatasetExistsAction existsAction = Prompt
  );
  void _createCaptureMenu();
  void _createToolsMenu();
@@ -323,7 +324,7 @@ private:
  void createToolBars();
  void _createProgressWidget();
  void _disableProgressWidget();
- virtual void sessionOpenHelper(string fileName);
+ virtual void sessionOpenHelper(string fileName, bool loadDatasets = true);
     
  template<class T> bool isDatasetValidFormat(const std::vector<std::string> &paths) const;
  bool determineDatasetFormat(const std::vector<std::string> &paths, std::string *fmt) const;
@@ -338,13 +339,13 @@ private:
 
  void _fileSaveHelper(string path);
 
- string _getDataSetName(string file, bool promptToReplaceExistingDataset = true);
+ string _getDataSetName(string file, DatasetExistsAction existsAction = Prompt);
 
 private slots:   
  void _plotClosed();
  void _statsClosed();
  void _pythonClosed();
- void sessionOpen(QString qfileName="");
+ void sessionOpen(QString qfileName="", bool loadDatasets = true);
  void fileSave();
  void fileSaveAs();
  void fileExit();


### PR DESCRIPTION
- No longer open the to-be-replaced dataset
- No longer popup and ask to replace or add new. Behavior stays the same when using GUI
- Only allow command line replacement for session file with single dataset