### PR TITLE
Auto determine scalar based on version

### DIFF
--- a/include/vapor/OSPRay.h
+++ b/include/vapor/OSPRay.h
@@ -10,6 +10,7 @@ namespace VOSP {
 RENDER_API int Initialize(int *argc, char **argv);
 RENDER_API int Shutdown();
 RENDER_API std::string Version();
+RENDER_API bool IsVersionAtLeast(int major, int minor);
 
 #ifdef BUILD_OSPRAY
 OSPData NewCopiedData(const void *data, OSPDataType type, uint64_t numItems1, uint64_t numItems2=1, uint64_t numItems3=1);

--- a/lib/render/OSPRay.cpp
+++ b/lib/render/OSPRay.cpp
@@ -74,6 +74,22 @@ std::string VOSP::Version()
 #endif
 }
 
+bool VOSP::IsVersionAtLeast(int testMajor, int testMinor)
+{
+#ifdef BUILD_OSPRAY
+    long major = ospDeviceGetProperty(ospGetCurrentDevice(), OSP_DEVICE_VERSION_MAJOR);
+    long minor = ospDeviceGetProperty(ospGetCurrentDevice(), OSP_DEVICE_VERSION_MINOR);
+    
+    if (major > testMajor || (major == testMajor && minor >= testMinor))
+        return true;
+    
+    return false;
+    
+#else
+    return false;
+#endif
+}
+
 #ifdef BUILD_OSPRAY
 
 OSPData VOSP::NewCopiedData(const void *data, OSPDataType type, uint64_t numItems1, uint64_t numItems2, uint64_t numItems3)

--- a/lib/render/VolumeOSPRay.cpp
+++ b/lib/render/VolumeOSPRay.cpp
@@ -224,6 +224,8 @@ int VolumeOSPRay::LoadData(const Grid *grid)
     
     if (dynamic_cast<const RegularGrid *>(grid))
         _ospSampleRateScalar = 1.f;
+    else if (VOSP::IsVersionAtLeast(2, 5))
+        _ospSampleRateScalar = 1.f;
     else
         _ospSampleRateScalar = _guessSamplingRateScalar(grid);
     
@@ -728,18 +730,21 @@ OSPVolume VolumeOSPRay::_loadVolumeStructured(const Grid *grid)
     ospCommit(data);
     ospSetObject(volume, "index", data);
     ospRelease(data);
+    indices.clear();
     Progress::Update(3);
     
     data = VOSP::NewCopiedData(startIndex.data(), OSP_UINT, startIndex.size());
     ospCommit(data);
     ospSetObject(volume, "cell.index", data);
     ospRelease(data);
+    startIndex.clear();
     Progress::Update(4);
     
     data = VOSP::NewCopiedData(cellType.data(), OSP_UCHAR, cellType.size());
     ospCommit(data);
     ospSetObject(volume, "cell.type", data);
     ospRelease(data);
+    cellType.clear();
     Progress::Update(5);
     Progress::Finish();
     
@@ -964,33 +969,35 @@ OSPVolume VolumeOSPRay::_loadVolumeUnstructured(const Grid *grid)
     ospCommit(data);
     ospSetObject(volume, "vertex.data", data);
     ospRelease(data);
+    delete [] vdata;
     Progress::Update(1);
     
     data = VOSP::NewCopiedData(cdata, OSP_VEC3F, nVerts);
     ospCommit(data);
     ospSetObject(volume, "vertex.position", data);
     ospRelease(data);
+    delete [] cdata;
     Progress::Update(2);
     
     data = VOSP::NewCopiedData(cellIndices.data(), OSP_UINT, cellIndices.size());
     ospCommit(data);
     ospSetObject(volume, "index", data);
     ospRelease(data);
+    cellIndices.clear();
     Progress::Update(3);
     
     data = VOSP::NewCopiedData(cellStarts.data(), OSP_UINT, cellStarts.size());
     ospCommit(data);
     ospSetObject(volume, "cell.index", data);
     ospRelease(data);
+    cellStarts.clear();
     Progress::Update(4);
     
     data = VOSP::NewCopiedData(cellTypes.data(), OSP_UCHAR, cellTypes.size());
     ospCommit(data);
     ospSetObject(volume, "cell.type", data);
     ospRelease(data);
-    
-    delete [] vdata;
-    delete [] cdata;
+    cellTypes.clear();
     Progress::Update(5);
     Progress::Finish();
     

--- a/lib/render/VolumeRenderer.cpp
+++ b/lib/render/VolumeRenderer.cpp
@@ -372,6 +372,7 @@ int VolumeRenderer::_loadData()
     CheckCache(_cache.compression, RP->GetCompressionLevel());
     CheckCache(_cache.minExt, minExt);
     CheckCache(_cache.maxExt, maxExt);
+    CheckCache(_cache.ospMaxCells, RP->GetValueLong("osp_max_cells", 1));
     if (!_cache.needsUpdate)
         return 0;
     


### PR DESCRIPTION
This PR ensures an additional sampling rate is applied to ospray volumes only if the Ospray version is < 2.5. It also slightly improves memory usage while loading data but does not resolve the overall memory usage requirements of ospray since most of the memory is allocated later but it was something small I noticed could be improved.