### PR TITLE
Additional fix for #2080 - Set cursor position to better position in VStringLineEdit

### DIFF
--- a/apps/vaporgui/VDoubleLineEdit.cpp
+++ b/apps/vaporgui/VDoubleLineEdit.cpp
@@ -11,7 +11,7 @@ VDoubleLineEdit::VDoubleLineEdit( double value ) :
     _value( value )
 {
     std::string formattedNumber = _formatValue( _value );
-    _setValueString( formattedNumber );
+    SetValueString( formattedNumber );
 }
 
 void VDoubleLineEdit::SetValueDouble( double value ) {
@@ -25,7 +25,7 @@ void VDoubleLineEdit::SetValueDouble( double value ) {
         return;
     }
 
-    _setValueString( formattedNumber );
+    SetValueString( formattedNumber );
 }
 
 double VDoubleLineEdit::GetValueDouble() const {

--- a/apps/vaporgui/VIntLineEdit.cpp
+++ b/apps/vaporgui/VIntLineEdit.cpp
@@ -13,7 +13,7 @@ VIntLineEdit::VIntLineEdit( int value ) :
     _value( value )
 {
     std::string formattedNumber = _formatValue( _value );
-    _setValueString( formattedNumber );
+    SetValueString( formattedNumber );
 }
 
 void VIntLineEdit::SetValueInt( int value ) {
@@ -27,7 +27,7 @@ void VIntLineEdit::SetValueInt( int value ) {
         return;
     }
 
-    _setValueString( formattedNumber );
+    SetValueString( formattedNumber );
 }
 
 int VIntLineEdit::GetValueInt() const {

--- a/apps/vaporgui/VNumericLineEdit.h
+++ b/apps/vaporgui/VNumericLineEdit.h
@@ -37,8 +37,6 @@ public:
     //! If the line edit is numeric, set whether the display is in scientific notation
     void SetSciNotation( bool sciNotation );
 
-    void SetValueString( std::string value ) = delete;
-
 protected slots:
     
     //! Called whenever the line edit's value is changed.  Must be reimplemented by derived classes

--- a/apps/vaporgui/VStringLineEdit.cpp
+++ b/apps/vaporgui/VStringLineEdit.cpp
@@ -60,5 +60,6 @@ void VStringLineEdit::_setValueString( std::string value ) {
     _strValue = value;
     _lineEdit->setText( QString::fromStdString( _strValue ) );
     _lineEdit->setToolTip( QString::fromStdString( _strValue ) );
+    _lineEdit->setCursorPosition(0);
 }
 

--- a/apps/vaporgui/VStringLineEdit.cpp
+++ b/apps/vaporgui/VStringLineEdit.cpp
@@ -25,6 +25,7 @@ void VStringLineEdit::SetValueString( std::string value ) {
     _strValue = value;
     _lineEdit->setText( QString::fromStdString( _strValue ) );
     _lineEdit->setToolTip( QString::fromStdString( _strValue ) );
+    _lineEdit->setCursorPosition(0);
 }
 
 std::string VStringLineEdit::GetValueString() const {
@@ -55,11 +56,3 @@ std::string VStringLineEdit::_getText() const {
     std::string value = _lineEdit->text().toStdString();
     return value;
 }
-
-void VStringLineEdit::_setValueString( std::string value ) {
-    _strValue = value;
-    _lineEdit->setText( QString::fromStdString( _strValue ) );
-    _lineEdit->setToolTip( QString::fromStdString( _strValue ) );
-    _lineEdit->setCursorPosition(0);
-}
-

--- a/apps/vaporgui/VStringLineEdit.h
+++ b/apps/vaporgui/VStringLineEdit.h
@@ -40,7 +40,6 @@ class VStringLineEdit : public VHBoxWidget {
 
     protected:
         std::string _getText() const;
-        void _setValueString( std::string value );
 
     protected slots:
         virtual void _valueChanged();


### PR DESCRIPTION
This change resets the VStringLineEdit's cursor to position 0 after a change is applied.  This results in more significant digits being displayed, before following digits of lesser magnitude.