### PR TITLE
Fix #2388 Variables without data at the first timestep cause misleading behavior

### DIFF
--- a/apps/vaporgui/AnimationEventRouter.cpp
+++ b/apps/vaporgui/AnimationEventRouter.cpp
@@ -32,6 +32,7 @@
 #include "AnimationParams.h"
 #include "RangeCombos.h"
 #include "AnimationEventRouter.h"
+#include <float.h>
 
 #include "images/playreverseA.xpm"
 #include "images/playforwardA.xpm"
@@ -168,7 +169,42 @@ void AnimationEventRouter::setCurrentTimestep(size_t ts) const
 
             size_t local_ts = dataStatus->MapGlobalToLocalTimeStep(dataSetNames[j], ts);
 
-            for (int k = 0; k < rParams.size(); k++) { rParams[k]->SetCurrentTimestep(local_ts); }
+            for (int k = 0; k < rParams.size(); k++) {
+                RenderParams *rp = rParams[k];
+                rp->SetCurrentTimestep(local_ts);
+                
+                // If variable was not initialzed but now is, reset the TF mapping range
+                std::string varNames[2] = {
+                    rp->GetVariableName(),
+                    rp->GetColorMapVariableName()
+                };
+                
+                for (int l = 0; l < 2; l++) {
+                    if (varNames[i].empty())
+                        continue;
+                    
+                    MapperFunction *tf = rp->GetMapperFunc(varNames[i]);
+                    vector<double> range = tf->getMinMaxMapValue();
+                    if (abs(range[1] - range[0]) > FLT_EPSILON)
+                        continue;
+                    
+                    DataMgr *dm = dataStatus->GetDataMgr(dataSetNames[j]);
+                    if (!dm) continue;
+                    
+                    if (!dm->VariableExists(local_ts, varNames[i], 0, 0))
+                        continue;
+                    
+                    if (dm->GetDataRange(local_ts, varNames[i], 0, 0, range) < 0)
+                        continue;
+                    
+                    bool SSE = paramsMgr->GetSaveStateEnabled();
+                    paramsMgr->SetSaveStateEnabled(false);
+                    tf->setMinMaxMapValue(range[0], range[1]);
+                    paramsMgr->SetSaveStateEnabled(SSE);
+                }
+                
+                
+            }
         }
     }
 

--- a/apps/vaporgui/AnimationEventRouter.cpp
+++ b/apps/vaporgui/AnimationEventRouter.cpp
@@ -172,38 +172,29 @@ void AnimationEventRouter::setCurrentTimestep(size_t ts) const
             for (int k = 0; k < rParams.size(); k++) {
                 RenderParams *rp = rParams[k];
                 rp->SetCurrentTimestep(local_ts);
-                
+
                 // If variable was not initialzed but now is, reset the TF mapping range
-                std::string varNames[2] = {
-                    rp->GetVariableName(),
-                    rp->GetColorMapVariableName()
-                };
-                
+                std::string varNames[2] = {rp->GetVariableName(), rp->GetColorMapVariableName()};
+
                 for (int l = 0; l < 2; l++) {
-                    if (varNames[i].empty())
-                        continue;
-                    
+                    if (varNames[i].empty()) continue;
+
                     MapperFunction *tf = rp->GetMapperFunc(varNames[i]);
-                    vector<double> range = tf->getMinMaxMapValue();
-                    if (abs(range[1] - range[0]) > FLT_EPSILON)
-                        continue;
-                    
+                    vector<double>  range = tf->getMinMaxMapValue();
+                    if (abs(range[1] - range[0]) > FLT_EPSILON) continue;
+
                     DataMgr *dm = dataStatus->GetDataMgr(dataSetNames[j]);
                     if (!dm) continue;
-                    
-                    if (!dm->VariableExists(local_ts, varNames[i], 0, 0))
-                        continue;
-                    
-                    if (dm->GetDataRange(local_ts, varNames[i], 0, 0, range) < 0)
-                        continue;
-                    
+
+                    if (!dm->VariableExists(local_ts, varNames[i], 0, 0)) continue;
+
+                    if (dm->GetDataRange(local_ts, varNames[i], 0, 0, range) < 0) continue;
+
                     bool SSE = paramsMgr->GetSaveStateEnabled();
                     paramsMgr->SetSaveStateEnabled(false);
                     tf->setMinMaxMapValue(range[0], range[1]);
                     paramsMgr->SetSaveStateEnabled(SSE);
                 }
-                
-                
             }
         }
     }

