### PR TITLE
Remove "~" references to home-directory in SettingsParams

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1930,9 +1930,7 @@ void MainForm::_performSessionAutoSave()
     if (_eventsSinceLastSave >= eventCountForAutoSave) {
         string autoSaveFile = sParams->GetAutoSaveSessionFile();
         int    rc = _paramsMgr->SaveToFile(autoSaveFile);
-        if (rc < 0) { 
-            MSG_ERR( "Unable to write settings file " + autoSaveFile );
-        }
+        if (rc < 0) { MSG_ERR("Unable to write settings file " + autoSaveFile); }
         _eventsSinceLastSave = 0;
     }
 }

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1930,7 +1930,9 @@ void MainForm::_performSessionAutoSave()
     if (_eventsSinceLastSave >= eventCountForAutoSave) {
         string autoSaveFile = sParams->GetAutoSaveSessionFile();
         int    rc = _paramsMgr->SaveToFile(autoSaveFile);
-        if (rc < 0) { MSG_ERR(); }
+        if (rc < 0) { 
+            MSG_ERR( "Unable to write settings file " + autoSaveFile );
+        }
         _eventsSinceLastSave = 0;
     }
 }

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1929,12 +1929,11 @@ void MainForm::_performSessionAutoSave()
 
     if (_eventsSinceLastSave >= eventCountForAutoSave) {
         string autoSaveFile = sParams->GetAutoSaveSessionFile();
-        int rc = _paramsMgr->SaveToFile(autoSaveFile);
-        if ( rc == -1 ) {
-            MSG_ERR( "Unable to open settings file " + autoSaveFile );
-        }
-        else if ( rc < -1 ) {
-            MSG_ERR( "Unable to write settings file " + autoSaveFile );
+        int    rc = _paramsMgr->SaveToFile(autoSaveFile);
+        if (rc == -1) {
+            MSG_ERR("Unable to open settings file " + autoSaveFile);
+        } else if (rc < -1) {
+            MSG_ERR("Unable to write settings file " + autoSaveFile);
         }
         _eventsSinceLastSave = 0;
     }

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1930,9 +1930,7 @@ void MainForm::_performSessionAutoSave()
     if (_eventsSinceLastSave >= eventCountForAutoSave) {
         string autoSaveFile = sParams->GetAutoSaveSessionFile();
         int    rc = _paramsMgr->SaveToFile(autoSaveFile);
-        if (rc < 0) {
-            MSG_ERR();
-        } 
+        if (rc < 0) { MSG_ERR(); }
         _eventsSinceLastSave = 0;
     }
 }

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1929,7 +1929,13 @@ void MainForm::_performSessionAutoSave()
 
     if (_eventsSinceLastSave >= eventCountForAutoSave) {
         string autoSaveFile = sParams->GetAutoSaveSessionFile();
-        _paramsMgr->SaveToFile(autoSaveFile);
+        int rc = _paramsMgr->SaveToFile(autoSaveFile);
+        if ( rc == -1 ) {
+            MSG_ERR( "Unable to open settings file " + autoSaveFile );
+        }
+        else if ( rc < -1 ) {
+            MSG_ERR( "Unable to write settings file " + autoSaveFile );
+        }
         _eventsSinceLastSave = 0;
     }
 }

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1930,11 +1930,9 @@ void MainForm::_performSessionAutoSave()
     if (_eventsSinceLastSave >= eventCountForAutoSave) {
         string autoSaveFile = sParams->GetAutoSaveSessionFile();
         int    rc = _paramsMgr->SaveToFile(autoSaveFile);
-        if (rc == -1) {
-            MSG_ERR("Unable to open settings file " + autoSaveFile);
-        } else if (rc < -1) {
-            MSG_ERR("Unable to write settings file " + autoSaveFile);
-        }
+        if (rc < 0) {
+            MSG_ERR();
+        } 
         _eventsSinceLastSave = 0;
     }
 }

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -223,6 +223,14 @@ string SettingsParams::GetAutoSaveSessionFile() const
     string defaultFile = autoSaveDir + "/VaporAutoSave.vs3";
 
     string file = GetValueString(_autoSaveFileLocationTag, defaultFile);
