### PR TITLE
Improve error handling during Python initialization

### DIFF
--- a/lib/render/MyPython.cpp
+++ b/lib/render/MyPython.cpp
@@ -127,9 +127,9 @@ int MyPython::Initialize() {
 	//
 	std::string stdErr =
 	"try:\n"
-	"	import sys, os\n"
+	"	import sys\n"
 	"except: \n"
-	"	print >> sys.stderr, \'Failed to import sys\'\n"
+	"	print('Failed to import sys')\n"
 	"	raise\n"
 	"class CatchErr:\n"
 	"	def __init__(self):\n"
@@ -149,9 +149,9 @@ int MyPython::Initialize() {
 
 	std::string stdOut =
 	"try:\n"
-	"	import sys, os\n"
+	"	import sys\n"
 	"except: \n"
-	"	print >> sys.stderr, \'Failed to import sys\'\n"
+	"	print('Failed to import sys')\n"
 	"	raise\n"
 	"class CatchOut:\n"
 	"	def __init__(self):\n"
@@ -175,7 +175,7 @@ int MyPython::Initialize() {
 	"try:\n"
 	"	import matplotlib\n"
 	"except: \n"
-	"	print >> sys.stderr, \'Failed to import matplotlib\'\n"
+	"	print('Failed to import matplotlib', file=sys.stderr)\n"
 	"	raise\n";
 	rc = PyRun_SimpleString(importMPL.c_str());
 	if (rc<0) {


### PR DESCRIPTION
Hi,

I compiled VAPOR for a user of our computing center and run into some issues.

I noticed that there are some problems regarding the way errors are currently handled during Python initialization.

I tried to fix some of the issues and I think there is still some room for improvements but I don't know the code base so I am not completely sure.

I think the main remaining issue is that although `SetErrMsg` is called, I don't think the error is actually ever displayed.

Best regards,
Rémi

