### PR TITLE
Retain python editor's script after closing the dialog

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -2253,9 +2253,10 @@ void MainForm::launchPythonVariables()
 {
     if (!_pythonVariables) {
         _pythonVariables = new PythonVariables(this);
-        connect(_pythonVariables, &QDialog::finished, this, &MainForm::_pythonClosed);
     }
-    if (_controlExec) { _pythonVariables->InitControlExec(_controlExec); }
+    if (_controlExec) { 
+	    _pythonVariables->InitControlExec(_controlExec);
+    }
     _pythonVariables->ShowMe();
 }
 

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -2258,14 +2258,6 @@ void MainForm::launchPythonVariables()
     _pythonVariables->ShowMe();
 }
 
-void MainForm::_pythonClosed()
-{
-    if (_pythonVariables != nullptr) {
-        delete _pythonVariables;
-        _pythonVariables = nullptr;
-    }
-}
-
 void MainForm::_setTimeStep()
 {
     _paramsMgr->BeginSaveStateGroup("Change Timestep");

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -2254,9 +2254,7 @@ void MainForm::launchPythonVariables()
     if (!_pythonVariables) {
         _pythonVariables = new PythonVariables(this);
     }
-    if (_controlExec) { 
-	    _pythonVariables->InitControlExec(_controlExec);
-    }
+    if (_controlExec) { _pythonVariables->InitControlExec(_controlExec); }
     _pythonVariables->ShowMe();
 }
 

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -326,7 +326,6 @@ private:
 private slots:
     void _plotClosed();
     void _statsClosed();
-    void _pythonClosed();
     void sessionOpen(QString qfileName = "", bool loadDatasets = true);
     void fileSave();
     void fileSaveAs();

--- a/apps/vaporgui/PythonVariables.cpp
+++ b/apps/vaporgui/PythonVariables.cpp
@@ -495,7 +495,6 @@ std::vector<string> PythonVariables::_buildInputVars() const
 
 void PythonVariables::_closeScript()
 {
-    _reset();
     close();
 }
 


### PR DESCRIPTION
Fixes #1225 - the python editor keeps its script after closing the dialog.