+
+    // Replace all occurances of "~" with the user's home directory
+    size_t pos = 0;
+    while((pos = file.find("~", pos)) != std::string::npos) {
+         file.replace(pos, 1, QDir::homePath().toStdString() );
+         pos += 1;
+    }
+
     return file;
 }
 

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -435,7 +435,7 @@ void SettingsParams::Init()
     SetSessionAutoSaveEnabled(true);
     SetChangesPerAutoSave(5);
     std::string homeDir = QDir::homePath().toStdString();
-    SetAutoSaveSessionFile(homeDir + "/VaporAutoSave.vs3");
+    SetAutoSaveSessionFile( homeDir + "/VaporAutoSave.vs3" );
 
     SetAutoStretchEnabled(true);
     SetNumThreads(4);
@@ -444,9 +444,9 @@ void SettingsParams::Init()
     SetWinWidth(1920);
     SetWinHeight(1024);
 
-    SetDefaultSessionDir(string(homeDir));
-    SetDefaultMetadataDir(string(homeDir));
-    SetDefaultFlowDir(string(homeDir));
+    SetDefaultSessionDir( string(homeDir ) );
+    SetDefaultMetadataDir( string(homeDir ) );
+    SetDefaultFlowDir( string( homeDir ) );
 
     string palettes = GetSharePath("palettes");
     SetDefaultTFDir(string(palettes));

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -248,7 +248,7 @@ string SettingsParams::GetSessionDir() const
 {
     string defaultDir = GetDefaultSessionDir();
     string dir = GetValueString(_sessionDirTag, defaultDir);
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    _swapTildeWithHome(dir);
     return (dir);
 }
 
