### PR TITLE
Fix external PR tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: Smoke test
           command: |
-            python3 /project/test_apps/smokeTests/smokeTests.py --testDataRoot=/smokeTestData/smokeTestData --binaryRoot=/project/build/bin --resultsDir=/project/test_apps/smokeTests/testResults
+            python3 /root/project/test_apps/smokeTests/smokeTests.py --testDataRoot=/smokeTestData/smokeTestData --binaryRoot=/root/project/build/bin --resultsDir=/root/project/test_apps/smokeTests/testResults
 
       - store_artifacts:
           path: /project/test_apps/smokeTests/testResults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
       at: *workspace_root
 
 jobs:
-  build_ubuntu18_fork:
+  build_ubuntu18:
     docker:
       - image: sgpearse/vapor3-ubuntu18:latest
 
@@ -42,50 +42,6 @@ jobs:
 
       - store_artifacts:
           path: /project/test_apps/smokeTests/testResults
-
-      - run:
-          name: check for warnings
-          command: |
-            if grep -q warning /tmp/output.txt; then
-               cat /tmp/output.txt
-               exit -1
-            else
-               exit 0
-            fi
-
-  build_ubuntu18:
-    docker:
-      - image: sgpearse/vapor3-ubuntu18:latest
-
-    steps:
-      - run:
-          name: install python
-          command: |
-            apt-get update
-            apt-get install -y python3
-
-      - checkout
-
-      - run:
-          name: cmake and make
-          command: |
-            cd /VAPOR
-            git pull
-            git checkout $CIRCLE_BRANCH
-            cd build
-            cmake -DBUILD_TEST_APPS=ON ..
-            make -j7 &> /tmp/output.txt
-
-      - store_artifacts:
-          path: /tmp/output.txt
-
-      - run:
-          name: Smoke test
-          command: |
-            python3 /VAPOR/test_apps/smokeTests/smokeTests.py --testDataRoot=/smokeTestData/smokeTestData --binaryRoot=/VAPOR/build/bin --resultsDir=/VAPOR/test_apps/smokeTests/testResults
-
-      - store_artifacts:
-          path: /VAPOR/test_apps/smokeTests/testResults
 
       - run:
           name: check for warnings
@@ -156,9 +112,8 @@ jobs:
           name: cmake3 and make
           command: |
             ls -lrth /usr/local/VAPOR-Deps
-            cd /VAPOR
-            git pull
-            git checkout $CIRCLE_BRANCH
+            cd /root/project
+            mkdir build
             cd build
             cmake3 ..
             make -j7
@@ -408,8 +363,8 @@ jobs:
 workflows:
   build:
     jobs:
-      - build_ubuntu18_fork
-      #- build_centos7
+      - build_ubuntu18
+      - build_centos7
       #- build_ubuntu16
       #- build_osx
       #- build_win10_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ workflows:
   build:
     jobs:
       - build_ubuntu18
-      - build_centos7
+      #- build_centos7
       #- build_ubuntu16
       #- build_osx
       #- build_win10_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,48 @@ references:
       at: *workspace_root
 
 jobs:
+  build_ubuntu18_fork:
+    docker:
+      - image: sgpearse/vapor3-ubuntu18:latest
+
+    steps:
+      - run:
+          name: install python
+          command: |
+            apt-get update
+            apt-get install -y python3
+
+      - checkout
+
+      - run:
+          name: cmake and make
+          command: |
+            mkdir build
+            cd build
+            cmake -DBUILD_TEST_APPS=ON ..
+            make -j7 &> /tmp/output.txt
+
+      - store_artifacts:
+          path: /tmp/output.txt
+
+      - run:
+          name: Smoke test
+          command: |
+            python3 /project/test_apps/smokeTests/smokeTests.py --testDataRoot=/smokeTestData/smokeTestData --binaryRoot=/project/build/bin --resultsDir=/project/test_apps/smokeTests/testResults
+
+      - store_artifacts:
+          path: /project/test_apps/smokeTests/testResults
+
+      - run:
+          name: check for warnings
+          command: |
+            if grep -q warning /tmp/output.txt; then
+               cat /tmp/output.txt
+               exit -1
+            else
+               exit 0
+            fi
+
   build_ubuntu18:
     docker:
       - image: sgpearse/vapor3-ubuntu18:latest
@@ -366,7 +408,7 @@ jobs:
 workflows:
   build:
     jobs:
-      - build_ubuntu18
+      - build_ubuntu18_fork
       #- build_centos7
       #- build_ubuntu16
       #- build_osx


### PR DESCRIPTION
Redirects CircleCI tests to point to the code in the /root/project directory, instead of the precompiled /VAPOR directory.