### PR TITLE
Fix #2617 VariableExists results incorrect

### DIFF
--- a/lib/vdc/VDCNetCDF.cpp
+++ b/lib/vdc/VDCNetCDF.cpp
@@ -1047,7 +1047,7 @@ bool VDCNetCDF::variableExists(size_t ts, string varname, int level, int lod) co
 
     for (int i = 0; i <= lod; i++) {
         struct stat statbuf;
-        if (stat(path.c_str(), &statbuf) < 0) return (false);
+        if (stat(paths[i].c_str(), &statbuf) < 0) return (false);
     }
     return (true);
 }

--- a/share/gitHooks/pre-push
+++ b/share/gitHooks/pre-push
@@ -26,4 +26,8 @@ else
     done
 
     git commit -a -m "clang-format pre-receive hook"
+
+    # git commit will return non-zero status if there's nothing to commit.  Make sure
+    # we return 0 so git 'push' will still be invoked
+    exit 0
 fi


### PR DESCRIPTION
Opened a separate issue and PR for this one because it appears this bug has become a feature. If you open a dataset with missing higher resolution data, it will just load the highest available resolution. This is not perfect as it will also select a too high CRatio which creates artifacting. After this PR, VariableExists correctly returns false for higher resolutions when they do not exists, but now if you try to select a higher resolution it will throw an error. My other PR for #1659 greys out options to select resolutions which do not exist, however.

Fix #2617