@@ -257,7 +257,7 @@ void SettingsParams::SetSessionDir(string name) { SetValueString(_sessionDirTag,
 string SettingsParams::GetDefaultSessionDir() const
 {
     string dir = GetValueString(_defaultSessionDirTag, string("."));
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    _swapTildeWithHome(dir);
     return (dir);
 }
 
@@ -277,7 +277,7 @@ string SettingsParams::GetMetadataDir() const
 {
     string defaultDir = GetDefaultMetadataDir();
     string dir = GetValueString(_metadataDirTag, defaultDir);
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    _swapTildeWithHome(dir);
     return (dir);
 }
 
@@ -286,7 +286,7 @@ void SettingsParams::SetMetadataDir(string dir) { SetValueString(_metadataDirTag
 string SettingsParams::GetDefaultMetadataDir() const
 {
     string dir = GetValueString(_defaultMetadataDirTag, string("."));
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    _swapTildeWithHome(dir);
     return (dir);
 }
 
@@ -300,7 +300,7 @@ string SettingsParams::GetTFDir() const
 {
     string defaultDir = GetDefaultTFDir();
     string dir = GetValueString(_tfDirTag, defaultDir);
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    _swapTildeWithHome(dir);
     return (dir);
 }
 
@@ -309,7 +309,7 @@ void SettingsParams::SetTFDir(string dir) { SetValueString(_tfDirTag, "set trans
 string SettingsParams::GetDefaultTFDir() const
 {
     string dir = GetValueString(_defaultTfDirTag, string(""));
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    _swapTildeWithHome(dir);
     return (dir);
 }
 
@@ -323,7 +323,7 @@ string SettingsParams::GetFlowDir() const
 {
     string defaultDir = GetDefaultFlowDir();
     string dir = GetValueString(_flowDirTag, defaultDir);
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    _swapTildeWithHome(dir);
     return (dir);
 }
 
@@ -332,7 +332,7 @@ void SettingsParams::SetFlowDir(string dir) { SetValueString(_flowDirTag, "set f
 string SettingsParams::GetDefaultFlowDir() const
 {
     string dir = GetValueString(_defaultFlowDirTag, string("."));
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    _swapTildeWithHome(dir);
     return (dir);
 }
 
@@ -342,7 +342,7 @@ string SettingsParams::GetPythonDir() const
 {
     string defaultDir = GetDefaultPythonDir();
     string dir = GetValueString(_pythonDirTag, defaultDir);
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    _swapTildeWithHome(dir);
     return (dir);
 }
 
@@ -351,7 +351,7 @@ void SettingsParams::SetPythonDir(string dir) { SetValueString(_pythonDirTag, "s
 string SettingsParams::GetDefaultPythonDir() const
 {
     string dir = GetValueString(_defaultPythonDirTag, string("."));
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    _swapTildeWithHome(dir);
     return (dir);
 }
 

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -144,7 +144,7 @@ void SettingsParams::_swapTildeWithHome(std::string &file) const
     size_t pos = 0;
     while ((pos = file.find("~", pos)) != std::string::npos) {
         file.replace(pos, 1, QDir::homePath().toStdString());
-        pos += 1;
+        pos += QDir::homePath().toStdString().length();
     }
 }
 

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -435,7 +435,7 @@ void SettingsParams::Init()
     SetSessionAutoSaveEnabled(true);
     SetChangesPerAutoSave(5);
     std::string homeDir = QDir::homePath().toStdString();
-    SetAutoSaveSessionFile( homeDir + "/VaporAutoSave.vs3");
+    SetAutoSaveSessionFile(homeDir + "/VaporAutoSave.vs3");
 
     SetAutoStretchEnabled(true);
     SetNumThreads(4);

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -139,6 +139,14 @@ void SettingsParams::Reinit() { Init(); }
 
 SettingsParams::~SettingsParams() {}
 
+void SettingsParams::_swapTildeWithHome( std::string& file ) const {
+    size_t pos = 0;
+    while((pos = file.find("~", pos)) != std::string::npos) {
+         file.replace(pos, 1, QDir::homePath().toStdString() );
+         pos += 1;
+    }
+}
+
 long SettingsParams::GetCacheMB() const
 {
     long val = GetValueLong(_cacheMBTag, 8000);
@@ -224,12 +232,7 @@ string SettingsParams::GetAutoSaveSessionFile() const
 
     string file = GetValueString(_autoSaveFileLocationTag, defaultFile);
 
-    // Replace all occurances of "~" with the user's home directory
-    size_t pos = 0;
-    while ((pos = file.find("~", pos)) != std::string::npos) {
-        file.replace(pos, 1, QDir::homePath().toStdString());
-        pos += 1;
-    }
+    _swapTildeWithHome( file );
 
     return file;
 }

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -226,9 +226,9 @@ string SettingsParams::GetAutoSaveSessionFile() const
 
     // Replace all occurances of "~" with the user's home directory
     size_t pos = 0;
-    while((pos = file.find("~", pos)) != std::string::npos) {
-         file.replace(pos, 1, QDir::homePath().toStdString() );
-         pos += 1;
+    while ((pos = file.find("~", pos)) != std::string::npos) {
+        file.replace(pos, 1, QDir::homePath().toStdString());
+        pos += 1;
     }
 
     return file;

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -139,11 +139,12 @@ void SettingsParams::Reinit() { Init(); }
 
 SettingsParams::~SettingsParams() {}
 
-void SettingsParams::_swapTildeWithHome( std::string& file ) const {
+void SettingsParams::_swapTildeWithHome(std::string &file) const
+{
     size_t pos = 0;
-    while((pos = file.find("~", pos)) != std::string::npos) {
-         file.replace(pos, 1, QDir::homePath().toStdString() );
-         pos += 1;
+    while ((pos = file.find("~", pos)) != std::string::npos) {
+        file.replace(pos, 1, QDir::homePath().toStdString());
+        pos += 1;
     }
 }
 
@@ -232,7 +233,7 @@ string SettingsParams::GetAutoSaveSessionFile() const
 
     string file = GetValueString(_autoSaveFileLocationTag, defaultFile);
 
-    _swapTildeWithHome( file );
+    _swapTildeWithHome(file);
 
     return file;
 }

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -236,7 +236,7 @@ string SettingsParams::GetSessionDir() const
 {
     string defaultDir = GetDefaultSessionDir();
     string dir = GetValueString(_sessionDirTag, defaultDir);
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -245,7 +245,7 @@ void SettingsParams::SetSessionDir(string name) { SetValueString(_sessionDirTag,
 string SettingsParams::GetDefaultSessionDir() const
 {
     string dir = GetValueString(_defaultSessionDirTag, string("."));
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -265,7 +265,7 @@ string SettingsParams::GetMetadataDir() const
 {
     string defaultDir = GetDefaultMetadataDir();
     string dir = GetValueString(_metadataDirTag, defaultDir);
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -274,7 +274,7 @@ void SettingsParams::SetMetadataDir(string dir) { SetValueString(_metadataDirTag
 string SettingsParams::GetDefaultMetadataDir() const
 {
     string dir = GetValueString(_defaultMetadataDirTag, string("."));
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -288,7 +288,7 @@ string SettingsParams::GetTFDir() const
 {
     string defaultDir = GetDefaultTFDir();
     string dir = GetValueString(_tfDirTag, defaultDir);
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -297,7 +297,7 @@ void SettingsParams::SetTFDir(string dir) { SetValueString(_tfDirTag, "set trans
 string SettingsParams::GetDefaultTFDir() const
 {
     string dir = GetValueString(_defaultTfDirTag, string(""));
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -311,7 +311,7 @@ string SettingsParams::GetFlowDir() const
 {
     string defaultDir = GetDefaultFlowDir();
     string dir = GetValueString(_flowDirTag, defaultDir);
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -320,7 +320,7 @@ void SettingsParams::SetFlowDir(string dir) { SetValueString(_flowDirTag, "set f
 string SettingsParams::GetDefaultFlowDir() const
 {
     string dir = GetValueString(_defaultFlowDirTag, string("."));
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -330,7 +330,7 @@ string SettingsParams::GetPythonDir() const
 {
     string defaultDir = GetDefaultPythonDir();
     string dir = GetValueString(_pythonDirTag, defaultDir);
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -339,7 +339,7 @@ void SettingsParams::SetPythonDir(string dir) { SetValueString(_pythonDirTag, "s
 string SettingsParams::GetDefaultPythonDir() const
 {
     string dir = GetValueString(_defaultPythonDirTag, string("."));
-    if (dir == "~") { dir = QDir::homePath().toStdString(); }
+    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -434,7 +434,8 @@ void SettingsParams::Init()
 {
     SetSessionAutoSaveEnabled(true);
     SetChangesPerAutoSave(5);
-    SetAutoSaveSessionFile("~/VaporAutoSave.vs3");
+    std::string homeDir = QDir::homePath().toStdString();
+    SetAutoSaveSessionFile( homeDir+ "/VaporAutoSave.vs3" );
 
     SetAutoStretchEnabled(true);
     SetNumThreads(4);
@@ -443,9 +444,9 @@ void SettingsParams::Init()
     SetWinWidth(1920);
     SetWinHeight(1024);
 
-    SetDefaultSessionDir(string("~"));
-    SetDefaultMetadataDir(string("~"));
-    SetDefaultFlowDir(string("~"));
+    SetDefaultSessionDir( string( homeDir ) );
+    SetDefaultMetadataDir( string( homeDir ) );
+    SetDefaultFlowDir(string( homeDir ) );
 
     string palettes = GetSharePath("palettes");
     SetDefaultTFDir(string(palettes));

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -236,7 +236,6 @@ string SettingsParams::GetSessionDir() const
 {
     string defaultDir = GetDefaultSessionDir();
     string dir = GetValueString(_sessionDirTag, defaultDir);
-    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -245,7 +244,6 @@ void SettingsParams::SetSessionDir(string name) { SetValueString(_sessionDirTag,
 string SettingsParams::GetDefaultSessionDir() const
 {
     string dir = GetValueString(_defaultSessionDirTag, string("."));
-    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -265,7 +263,6 @@ string SettingsParams::GetMetadataDir() const
 {
     string defaultDir = GetDefaultMetadataDir();
     string dir = GetValueString(_metadataDirTag, defaultDir);
-    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -274,7 +271,6 @@ void SettingsParams::SetMetadataDir(string dir) { SetValueString(_metadataDirTag
 string SettingsParams::GetDefaultMetadataDir() const
 {
     string dir = GetValueString(_defaultMetadataDirTag, string("."));
-    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -288,7 +284,6 @@ string SettingsParams::GetTFDir() const
 {
     string defaultDir = GetDefaultTFDir();
     string dir = GetValueString(_tfDirTag, defaultDir);
-    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -297,7 +292,6 @@ void SettingsParams::SetTFDir(string dir) { SetValueString(_tfDirTag, "set trans
 string SettingsParams::GetDefaultTFDir() const
 {
     string dir = GetValueString(_defaultTfDirTag, string(""));
-    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -311,7 +305,6 @@ string SettingsParams::GetFlowDir() const
 {
     string defaultDir = GetDefaultFlowDir();
     string dir = GetValueString(_flowDirTag, defaultDir);
-    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -320,7 +313,6 @@ void SettingsParams::SetFlowDir(string dir) { SetValueString(_flowDirTag, "set f
 string SettingsParams::GetDefaultFlowDir() const
 {
     string dir = GetValueString(_defaultFlowDirTag, string("."));
-    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -330,7 +322,6 @@ string SettingsParams::GetPythonDir() const
 {
     string defaultDir = GetDefaultPythonDir();
     string dir = GetValueString(_pythonDirTag, defaultDir);
-    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -339,7 +330,6 @@ void SettingsParams::SetPythonDir(string dir) { SetValueString(_pythonDirTag, "s
 string SettingsParams::GetDefaultPythonDir() const
 {
     string dir = GetValueString(_defaultPythonDirTag, string("."));
-    //if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -236,6 +236,7 @@ string SettingsParams::GetSessionDir() const
 {
     string defaultDir = GetDefaultSessionDir();
     string dir = GetValueString(_sessionDirTag, defaultDir);
+    if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -244,6 +245,7 @@ void SettingsParams::SetSessionDir(string name) { SetValueString(_sessionDirTag,
 string SettingsParams::GetDefaultSessionDir() const
 {
     string dir = GetValueString(_defaultSessionDirTag, string("."));
+    if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -263,6 +265,7 @@ string SettingsParams::GetMetadataDir() const
 {
     string defaultDir = GetDefaultMetadataDir();
     string dir = GetValueString(_metadataDirTag, defaultDir);
+    if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -271,6 +274,7 @@ void SettingsParams::SetMetadataDir(string dir) { SetValueString(_metadataDirTag
 string SettingsParams::GetDefaultMetadataDir() const
 {
     string dir = GetValueString(_defaultMetadataDirTag, string("."));
+    if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -284,6 +288,7 @@ string SettingsParams::GetTFDir() const
 {
     string defaultDir = GetDefaultTFDir();
     string dir = GetValueString(_tfDirTag, defaultDir);
+    if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -292,6 +297,7 @@ void SettingsParams::SetTFDir(string dir) { SetValueString(_tfDirTag, "set trans
 string SettingsParams::GetDefaultTFDir() const
 {
     string dir = GetValueString(_defaultTfDirTag, string(""));
+    if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -305,6 +311,7 @@ string SettingsParams::GetFlowDir() const
 {
     string defaultDir = GetDefaultFlowDir();
     string dir = GetValueString(_flowDirTag, defaultDir);
+    if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -313,6 +320,7 @@ void SettingsParams::SetFlowDir(string dir) { SetValueString(_flowDirTag, "set f
 string SettingsParams::GetDefaultFlowDir() const
 {
     string dir = GetValueString(_defaultFlowDirTag, string("."));
+    if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -322,6 +330,7 @@ string SettingsParams::GetPythonDir() const
 {
     string defaultDir = GetDefaultPythonDir();
     string dir = GetValueString(_pythonDirTag, defaultDir);
+    if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -330,6 +339,7 @@ void SettingsParams::SetPythonDir(string dir) { SetValueString(_pythonDirTag, "s
 string SettingsParams::GetDefaultPythonDir() const
 {
     string dir = GetValueString(_defaultPythonDirTag, string("."));
+    if (dir == "~") { dir = QDir::homePath().toStdString(); }
     return (dir);
 }
 
@@ -425,7 +435,7 @@ void SettingsParams::Init()
     SetSessionAutoSaveEnabled(true);
     SetChangesPerAutoSave(5);
     std::string homeDir = QDir::homePath().toStdString();
-    SetAutoSaveSessionFile( homeDir+ "/VaporAutoSave.vs3" );
+    SetAutoSaveSessionFile( homeDir + "/VaporAutoSave.vs3");
 
     SetAutoStretchEnabled(true);
     SetNumThreads(4);
@@ -434,9 +444,9 @@ void SettingsParams::Init()
     SetWinWidth(1920);
     SetWinHeight(1024);
 
-    SetDefaultSessionDir( string( homeDir ) );
-    SetDefaultMetadataDir( string( homeDir ) );
-    SetDefaultFlowDir(string( homeDir ) );
+    SetDefaultSessionDir(string(homeDir));
+    SetDefaultMetadataDir(string(homeDir));
+    SetDefaultFlowDir(string(homeDir));
 
     string palettes = GetSharePath("palettes");
     SetDefaultTFDir(string(palettes));

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -435,7 +435,7 @@ void SettingsParams::Init()
     SetSessionAutoSaveEnabled(true);
     SetChangesPerAutoSave(5);
     std::string homeDir = QDir::homePath().toStdString();
-    SetAutoSaveSessionFile( homeDir + "/VaporAutoSave.vs3" );
+    SetAutoSaveSessionFile(homeDir + "/VaporAutoSave.vs3");
 
     SetAutoStretchEnabled(true);
     SetNumThreads(4);
@@ -444,9 +444,9 @@ void SettingsParams::Init()
     SetWinWidth(1920);
     SetWinHeight(1024);
 
-    SetDefaultSessionDir( string(homeDir ) );
-    SetDefaultMetadataDir( string(homeDir ) );
-    SetDefaultFlowDir( string( homeDir ) );
+    SetDefaultSessionDir(string(homeDir));
+    SetDefaultMetadataDir(string(homeDir));
+    SetDefaultFlowDir(string(homeDir));
 
     string palettes = GetSharePath("palettes");
     SetDefaultTFDir(string(palettes));

--- a/apps/vaporgui/SettingsParams.h
+++ b/apps/vaporgui/SettingsParams.h
@@ -169,7 +169,7 @@ private:
     static const string _settingsNeedsWriteTag;
 
     bool _loadFromSettingsFile();
-    void _swapTildeWithHome( std::string& file ) const;
+    void _swapTildeWithHome(std::string &file) const;
 
     string _settingsPath;
 };

--- a/apps/vaporgui/SettingsParams.h
+++ b/apps/vaporgui/SettingsParams.h
@@ -169,6 +169,7 @@ private:
     static const string _settingsNeedsWriteTag;
 
     bool _loadFromSettingsFile();
+    void _swapTildeWithHome( std::string& file ) const;
 
     string _settingsPath;
 };

--- a/lib/params/ParamsMgr.cpp
+++ b/lib/params/ParamsMgr.cpp
@@ -1063,7 +1063,7 @@ int ParamsMgr::SaveToFile(string path) const
 
     if (out.bad()) {
         MyBase::SetErrMsg("Failed to write file %s : %M", path.c_str());
-        return (-2);
+        return (-1);
     }
     out.close();
 

--- a/lib/params/ParamsMgr.cpp
+++ b/lib/params/ParamsMgr.cpp
@@ -1063,7 +1063,7 @@ int ParamsMgr::SaveToFile(string path) const
 
     if (out.bad()) {
         MyBase::SetErrMsg("Failed to write file %s : %M", path.c_str());
-        return (-1);
+        return (-2);
     }
     out.close();
 


### PR DESCRIPTION
Fixes #2657 by removing "~" references to the user's home directory, and adding error checking for file-writes in MainForm.

The ofstream method is picky about the file path its given.   While it writes to existing files with "~" in its path, it will not create them.

Note: You may need to "restore defaults" to overwrite an existing .vapor3_prefs file in your home directory, which still may refer to "home" as "~"

Also fixes #2676