--- a/apps/vaporgui/QRangeSliderTextCombo.cpp
+++ b/apps/vaporgui/QRangeSliderTextCombo.cpp
@@ -30,7 +30,7 @@ QRangeSliderTextCombo::QRangeSliderTextCombo()
 
     _leftText->RemoveContextMenu();
     _rightText->RemoveContextMenu();
-    
+
     _leftText->SetAutoTooltip(false);
     _rightText->SetAutoTooltip(false);
 
@@ -56,11 +56,8 @@ void QRangeSliderTextCombo::SetRange(float min, float max)
     SetValue(_left, _right);
     _menu->SetMinimum(_min);
     _menu->SetMaximum(_max);
-    
-    setToolTip(QString::fromStdString(
-        "Min: " + std::to_string(_min) + "\n" +
-        "Max: " + std::to_string(_max)
-    ));
+
+    setToolTip(QString::fromStdString("Min: " + std::to_string(_min) + "\n" + "Max: " + std::to_string(_max)));
 }
 
 void QRangeSliderTextCombo::SetValue(float left, float right)

--- a/apps/vaporgui/QRangeSliderTextCombo.cpp
+++ b/apps/vaporgui/QRangeSliderTextCombo.cpp
@@ -73,7 +73,7 @@ void QRangeSliderTextCombo::SetValue(float left, float right)
     _left = left;
     _right = right;
     setTextboxes(left, right);
-    if (fabsf(_max - _min) < FLT_EPSILON)
+    if (abs(_max - _min) < FLT_EPSILON)
         _slider->SetValue(0, 1);
     else
         _slider->SetValue((left - _min) / (_max - _min), (right - _min) / (_max - _min));

--- a/apps/vaporgui/QRangeSliderTextCombo.cpp
+++ b/apps/vaporgui/QRangeSliderTextCombo.cpp
@@ -30,6 +30,9 @@ QRangeSliderTextCombo::QRangeSliderTextCombo()
 
     _leftText->RemoveContextMenu();
     _rightText->RemoveContextMenu();
+    
+    _leftText->SetAutoTooltip(false);
+    _rightText->SetAutoTooltip(false);
 
     _menu = new VDoubleRangeMenu(this, _leftText->GetSciNotation(), _leftText->GetNumDigits(), _min, _max, _allowCustomRange);
     connect(_menu, &VDoubleRangeMenu::MinChanged, this, &QRangeSliderTextCombo::minChanged);
@@ -45,7 +48,7 @@ QRangeSliderTextCombo::QRangeSliderTextCombo()
 
 void QRangeSliderTextCombo::SetRange(float min, float max)
 {
-    if (min < max) {
+    if (min <= max) {
         _min = min;
         _max = max;
     }
@@ -53,6 +56,11 @@ void QRangeSliderTextCombo::SetRange(float min, float max)
     SetValue(_left, _right);
     _menu->SetMinimum(_min);
     _menu->SetMaximum(_max);
+    
+    setToolTip(QString::fromStdString(
+        "Min: " + std::to_string(_min) + "\n" +
+        "Max: " + std::to_string(_max)
+    ));
 }
 
 void QRangeSliderTextCombo::SetValue(float left, float right)
@@ -65,7 +73,10 @@ void QRangeSliderTextCombo::SetValue(float left, float right)
     _left = left;
     _right = right;
     setTextboxes(left, right);
-    _slider->SetValue((left - _min) / (_max - _min), (right - _min) / (_max - _min));
+    if (fabsf(_max - _min) < FLT_EPSILON)
+        _slider->SetValue(0, 1);
+    else
+        _slider->SetValue((left - _min) / (_max - _min), (right - _min) / (_max - _min));
 }
 
 void QRangeSliderTextCombo::AllowCustomRange()

