### PR TITLE
Introduce clang-format checks on CircleCI, and client tools to perform local linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,10 +69,18 @@ jobs:
       - run:
           name: run clang-format
           command: |
-            for FILE in $(git diff --name-only origin/master |grep -E "\.h|\.cpp")
-            do
-                echo "    Running clang format on  $FILE"
-                clang-format-11 --dry-run $FILE >> /tmp/clang-format.txt 2>&1
+            for COMMIT in $(git log --pretty=format:%h main...$BRANCH); do
+                for FILE in $(git diff --name-only origin/main |grep -E "\.h|\.cpp"); do
+                    NUMBERS=""
+                    for NUMBER in $(git blame --line-porcelain "$FILE" | egrep ^$COMMIT | cut -d' ' -f3); do
+                        NUMBERS="$NUMBERS --lines $NUMBER:$NUMBER "
+                    done
+
+                    if [ "$NUMBERS" != "" ]; then
+                        echo "  Running clang-format on $FILE"
+                        clang-format-11 --dry-run $FILE $NUMBERS >> /tmp/clang-format.txt 2>&1
+                    fi
+                done
             done
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,14 +54,15 @@ jobs:
 
   test_clang_format:
     docker:
-      - image: sgpearse/vapor3-ubuntu18:latest
+      - image: ubuntu:20.04
     
     steps:
       - run:
-          name: install clang-format
+          name: install deps
           command: |
             apt-get update
-            apt-get install -y clang-format
+            apt-get install -y clang-format-11
+            apt-get install -y git
 
       - checkout
 
@@ -71,7 +72,7 @@ jobs:
             for FILE in $(git diff --name-only origin/master |grep -E "\.h|\.cpp")
             do
                 echo "    Running clang format on  $FILE"
-                clang-format --dry-run $FILE >> /tmp/clang-format.txt 2>&1
+                clang-format-11 --dry-run $FILE >> /tmp/clang-format.txt 2>&1
             done
 
       - store_artifacts:

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: true
+AlignConsecutiveDeclarations: true
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: WebKit
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: false
+ColumnLimit:     200
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: NoIndent
+IndentGotoLabels: true
+IndentPPDirectives: BeforeHash
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 3
+NamespaceIndentation: None
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 4
+SpacesInAngles:  false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 4
+UseCRLF: false
+UseTab: Never
+...

--- a/share/gitHooks/pre-push
+++ b/share/gitHooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+
+# Run clang-format on all .cpp and .h files to be pushed
+for FILE in $(git diff --name-only origin/master |grep -E "\.h|\.cpp")
+do
+    echo "    Running clang format on  $FILE"
+    clang-format -i $FILE
+done
+
+git commit -a -m "clang-format pre-receive hook"

--- a/share/gitHooks/pre-push
+++ b/share/gitHooks/pre-push
@@ -2,7 +2,7 @@
 #
 
 # Run clang-format on all .cpp and .h files to be pushed
-for FILE in $(git diff --name-only origin/master |grep -E "\.h|\.cpp")
+for FILE in $(git diff --name-only origin/main |grep -E "\.h|\.cpp")
 do
     echo "    Running clang format on  $FILE"
     clang-format -i $FILE

--- a/share/gitHooks/pre-push
+++ b/share/gitHooks/pre-push
@@ -1,11 +1,29 @@
 #!/bin/sh
 #
 
-# Run clang-format on all .cpp and .h files to be pushed
-for FILE in $(git diff --name-only origin/main |grep -E "\.h|\.cpp")
-do
-    echo "    Running clang format on  $FILE"
-    clang-format -i $FILE
-done
+BRANCH=`git rev-parse --abbrev-ref HEAD`
 
-git commit -a -m "clang-format pre-receive hook"
+# If we're on the readTheDocs branch, skip clang-format
+#
+if [ "$BRANCH" = "readTheDocs" ]; then
+    echo "pre-push hook skipped for current branch."
+
+# Otherwise format the changed lines in all commits up to this push
+#
+else
+    for COMMIT in $(git log --pretty=format:%h main...$BRANCH); do
+        for FILE in $(git diff --name-only origin/main |grep -E "\.h|\.cpp"); do
+            NUMBERS=""
+            for NUMBER in $(git blame --line-porcelain "$FILE" | egrep ^$COMMIT | cut -d' ' -f3); do
+                NUMBERS="$NUMBERS --lines $NUMBER:$NUMBER "
+            done
+
+            if [ "$NUMBERS" != "" ]; then
+                echo "  Running clang-format on $FILE"
+                clang-format -i $FILE $NUMBERS
+            fi
+        done
+    done
+
+    git commit -a -m "clang-format pre-receive hook"
+fi

--- a/share/gitHooks/setupHooks.sh
+++ b/share/gitHooks/setupHooks.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+HOOK_DIR=$ROOT_DIR/.git/hooks
+HOOK=$HOOK_DIR/pre-push
+ln -sf $ROOT_DIR/share/gitHooks/pre-push $HOOK
+
+if [ -e "$HOOK" ]
+then
+    echo "pre-push hook installed in $HOOK_DIR"
+else
+    echo "Failure: Unable to create sym-link in $HOOK_DIR"
+fi


### PR DESCRIPTION
This PR addresses #2309.  There are two parts:

1) CircleCI configuration to test that code has been linted with our style

2) Tools so that we as developers can automatically lint the code when pushing, through a pre-push hook

When this gets merged merged developers will need to do the following:

- Install clang-format, version 11+
- Run the following script, which will install the pre-push hook in the .git/hooks directory of your local repository
`VAPOR/share/gitHooks/setupHooks.sh`