### PR TITLE
Fix #2530 Setting constant colors for glyphs is non-intuitive

### DIFF
--- a/apps/vaporgui/BarbEventRouter.cpp
+++ b/apps/vaporgui/BarbEventRouter.cpp
@@ -25,6 +25,7 @@ BarbEventRouter::BarbEventRouter(QWidget *parent, ControlExec *ce) : RenderEvent
     }));
     
     AddSubtab("Appearance", new PGroup({
+        new PColormapTFEditor,
         new PSection("Barbs", {
             (new PIntegerSliderEdit(BP::_xBarbsCountTag, "X Barbs"))->SetRange(1, 50),
             (new PIntegerSliderEdit(BP::_yBarbsCountTag, "Y Barbs"))->SetRange(1, 50),
@@ -33,7 +34,6 @@ BarbEventRouter::BarbEventRouter(QWidget *parent, ControlExec *ce) : RenderEvent
             (new PDoubleSliderEdit(BP::_thicknessScaleTag, "Thickness Scale"))->SetRange(0.01, 4)->EnableDynamicUpdate(),
             new PConstantColorWidget
         }),
-        (new PColormapTFEditor)->ShowBasedOnParam(BP::_useSingleColorTag, false)
     }));
     
     AddSubtab("Geometry", new PGeometrySubtab);

--- a/apps/vaporgui/BarbEventRouter.cpp
+++ b/apps/vaporgui/BarbEventRouter.cpp
@@ -1,6 +1,7 @@
 #include "BarbEventRouter.h"
 #include "vapor/BarbParams.h"
 #include "PWidgets.h"
+#include "PConstantColorWidget.h"
 
 using namespace VAPoR;
 typedef BarbParams BP;
@@ -30,8 +31,7 @@ BarbEventRouter::BarbEventRouter(QWidget *parent, ControlExec *ce) : RenderEvent
             (new PIntegerSliderEdit(BP::_zBarbsCountTag, "Z Barbs"))->SetRange(1, 50),
             (new PDoubleSliderEdit(BP::_lengthScaleTag, "Length Scale"))->SetRange(0.01, 4)->EnableDynamicUpdate(),
             (new PDoubleSliderEdit(BP::_thicknessScaleTag, "Thickness Scale"))->SetRange(0.01, 4)->EnableDynamicUpdate(),
-            new PCheckbox(BP::_useSingleColorTag, "Use Constant Color"),
-            new PColorSelector(BP::_constantColorTag, "Constant Color")
+            new PConstantColorWidget
         }),
         (new PColormapTFEditor)->ShowBasedOnParam(BP::_useSingleColorTag, false)
     }));

--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -237,6 +237,8 @@ set (SRCS
 	PFlowRakeRegionSelector.h
 	PMultiVarSelector.cpp
 	PMultiVarSelector.h
+    PConstantColorWidget.cpp
+    PConstantColorWidget.h
 
 	# Need to include all files that request .ui files
 	Statistics.h

--- a/apps/vaporgui/ContourEventRouter.cpp
+++ b/apps/vaporgui/ContourEventRouter.cpp
@@ -2,6 +2,7 @@
 #include "vapor/ContourParams.h"
 #include "PWidgets.h"
 #include "PSliderEditHLI.h"
+#include "PConstantColorWidget.h"
 
 using namespace VAPoR;
 typedef ContourParams CP;
@@ -29,6 +30,7 @@ ContourEventRouter::ContourEventRouter(QWidget *parent, ControlExec *ce) : Rende
             _spacingSlider = new PDoubleSliderEditHLI<CP>("Spacing", &CP::GetContourSpacing, &CP::SetContourSpacing),
             (new PIntegerSliderEditHLI<CP>("Count", &CP::GetContourCount, &CP::SetContourCount))->SetRange(1, 50),
             _minValueSlider = new PDoubleSliderEditHLI<CP>("Minimum Value", &CP::GetContourMin, &CP::SetContourMin),
+            new PConstantColorWidget
         }),
     }));
     

--- a/apps/vaporgui/FlowEventRouter.cpp
+++ b/apps/vaporgui/FlowEventRouter.cpp
@@ -3,6 +3,7 @@
 #include "PWidgets.h"
 #include "PFlowRakeRegionSelector.h"
 #include "PMultiVarSelector.h"
+#include "PConstantColorWidget.h"
 
 using namespace VAPoR;
 typedef FlowParams FP;