--- a/apps/vaporgui/VStringLineEdit.cpp
+++ b/apps/vaporgui/VStringLineEdit.cpp
@@ -21,8 +21,7 @@ void VStringLineEdit::SetValueString(std::string value)
 {
     _strValue = value;
     _lineEdit->setText(QString::fromStdString(_strValue));
-    if (_autoTooltip)
-        _lineEdit->setToolTip(QString::fromStdString(_strValue));
+    if (_autoTooltip) _lineEdit->setToolTip(QString::fromStdString(_strValue));
     _lineEdit->setCursorPosition(0);
 }
 

--- a/apps/vaporgui/VStringLineEdit.cpp
+++ b/apps/vaporgui/VStringLineEdit.cpp
@@ -21,7 +21,8 @@ void VStringLineEdit::SetValueString(std::string value)
 {
     _strValue = value;
     _lineEdit->setText(QString::fromStdString(_strValue));
-    _lineEdit->setToolTip(QString::fromStdString(_strValue));
+    if (_autoTooltip)
+        _lineEdit->setToolTip(QString::fromStdString(_strValue));
     _lineEdit->setCursorPosition(0);
 }
 
@@ -38,6 +39,15 @@ void VStringLineEdit::SetCustomContextMenu()
     _lineEdit->setContextMenuPolicy(Qt::CustomContextMenu);
     setContextMenuPolicy(Qt::CustomContextMenu);
     connect(_lineEdit, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(_showMenu(const QPoint &)));
+}
+
+void VStringLineEdit::SetAutoTooltip(bool on)
+{
+    _autoTooltip = on;
+    if (on)
+        _lineEdit->setToolTip(_lineEdit->text());
+    else
+        _lineEdit->setToolTip("");
 }
 
 void VStringLineEdit::_valueChanged()

--- a/apps/vaporgui/VStringLineEdit.h
+++ b/apps/vaporgui/VStringLineEdit.h
@@ -36,10 +36,13 @@ public:
 
     void SetReadOnly(bool b) { _lineEdit->setReadOnly(b); }
     void Clear() { SetValueString(""); }
+    
+    void SetAutoTooltip(bool on);
 
 private:
     QLineEdit * _lineEdit;
     std::string _strValue;
+    bool _autoTooltip = true;
 
 protected:
     std::string _getText() const;

--- a/apps/vaporgui/VStringLineEdit.h
+++ b/apps/vaporgui/VStringLineEdit.h
@@ -36,13 +36,13 @@ public:
 
     void SetReadOnly(bool b) { _lineEdit->setReadOnly(b); }
     void Clear() { SetValueString(""); }
-    
+
     void SetAutoTooltip(bool on);
 
 private:
     QLineEdit * _lineEdit;
     std::string _strValue;
-    bool _autoTooltip = true;
+    bool        _autoTooltip = true;
 
 protected:
     std::string _getText() const;


### PR DESCRIPTION
Makes behavior of range selector clearer when uninitialized variable. When the range is 0-0 and both min/max are 0, the range selector shows that the whole range is selected. When you select the next timestep, now it shows that just 0 is selected but the tilmestep has more data. It also now has a tooltip which shows the entire possible range.

**Timestep 0**
<img width="403" alt="1" src="https://user-images.githubusercontent.com/2772687/105807104-9075b900-5f62-11eb-96eb-0b7561c1c05f.png">

**Timestep 1**
<img width="384" alt="2" src="https://user-images.githubusercontent.com/2772687/105807106-92d81300-5f62-11eb-834f-cd3f516a1c10.png">

Fix #2388
Fix #1705