### PR TITLE
Fixed #2661 - Flow: variable output not consistent

### DIFF
--- a/include/vapor/FlowRenderer.h
+++ b/include/vapor/FlowRenderer.h
@@ -59,7 +59,6 @@ private:
     // A few variables to keep the current advection states.
     // Some of them are initialized to be at an illegal state.
     int _cache_refinementLevel = 0;
-
     int _cache_compressionLevel = 0;
 
     float              _cache_velocityMltp = 1.0f;

--- a/include/vapor/FlowRenderer.h
+++ b/include/vapor/FlowRenderer.h
@@ -59,9 +59,9 @@ private:
     // A few variables to keep the current advection states.
     // Some of them are initialized to be at an illegal state.
     int _cache_refinementLevel = 0;
-    ;
+
     int _cache_compressionLevel = 0;
-    ;
+
     float              _cache_velocityMltp = 1.0f;
     bool               _cache_isSteady = false;
     long               _cache_steadyNumOfSteps = 0;

--- a/include/vapor/VaporField.h
+++ b/include/vapor/VaporField.h
@@ -76,7 +76,6 @@ public:
     // Functions for interaction with VAPOR components
     //
     void AssignDataManager(VAPoR::DataMgr *dmgr);
-    void UpdateParamAndVarNames(const VAPoR::FlowParams *p);
     void UpdateParams(const VAPoR::FlowParams *);
 
     //

--- a/lib/flow/VaporField.cpp
+++ b/lib/flow/VaporField.cpp
@@ -383,22 +383,6 @@ void VaporField::AssignDataManager(VAPoR::DataMgr *dmgr)
     for (size_t i = 0; i < timeCoords.size(); i++) _timestamps[i] = timeCoords[i];
 }
 
-void VaporField::UpdateParamAndVarNames(const VAPoR::FlowParams *p)
-{
-    _params = p;
-
-    // Update properties of this Field
-    IsSteady = p->GetIsSteady();
-    ScalarName = p->GetColorMapVariableName();
-    auto velNames = p->GetFieldVariableNames();
-    for (int i = 0; i < 3; i++) {
-        if (i < velNames.size())
-            VelocityNames[i] = velNames.at(i);
-        else
-            VelocityNames[i] = "";    // make sure it keeps an empty string,
-    }                                 // instead of whatever left from before.
-}
-
 void VaporField::UpdateParams(const VAPoR::FlowParams *p)
 {
     _params = p;

--- a/lib/render/FlowRenderer.cpp
+++ b/lib/render/FlowRenderer.cpp
@@ -182,12 +182,10 @@ int FlowRenderer::_paintGL(bool fast)
     _velocityField.UpdateParams(params);
     _velocityField.ScalarName.clear();
     auto vel_tmp = params->GetFieldVariableNames();
-    for( int i = 0; i < 3; i++ )
-        _velocityField.VelocityNames[i] = i < vel_tmp.size() ? vel_tmp[i] : "";
+    for (int i = 0; i < 3; i++) _velocityField.VelocityNames[i] = i < vel_tmp.size() ? vel_tmp[i] : "";
 
     _colorField.UpdateParams(params);
-    for( int i = 0; i < 3; i++ )
-        _colorField.VelocityNames[i].clear();
+    for (int i = 0; i < 3; i++) _colorField.VelocityNames[i].clear();
     _colorField.ScalarName = params->GetColorMapVariableName();
 
     // In case there's 0 variable selected, meaning that more than 2 of the velocity

--- a/lib/render/FlowRenderer.cpp
+++ b/lib/render/FlowRenderer.cpp
@@ -179,8 +179,16 @@ int FlowRenderer::_paintGL(bool fast)
 
     if (_velocityStatus != FlowStatus::UPTODATE || _colorStatus != FlowStatus::UPTODATE) _renderStatus = FlowStatus::SIMPLE_OUTOFDATE;
 
-    _velocityField.UpdateParamAndVarNames(params);
-    _colorField.UpdateParamAndVarNames(params);
+    _velocityField.UpdateParams(params);
+    _velocityField.ScalarName.clear();
+    auto vel_tmp = params->GetFieldVariableNames();
+    for( int i = 0; i < 3; i++ )
+        _velocityField.VelocityNames[i] = i < vel_tmp.size() ? vel_tmp[i] : "";
+
+    _colorField.UpdateParams(params);
+    for( int i = 0; i < 3; i++ )
+        _colorField.VelocityNames[i].clear();
+    _colorField.ScalarName = params->GetColorMapVariableName();
 
     // In case there's 0 variable selected, meaning that more than 2 of the velocity
     // variable names are empty strings, then the paint routine aborts.

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -937,7 +937,7 @@ Grid *DataMgr::GetVariable(size_t ts, string varname, int level, int lod, vector
         return (new RegularGrid());
     }
 
-    return (DataMgr::GetVariable(ts, varname, level, lod, min_ui, max_ui));
+    return (DataMgr::GetVariable(ts, varname, level, lod, min_ui, max_ui, lock));
 }
 
 Grid *DataMgr::_getVariable(size_t ts, string varname, int level, int lod, bool lock, bool dataless)


### PR DESCRIPTION
This PR fixes a problem with locks in the DataMgr. In some cases a request to DataMgr::GetVariable() with lock=true did not result in a locked variable. The issue associated with this PR, #2661, will now generate an error message with the default cache size of 8000 MBs. Changing the cache size to 12000 MBs (and perhaps smaller) will provide enough memory for the test case associated with the issue. 