@@ -86,6 +87,7 @@ FlowEventRouter::FlowEventRouter(QWidget *parent, ControlExec *ce) : RenderEvent
     AddSubtab("Appearance", new PGroup({
         (new PTFEditor(RenderParams::_colorMapVariableNameTag))->ShowOpacityBasedOnParam("NULL", 1),
         new PSection("Appearance", {
+            new PConstantColorWidget,
             new PEnumDropdown(FP::RenderTypeTag, {"Tubes", "Samples", "KLGWTH"}, {FP::RenderTypeStream, FP::RenderTypeSamples, FP::RenderTypeDensity}, "Render Type"),
             (new PShowIf(FP::RenderTypeTag))->Equals(FP::RenderTypeStream)->Then({
                 new PCheckbox(FP::RenderGeom3DTag, "3D Geometry"),

--- a/apps/vaporgui/PConstantColorWidget.cpp
+++ b/apps/vaporgui/PConstantColorWidget.cpp
@@ -1,0 +1,13 @@
+#include "PConstantColorWidget.h"
+#include "PCheckbox.h"
+#include "PColorSelector.h"
+#include <vapor/RenderParams.h>
+
+using VAPoR::RenderParams;
+
+PConstantColorWidget::PConstantColorWidget()
+{
+    Add(new PCheckbox(RenderParams::_useSingleColorTag, "Use Constant Color"));
+    Add((new PSubGroup({new PColorSelector(RenderParams::_constantColorTag, "Constant Color")}))
+        ->ShowBasedOnParam(RenderParams::_useSingleColorTag));
+}

--- a/apps/vaporgui/PConstantColorWidget.h
+++ b/apps/vaporgui/PConstantColorWidget.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "PGroup.h"
+
+class PConstantColorWidget : public PGroup {
+    
+public:
+    PConstantColorWidget();
+};

--- a/apps/vaporgui/WireFrameEventRouter.cpp
+++ b/apps/vaporgui/WireFrameEventRouter.cpp
@@ -1,6 +1,7 @@
 #include "WireFrameEventRouter.h"
 #include "vapor/WireFrameParams.h"
 #include "PWidgets.h"
+#include "PConstantColorWidget.h"
 
 using namespace VAPoR;
 
@@ -19,7 +20,13 @@ WireFrameEventRouter::WireFrameEventRouter(QWidget *parent, ControlExec *ce) : R
         new PFidelitySection
     }));
     
-    AddSubtab("Appearance", (new PTFEditor)->ShowOpacityBasedOnParam("NULL", 1));
+    AddSubtab("Appearance", new PGroup({
+        (new PTFEditor)->ShowOpacityBasedOnParam("NULL", 1),
+        new PSection("Appearance", {
+            new PConstantColorWidget
+        })
+    }));
+    
     AddSubtab("Geometry", new PGeometrySubtab);
     AddSubtab("Annotation", new PAnnotationColorbarWidget);
 

--- a/lib/render/ContourRenderer.cpp
+++ b/lib/render/ContourRenderer.cpp
@@ -101,7 +101,6 @@ int ContourRenderer::_buildCache()
     _saveCacheParams();
 
     vector<VertexData>           vertices;
-    vector<pair<int, glm::vec4>> colors;
 
     if (cParams->GetVariableName().empty()) { return 0; }
     vector<double> contours = cParams->GetContourValues(_cacheParams.varName);
@@ -181,6 +180,15 @@ int ContourRenderer::_paintGL(bool)
     MapperFunction *tf = rp->GetMapperFunc(rp->GetVariableName());
     float           lut[4 * 256];
     tf->makeLut(lut);
+    if (rp->UseSingleColor()) {
+        float c[3];
+        rp->GetConstantColor(c);
+        for (int i = 0; i < 256; i++) {
+            lut[i*4+0] = c[0];
+            lut[i*4+1] = c[1];
+            lut[i*4+2] = c[2];
+        }
+    }
     _lutTexture.TexImage(GL_RGBA8, 256, 0, 0, GL_RGBA, GL_FLOAT, lut);
 
     ShaderProgram *shader = _glManager->shaderManager->GetShader("Contour");

--- a/lib/render/WireFrameRenderer.cpp
+++ b/lib/render/WireFrameRenderer.cpp
@@ -339,6 +339,15 @@ int WireFrameRenderer::_paintGL(bool fast)
     MapperFunction *tf = rp->GetMapperFunc(rp->GetVariableName());
     float           lut[4 * 256];
     tf->makeLut(lut);
+    if (rp->UseSingleColor()) {
+        float c[3];
+        rp->GetConstantColor(c);
+        for (int i = 0; i < 256; i++) {
+            lut[i*4+0] = c[0];
+            lut[i*4+1] = c[1];
+            lut[i*4+2] = c[2];
+        }
+    }
     _lutTexture.TexImage(GL_RGBA8, 256, 0, 0, GL_RGBA, GL_FLOAT, lut);
 
     SmartShaderProgram shader = _glManager->shaderManager->GetSmartShader("Wireframe");


### PR DESCRIPTION
Fix #2530

Adds an explicit "Use Constant Color" checkbox and color selector to all the mentioned renderers.

Copy of #2602