### PR TITLE
Remove window size locking from Vapor's "Settings"

### DIFF
--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -26,9 +26,6 @@ AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(
                          new PCheckboxHLI<SettingsParams>("Automatically stretch domain", &SettingsParams::GetAutoStretchEnabled, &SettingsParams::SetAutoStretchEnabled),
                          new PIntegerInputHLI<SettingsParams>("Number of threads (0 for available num. of CPU cores)", &SettingsParams::GetNumThreads, &SettingsParams::SetNumThreads),
                          new PIntegerInputHLI<SettingsParams>("Cache size (Megabytes)", &SettingsParams::GetCacheMB, &SettingsParams::SetCacheMB),
-                         new PCheckboxHLI<SettingsParams>("Lock window dimensions", &SettingsParams::GetWinSizeLock, &SettingsParams::SetWinSizeLock),
-                         (new PIntegerInputHLI<SettingsParams>("Width", &SettingsParams::GetWinWidth, &SettingsParams::SetWinWidth))->EnableBasedOnParam(SettingsParams::_winSizeLockTag),
-                         (new PIntegerInputHLI<SettingsParams>("Height", &SettingsParams::GetWinHeight, &SettingsParams::SetWinHeight))->EnableBasedOnParam(SettingsParams::_winSizeLockTag),
                          new PLabel("*Vapor must be restarted for these settings to take effect"),
                      }),
 

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -387,13 +387,6 @@ MainForm::MainForm(vector<QString> files, QApplication *app, QWidget *parent) : 
     _controlExec->SetCacheSize(sP->GetCacheMB());
     _controlExec->SetNumThreads(sP->GetNumThreads());
 
-    bool lockSize = sP->GetWinSizeLock();
-    if (lockSize) {
-        size_t width, height;
-        sP->GetWinSize(width, height);
-        setFixedSize(QSize(width, height));
-    }
-
     _vizWinMgr = new VizWinMgr(this, _mdiArea, _controlExec);
 
     _tabMgr = new TabManager(this, _controlExec);

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -43,8 +43,6 @@ const string SettingsParams::_cacheMBTag = "CacheMBs";
 const string SettingsParams::_numThreadsTag = "NumThreads";
 const string SettingsParams::_texSizeTag = "TexSize";
 const string SettingsParams::_texSizeEnableTag = "TexSizeEnabled";
-const string SettingsParams::_winSizeTag = "WinSize";
-const string SettingsParams::_winSizeLockTag = "WinSizeLocked";
 const string SettingsParams::_sessionDirTag = "SessionDir";
 const string SettingsParams::_defaultSessionDirTag = "SessionDir";
 const string SettingsParams::_metadataDirTag = "MetadataDir";
@@ -168,10 +166,6 @@ void SettingsParams::SetTextureSize(long val)
 void SettingsParams::SetTexSizeEnable(bool val) { SetValueLong(_texSizeEnableTag, "toggle enable texture size", (long)val); }
 
 bool SettingsParams::GetTexSizeEnable() const { return (0 != GetValueLong(_texSizeEnableTag, (long)0)); }
-
-void SettingsParams::SetWinSizeLock(bool val) { SetValueLong(_winSizeLockTag, "toggle lock window size", (long)val); }
-
-bool SettingsParams::GetWinSizeLock() const { return (0 != GetValueLong(_winSizeLockTag, (long)false)); }
 
 bool SettingsParams::GetAutoStretchEnabled() const { return (0 != GetValueLong(_autoStretchTag, (long)true)); }
 
@@ -439,9 +433,6 @@ void SettingsParams::Init()
     SetAutoStretchEnabled(true);
     SetNumThreads(4);
     SetCacheMB(8000);
-    SetWinSizeLock(false);
-    SetWinWidth(1920);
-    SetWinHeight(1024);
 
     SetDefaultSessionDir(string("~"));
     SetDefaultMetadataDir(string("~"));
@@ -452,57 +443,6 @@ void SettingsParams::Init()
 
     string python = GetPythonDir();
     SetDefaultPythonDir(string(python));
-}
-
-void SettingsParams::SetWinWidth(int width)
-{
-    size_t dummyWidth, height;
-    GetWinSize(dummyWidth, height);
-    SetWinSize(width, height);
-}
-
-void SettingsParams::SetWinHeight(int height)
-{
-    size_t width, dummyHeight;
-    GetWinSize(width, dummyHeight);
-    SetWinSize(width, height);
-}
-
-int SettingsParams::GetWinWidth() const
-{
-    size_t width, height;
-    GetWinSize(width, height);
-    return width;
-}
-
-int SettingsParams::GetWinHeight() const
-{
-    size_t width, height;
-    GetWinSize(width, height);
-    return height;
-}
-
-void SettingsParams::SetWinSize(size_t width, size_t height)
-{
-    if (width < 400) width = 400;
-    if (height < 400) height = 400;
-
-    vector<long> val;
-    val.push_back(width);
-    val.push_back(height);
-    SetValueLongVec(_winSizeTag, "Set window size", val);
-}
-
-void SettingsParams::GetWinSize(size_t &width, size_t &height) const
-{
-    vector<long> defaultv;
-    defaultv.push_back(1280);
-    defaultv.push_back(1024);
-    vector<long> val = GetValueLongVec(_winSizeTag, defaultv);
-    if (val[0] < 400) val[0] = defaultv[0];
-    if (val[1] < 400) val[1] = defaultv[1];
-    width = val[0];
-    height = val[1];
 }
 
 std::string SettingsParams::GetSettingsPath() const { return _settingsPath; }

--- a/apps/vaporgui/SettingsParams.h
+++ b/apps/vaporgui/SettingsParams.h
@@ -123,7 +123,6 @@ public:
 
     int SaveSettings() const;
 
-    static const string _winSizeLockTag;
     static const string _sessionAutoSaveEnabledTag;
 
     std::string GetSettingsPath() const;
@@ -135,7 +134,6 @@ private:
     static const string _cacheMBTag;
     static const string _texSizeTag;
     static const string _texSizeEnableTag;
-    static const string _winSizeTag;
     static const string _currentPrefsPathTag;
     static const string _sessionDirTag;
     static const string _defaultSessionDirTag;

--- a/apps/vaporgui/SettingsParams.h
+++ b/apps/vaporgui/SettingsParams.h
@@ -60,15 +60,6 @@ public:
     void SetTexSizeEnable(bool val);
     bool GetTexSizeEnable() const;
 
-    void SetWinSizeLock(bool val);
-    bool GetWinSizeLock() const;
-    void SetWinSize(size_t width, size_t height);
-    void SetWinWidth(int width);
-    void SetWinHeight(int height);
-    void GetWinSize(size_t &width, size_t &height) const;
-    int  GetWinWidth() const;
-    int  GetWinHeight() const;
-
     bool GetAutoStretchEnabled() const;
     void SetAutoStretchEnabled(bool val);
 


### PR DESCRIPTION
Removes window size locking from the GUI and SettingsParams database.  Fixes #2656.