### PR TITLE
Fixed #2569 - Grid::GetValue returns wrong value for 3D grids

### DIFF
--- a/include/vapor/CurvilinearGrid.h
+++ b/include/vapor/CurvilinearGrid.h
@@ -316,12 +316,6 @@ private:
  bool _terrainFollowing;
  std::shared_ptr <const QuadTreeRectangle<float, size_t> > _qtr;
 
- mutable struct {
-	size_t k = 0;
-	float z0 = 0.0;
-	float z1 = 0.0;
- } _insideGridCache;
-
  void _curvilinearGrid(
 	const RegularGrid &xrg,
 	const RegularGrid &yrg,

--- a/include/vapor/LayeredGrid.h
+++ b/include/vapor/LayeredGrid.h
@@ -213,12 +213,6 @@ private:
  DblArr3 _maxu = {{0.0, 0.0, 0.0}};
  int _interpolationOrder;
 
- mutable struct {
-	size_t k = 0;
-	float z0 = 0.0;
-	float z1 = 0.0;
- } _insideGridCache;
-
  virtual float GetValueNearestNeighbor(
 	const DblArr3 &coords
  ) const override;

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -687,44 +687,28 @@ bool CurvilinearGrid::_insideGridHelperTerrain(
 
 	float z0, z1;
 
-	// Check cached z values from last search first
+	// Find k index of cell containing z. Already know i and j indices
 	//
-	if (((z-_insideGridCache.z0) * (z-_insideGridCache.z1)) < 0.0) {
-		k = _insideGridCache.k;
-		z0 = _insideGridCache.z0;
-		z1 = _insideGridCache.z1;
-	}
-	else {
-		 
+	size_t nz = GetDimensions()[2];
+	vector <double> zcoords(nz);
+	for (int kk=0; kk<nz; kk++) {
 
-		// Find k index of cell containing z. Already know i and j indices
+		// Interpolate Z coordinate across triangle
 		//
-		size_t nz = GetDimensions()[2];
-		vector <double> zcoords(nz);
-		for (int kk=0; kk<nz; kk++) {
+		float zk = 
+			_zrg.AccessIJK(iv[0], jv[0], kk) * lambda[0] +
+			_zrg.AccessIJK(iv[1], jv[1], kk) * lambda[1] +
+			_zrg.AccessIJK(iv[2], jv[2], kk) * lambda[2];
 
-			// Interpolate Z coordinate across triangle
-			//
-			float zk = 
-				_zrg.AccessIJK(iv[0], jv[0], kk) * lambda[0] +
-				_zrg.AccessIJK(iv[1], jv[1], kk) * lambda[1] +
-				_zrg.AccessIJK(iv[2], jv[2], kk) * lambda[2];
-
-				zcoords[kk] = zk;
-		}
-
-		if (! Wasp::BinarySearchRange(zcoords, z, k)) return(false);
-
-		VAssert(k < nz-1);
-
-		z0 = zcoords[k];
-		z1 = zcoords[k+1];
-
-		_insideGridCache.k = k;
-		_insideGridCache.z0 = z0;
-		_insideGridCache.z1 = z1;
-
+			zcoords[kk] = zk;
 	}
+
+	if (! Wasp::BinarySearchRange(zcoords, z, k)) return(false);
+
+	VAssert(k < nz-1);
+
+	z0 = zcoords[k];
+	z1 = zcoords[k+1];
 
 	zwgt[0] = 1.0 - (z - z0) / (z1 - z0);
 	zwgt[1] = 1.0 - zwgt[0];

--- a/lib/vdc/LayeredGrid.cpp
+++ b/lib/vdc/LayeredGrid.cpp
@@ -178,46 +178,30 @@ bool LayeredGrid::_insideGrid(
 
 	float z0, z1;
 
-	// Check cached z values from last search first
+	// Find k index of cell containing z. Already know i and j indices
 	//
-	if (((coords[2]-_insideGridCache.z0) * (coords[2]-_insideGridCache.z1)) < 0.0) {
-		indices[2] = _insideGridCache.k;
-		z0 = _insideGridCache.z0;
-		z1 = _insideGridCache.z1;
-	}
-	else {
-		 
+	vector <double> zcoords;
 
-		// Find k index of cell containing z. Already know i and j indices
+	size_t nz = GetDimensions()[2];
+	zcoords.reserve(nz);
+	for (int kk=0; kk<nz; kk++) {
+
+		// Interpolate Z coordinate across triangle
 		//
-		vector <double> zcoords;
+		float zk = 
+			_zrg.AccessIJK(iv[0], jv[0], kk) * lambda[0] +
+			_zrg.AccessIJK(iv[1], jv[1], kk) * lambda[1] +
+			_zrg.AccessIJK(iv[2], jv[2], kk) * lambda[2];
 
-		size_t nz = GetDimensions()[2];
-		zcoords.reserve(nz);
-		for (int kk=0; kk<nz; kk++) {
-
-			// Interpolate Z coordinate across triangle
-			//
-			float zk = 
-				_zrg.AccessIJK(iv[0], jv[0], kk) * lambda[0] +
-				_zrg.AccessIJK(iv[1], jv[1], kk) * lambda[1] +
-				_zrg.AccessIJK(iv[2], jv[2], kk) * lambda[2];
-
-				zcoords.push_back(zk);
-		}
-
-		if (! Wasp::BinarySearchRange(zcoords, coords[2], indices[2])) return(false);
-
-		VAssert(indices[2] < nz-1);
-
-		z0 = zcoords[indices[2]];
-		z1 = zcoords[indices[2]+1];
-
-		_insideGridCache.k = indices[2];
-		_insideGridCache.z0 = z0;
-		_insideGridCache.z1 = z1;
-
+			zcoords.push_back(zk);
 	}
+
+	if (! Wasp::BinarySearchRange(zcoords, coords[2], indices[2])) return(false);
+
+	VAssert(indices[2] < nz-1);
+
+	z0 = zcoords[indices[2]];
+	z1 = zcoords[indices[2]+1];
 
 	wgts[2] = 1.0 - (coords[2] - z0) / (z1 - z0);
 

--- a/test_apps/smokeTests/testResults/cf_baseline.txt
+++ b/test_apps/smokeTests/testResults/cf_baseline.txt
@@ -60,4 +60,4 @@ Time Coordinates:
 
 Time coordinate variable name: time
 Number of time steps: 1
-Elapsed time: 0.490985
+Elapsed time: 0.131529

--- a/test_apps/smokeTests/testResults/vdc_baseline.txt
+++ b/test_apps/smokeTests/testResults/vdc_baseline.txt
@@ -113,9 +113,9 @@ Grid test for 3D variable P:
     Dimension Lengths:  315 309 34
     Topology Dimension: 3
 
-    RMS error:                                           9.03838
+    RMS error:                                           0
     Missing value count:                                 0
-    GetValueAtIndex() vs GetValue() disagreement count:  283693
+    GetValueAtIndex() vs GetValue() disagreement count:  0
 
 Projection String:  +proj=merc +lon_0=-85 +lat_ts=30 +ellps=WGS84
 
@@ -147,4 +147,4 @@ Time Coordinates:
 
 Time coordinate variable name: Time
 Number of time steps: 1
-Elapsed time: 11.2818
+Elapsed time: 15.3444

--- a/test_apps/smokeTests/testResults/wrf_baseline.txt
+++ b/test_apps/smokeTests/testResults/wrf_baseline.txt
@@ -113,9 +113,9 @@ Grid test for 3D variable P:
     Dimension Lengths:  315 309 34
     Topology Dimension: 3
 
-    RMS error:                                           5.20866
+    RMS error:                                           0
     Missing value count:                                 0
-    GetValueAtIndex() vs GetValue() disagreement count:  78579
+    GetValueAtIndex() vs GetValue() disagreement count:  0
 
 Projection String:  +proj=merc +lon_0=-85 +lat_ts=30 +ellps=WGS84
 
@@ -147,4 +147,4 @@ Time Coordinates:
 
 Time coordinate variable name: Time
 Number of time steps: 1
-Elapsed time: 10.6989
+Elapsed time: 15.4913


### PR DESCRIPTION
This PR fixes #2569 by removing the cached Z coordinate, which was incorrectly being used. This solution has a minor impact on performance. Alternatively, the use of the cached Z value could have been fixed, but the implemented solution makes GetValue thread safe.


@sgpearse This PR will fail the regression test with testDataMgr because the "ground truth" is incorrect. 

With the changes in this PR the command:

testDataMgr -fileType wrf ~/Data/WRF/Katrina/wrfout_d02_2005-08-29_00

gives: 

```
Grid test for 3D variable P:
    # Dimensions:       3
    Dimension Lengths:  315 309 34
    Topology Dimension: 3

    RMS error:                                           0
    Missing value count:                                 0
    GetValueAtIndex() vs GetValue() disagreement count:  0
```