### PR TITLE
Fix #1659 VDC that is missing higher resolution data still reports having it

### DIFF
--- a/apps/vaporgui/PFidelitySection.cpp
+++ b/apps/vaporgui/PFidelitySection.cpp
@@ -50,26 +50,25 @@ void PQuickFidelitySelector::updateGUI() const
     int lod = rp->GetCompressionLevel();
     int ref = rp->GetRefinementLevel();
     int n = items.size();
-    
+
     _vComboBox->SetIndex(paramsToSimple(n, nLod, nRef, lod, ref));
-    
+
     long ts = rp->GetCurrentTimestep();
     for (int i = 0; i < n; i++) {
         simpleToParams(n, nLod, nRef, i, &lod, &ref);
         bool exists = dm->VariableExists(ts, vn, 0, ref);
-        if (!exists)
-            _vComboBox->SetItemEnabled(i, false);
+        if (!exists) _vComboBox->SetItemEnabled(i, false);
     }
 }
 
 void PQuickFidelitySelector::dropdownTextChanged(std::string)
 {
     auto *rp = (RenderParams *)getParams();
-    auto dm = getDataMgr();
-    auto vn = rp->GetFirstVariableName();
-    int  nLod = dm->GetCRatios(vn).size();
-    int  nRef = dm->GetNumRefLevels(vn);
-    int lod, ref;
+    auto  dm = getDataMgr();
+    auto  vn = rp->GetFirstVariableName();
+    int   nLod = dm->GetCRatios(vn).size();
+    int   nRef = dm->GetNumRefLevels(vn);
+    int   lod, ref;
     simpleToParams(_vComboBox->GetCount(), nLod, nRef, _vComboBox->GetCurrentIndex(), &lod, &ref);
 
     rp->BeginGroup("Change lod/cRatio");
@@ -84,8 +83,8 @@ void PQuickFidelitySelector::simpleToParams(int nSimple, int nLod, int nRef, int
         *lod = 0;
         *ref = 0;
     } else {
-        *lod = simple * (nLod-1) / (nSimple-1);
-        *ref = simple * (nRef-1) / (nSimple-1);
+        *lod = simple * (nLod - 1) / (nSimple - 1);
+        *ref = simple * (nRef - 1) / (nSimple - 1);
     }
 }
 
@@ -93,7 +92,7 @@ int PQuickFidelitySelector::paramsToSimple(int nSimple, int nLod, int nRef, int 
 {
     int div = nLod + nRef - 2;
     if (div == 0) return 0;
-    return (1 + lod + ref) * (nSimple-1) / div;
+    return (1 + lod + ref) * (nSimple - 1) / div;
 }
 
 // ==================================
@@ -143,7 +142,7 @@ void PRefinementSelector::updateGUI() const
     auto dm = getDataMgr();
     int  nrf = dm->GetNumRefLevels(varName);
     long timestep = rp->GetCurrentTimestep();
-    
+
     vector<string> items;
 
     for (int i = 0; i < nrf; i++) {
@@ -159,11 +158,10 @@ void PRefinementSelector::updateGUI() const
 
     _vComboBox->SetOptions(items);
     _vComboBox->SetIndex(rp->GetRefinementLevel());
-    
+
     for (int i = 0; i < nrf; i++) {
         bool exists = dm->VariableExists(timestep, varName, 0, i);
-        if (!exists)
-            _vComboBox->SetItemEnabled(i, false);
+        if (!exists) _vComboBox->SetItemEnabled(i, false);
     }
 }
 

--- a/apps/vaporgui/PFidelitySection.cpp
+++ b/apps/vaporgui/PFidelitySection.cpp
@@ -109,13 +109,21 @@ void PLODSelector::updateGUI() const
     RenderParams *rp = dynamic_cast<RenderParams *>(getParams());
     VAssert(rp && "Params must be RenderParams");
 
-    auto           cr = getDataMgr()->GetCRatios(rp->GetFirstVariableName());
+    auto varName = rp->GetFirstVariableName();
+    auto dm = getDataMgr();
+    auto cr = dm->GetCRatios(varName);
+    long timestep = rp->GetCurrentTimestep();
+    
     vector<string> items;
-
     for (int i = 0; i < cr.size(); i++) items.push_back(to_string(i) + " (" + to_string(cr[i]) + ":1)");
 
     _vComboBox->SetOptions(items);
     _vComboBox->SetIndex(rp->GetCompressionLevel());
+    
+    for (int i = 0; i < cr.size(); i++) {
+        bool exists = dm->VariableExists(timestep, varName, 0, i);
+        if (!exists) _vComboBox->SetItemEnabled(i, false);
+    }
 }
 
 void PLODSelector::dropdownIndexChanged(int i)
