### PR TITLE
Fixed #2651 : Crash opening data set after a previous data set failed to open

### DIFF
--- a/apps/vaporgui/AnnotationEventRouter.cpp
+++ b/apps/vaporgui/AnnotationEventRouter.cpp
@@ -229,7 +229,7 @@ void AnnotationEventRouter::updateCopyRegionCombo()
 
     ParamsMgr *              paramsMgr = _controlExec->GetParamsMgr();
     std::vector<std::string> visNames = paramsMgr->GetVisualizerNames();
-    DataStatus *        dataStatus = _controlExec->GetDataStatus();
+    DataStatus *             dataStatus = _controlExec->GetDataStatus();
 
     for (int i = 0; i < visNames.size(); i++) {
         string visName = visNames[i];

--- a/apps/vaporgui/AnnotationEventRouter.cpp
+++ b/apps/vaporgui/AnnotationEventRouter.cpp
@@ -229,6 +229,8 @@ void AnnotationEventRouter::updateCopyRegionCombo()
 
     ParamsMgr *              paramsMgr = _controlExec->GetParamsMgr();
     std::vector<std::string> visNames = paramsMgr->GetVisualizerNames();
+    DataStatus *        dataStatus = _controlExec->GetDataStatus();
+
     for (int i = 0; i < visNames.size(); i++) {
         string visName = visNames[i];
 
@@ -244,7 +246,7 @@ void AnnotationEventRouter::updateCopyRegionCombo()
         for (int j = 0; j < typeNames.size(); j++) {
             string typeName = typeNames[j];
 
-            std::vector<string> dmNames = paramsMgr->GetDataMgrNames();
+            std::vector<string> dmNames = dataStatus->GetDataMgrNames();
             for (int k = 0; k < dmNames.size(); k++) {
                 string dataSetName = dmNames[k];
                 addRendererToCombo(visName, typeName, visAbb, dataSetName);

--- a/apps/vaporgui/NavigationEventRouter.cpp
+++ b/apps/vaporgui/NavigationEventRouter.cpp
@@ -370,7 +370,7 @@ void NavigationEventRouter::updateTransforms()
         ViewpointParams *vParams = paramsMgr->GetViewpointParams(winNames[i]);
         if (!vParams) continue;
 
-		DataStatus *   dataStatus = _controlExec->GetDataStatus();
+        DataStatus *   dataStatus = _controlExec->GetDataStatus();
         vector<string> names = dataStatus->GetDataMgrNames();
 
         for (int j = 0; j < names.size(); j++) {

--- a/apps/vaporgui/NavigationEventRouter.cpp
+++ b/apps/vaporgui/NavigationEventRouter.cpp
@@ -370,7 +370,8 @@ void NavigationEventRouter::updateTransforms()
         ViewpointParams *vParams = paramsMgr->GetViewpointParams(winNames[i]);
         if (!vParams) continue;
 
-        vector<string> names = paramsMgr->GetDataMgrNames();
+		DataStatus *   dataStatus = _controlExec->GetDataStatus();
+        vector<string> names = dataStatus->GetDataMgrNames();
 
         for (int j = 0; j < names.size(); j++) {
             Transform *t = vParams->GetTransform(names[j]);
@@ -380,7 +381,6 @@ void NavigationEventRouter::updateTransforms()
                 vector<double> minExts;
                 vector<double> maxExts;
                 vector<double> origin;
-                DataStatus *   dataStatus = _controlExec->GetDataStatus();
 
                 dataStatus->GetActiveExtents(paramsMgr, winNames[i], names[j], ts, minExts, maxExts);
 

--- a/apps/vaporgui/RenderHolder.cpp
+++ b/apps/vaporgui/RenderHolder.cpp
@@ -281,8 +281,7 @@ void RenderHolder::_showIntelDriverWarning(const string &rendererType)
 
 void RenderHolder::_showNewRendererDialog()
 {
-    ParamsMgr *    paramsMgr = _controlExec->GetParamsMgr();
-    vector<string> dataSetNames = paramsMgr->GetDataMgrNames();
+    vector<string> dataSetNames = _controlExec->GetDataStatus()->GetDataMgrNames();
 
     _initializeNewRendererDialog(dataSetNames);
     _newRendererDialog->open();
@@ -291,7 +290,7 @@ void RenderHolder::_showNewRendererDialog()
 void RenderHolder::_newRendererDialogAccepted()
 {
     ParamsMgr *    paramsMgr = _controlExec->GetParamsMgr();
-    vector<string> dataSetNames = paramsMgr->GetDataMgrNames();
+    vector<string> dataSetNames = _controlExec->GetDataStatus()->GetDataMgrNames();
 
     string rendererType = _newRendererDialog->GetSelectedRenderer();
     _showIntelDriverWarning(rendererType);

--- a/include/vapor/ControlExecutive.h
+++ b/include/vapor/ControlExecutive.h
@@ -8,6 +8,7 @@
 
 #include <vapor/ParamsMgr.h>
 #include <vapor/GLManager.h>
+#include <vapor/DataStatus.h>
 
 using namespace std;
 namespace VAPoR {
@@ -329,7 +330,7 @@ public:
     //!
     //! \sa OpenData(), CloseData()
     //
-    std::vector<string> GetDataNames() const { return (_paramsMgr->GetDataMgrNames()); }
+    std::vector<string> GetDataNames() const { return (_dataStatus->GetDataMgrNames()); }
 
     //! Obtain the current DataStatus
     //! Needed to store in GUI when the DataStatus changes.

--- a/lib/render/AnnotationRenderer.cpp
+++ b/lib/render/AnnotationRenderer.cpp
@@ -420,7 +420,7 @@ void AnnotationRenderer::_calculateDomainExtents(std::vector<double> &domainExte
 {
     domainExtents = {NAN, NAN, NAN, NAN, NAN, NAN};
 
-    vector<string> names = m_paramsMgr->GetDataMgrNames();
+    vector<string> names = m_dataStatus->GetDataMgrNames();
     for (int i = 0; i < names.size(); i++) {
         std::vector<double> dataMgrMinExts, dataMgrMaxExts;
 
@@ -457,7 +457,7 @@ void AnnotationRenderer::InScenePaint(size_t ts)
 
     if (vfParams->GetUseDomainFrame()) drawDomainFrame(domainExtents);
 
-    vector<string> names = m_paramsMgr->GetDataMgrNames();
+    vector<string> names = m_dataStatus->GetDataMgrNames();
     Transform *    t = vpParams->GetTransform(names[0]);
     applyTransform(t);
 

--- a/lib/render/CalcEngineMgr.cpp
+++ b/lib/render/CalcEngineMgr.cpp
@@ -151,7 +151,7 @@ void CalcEngineMgr::_sync()
     // Reubild PyEngine instances from database
     //
 
-    vector<string>  dataSetNames = _paramsMgr->GetDataMgrNames();
+    vector<string>  dataSetNames = _dataStatus->GetDataMgrNames();
     DatasetsParams *dParams = _paramsMgr->GetDatasetsParams();
     VAssert(dParams);
 

--- a/lib/render/Visualizer.cpp
+++ b/lib/render/Visualizer.cpp
@@ -88,7 +88,7 @@ int Visualizer::resizeGL(int wid, int ht) { return 0; }
 
 int Visualizer::_getCurrentTimestep() const
 {
-    vector<string> dataSetNames = _paramsMgr->GetDataMgrNames();
+    vector<string> dataSetNames = _dataStatus->GetDataMgrNames();
 
     bool   first = true;
     size_t min_ts = 0;
@@ -520,8 +520,8 @@ int Visualizer::_captureImage(std::string path)
     if (writer == nullptr) goto captureImageEnd;
 
     if (geoTiffOutput) {
-        VAssert(_paramsMgr->GetDataMgrNames().size());
-        string projString = _dataStatus->GetDataMgr(_paramsMgr->GetDataMgrNames()[0])->GetMapProjection();
+        VAssert(_dataStatus->GetDataMgrNames().size());
+        string projString = _dataStatus->GetDataMgr(_dataStatus->GetDataMgrNames()[0])->GetMapProjection();
 
         vector<double> dataMinExtents, dataMaxExtents;
         _dataStatus->GetActiveExtents(_paramsMgr, _winName, _getCurrentTimestep(), dataMinExtents, dataMaxExtents);


### PR DESCRIPTION
Fixed #2651 : Crash opening data set after a previous data set failed to open

There are two API calls for returning the list of datasets (DataMgrs) known
to the application: ParamsMgr::GetDataMgrNames() and
DataStatus::GetDataMgrNames(). The former returns the list of data sets
contained in the application state (aka session file). The latter returns
the list of all *open* data sets. In most cases the returned values are
identical. However, if a data set has not been opened (e.g. due to failure
opening the data set) the lists will be different. There were numerous cases
in the application where the lists were assumed to be identical. I.e. if
a data set was known to the application it was assumed to be opened (have
a DataMgr associated with it). This was not the case.

Longer term it might make sense to give these API entry points more
accurately descriptive names. 

Note: this PR has the potential for regressions; we may want to delay merger until after 3.4 when we do more thorough GUI testing.