@@ -141,7 +149,6 @@ void PRefinementSelector::updateGUI() const
     auto varName = rp->GetFirstVariableName();
     auto dm = getDataMgr();
     int  nrf = dm->GetNumRefLevels(varName);
-    long timestep = rp->GetCurrentTimestep();
 
     vector<string> items;
 
@@ -158,11 +165,6 @@ void PRefinementSelector::updateGUI() const
 
     _vComboBox->SetOptions(items);
     _vComboBox->SetIndex(rp->GetRefinementLevel());
-
-    for (int i = 0; i < nrf; i++) {
-        bool exists = dm->VariableExists(timestep, varName, 0, i);
-        if (!exists) _vComboBox->SetItemEnabled(i, false);
-    }
 }
 
 void PRefinementSelector::dropdownIndexChanged(int i)

--- a/apps/vaporgui/PFidelitySection.cpp
+++ b/apps/vaporgui/PFidelitySection.cpp
@@ -113,13 +113,13 @@ void PLODSelector::updateGUI() const
     auto dm = getDataMgr();
     auto cr = dm->GetCRatios(varName);
     long timestep = rp->GetCurrentTimestep();
-    
+
     vector<string> items;
     for (int i = 0; i < cr.size(); i++) items.push_back(to_string(i) + " (" + to_string(cr[i]) + ":1)");
 
     _vComboBox->SetOptions(items);
     _vComboBox->SetIndex(rp->GetCompressionLevel());
-    
+
     for (int i = 0; i < cr.size(); i++) {
         bool exists = dm->VariableExists(timestep, varName, 0, i);
         if (!exists) _vComboBox->SetItemEnabled(i, false);

--- a/apps/vaporgui/PFidelitySection.h
+++ b/apps/vaporgui/PFidelitySection.h
@@ -24,8 +24,11 @@ protected:
     virtual void updateGUI() const override;
     bool         requireDataMgr() const override { return true; }
 
-private slots:
-    void dropdownTextChanged(std::string text);
+private:
+    void dropdownTextChanged(std::string);
+    
+    static void simpleToParams(int nSimple, int nLod, int nRef, int simple, int *lod, int *ref);
+    static int  paramsToSimple(int nSimple, int nLod, int nRef, int lod, int ref);
 };
 
 class PLODSelector : public PLineItem {

--- a/apps/vaporgui/PFidelitySection.h
+++ b/apps/vaporgui/PFidelitySection.h
@@ -26,7 +26,7 @@ protected:
 
 private:
     void dropdownTextChanged(std::string);
-    
+
     static void simpleToParams(int nSimple, int nLod, int nRef, int simple, int *lod, int *ref);
     static int  paramsToSimple(int nSimple, int nLod, int nRef, int lod, int ref);
 };

--- a/apps/vaporgui/VComboBox.cpp
+++ b/apps/vaporgui/VComboBox.cpp
@@ -1,4 +1,5 @@
 #include "VComboBox.h"
+#include <QStandardItemModel>
 
 VComboBox::VComboBox(const std::vector<std::string> &values) : VHBoxWidget()
 {
@@ -41,6 +42,15 @@ void VComboBox::SetValue(const std::string &value)
     QString qValue = QString::fromStdString(value);
     int     index = _combo->findText(qValue);
     if (index >= 0) SetIndex(index);
+}
+
+void VComboBox::SetItemEnabled(int index, bool enabled)
+{
+    QStandardItemModel *model = dynamic_cast<QStandardItemModel*>(_combo->model());
+    assert(model);
+    if (!model) return;
+    
+    model->item(index)->setEnabled(enabled);
 }
 
 int VComboBox::GetCurrentIndex() const { return _combo->currentIndex(); }

--- a/apps/vaporgui/VComboBox.cpp
+++ b/apps/vaporgui/VComboBox.cpp
@@ -46,10 +46,10 @@ void VComboBox::SetValue(const std::string &value)
 
 void VComboBox::SetItemEnabled(int index, bool enabled)
 {
-    QStandardItemModel *model = dynamic_cast<QStandardItemModel*>(_combo->model());
+    QStandardItemModel *model = dynamic_cast<QStandardItemModel *>(_combo->model());
     assert(model);
     if (!model) return;
-    
+
     model->item(index)->setEnabled(enabled);
 }
 

--- a/apps/vaporgui/VComboBox.h
+++ b/apps/vaporgui/VComboBox.h
@@ -18,6 +18,7 @@ public:
     void SetOptions(const std::vector<std::string> &values);
     void SetIndex(int index);
     void SetValue(const std::string &value);
+    void SetItemEnabled(int index, bool enabled);
 
     std::string GetValue() const;
     int         GetCurrentIndex() const;


### PR DESCRIPTION
Fix #1659

Adds the ability to automatically grey out missing resolutions but without merging #2618, all resolutions are always returned as existing by the data mgr.