### PR TITLE
Issue 2678 : The VAPOR cache size is unintuitive and should be made unlimited by default

### DIFF
--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -141,14 +141,14 @@ SettingsParams::~SettingsParams() {}
 
 long SettingsParams::GetCacheMB() const
 {
-    long val = GetValueLong(_cacheMBTag, 8000);
-    if (val < 0) val = 8000;
+    long val = GetValueLong(_cacheMBTag, 0);
+    if (val < 0) val = 0;
     return (val);
 }
 
 void SettingsParams::SetCacheMB(long val)
 {
-    if (val < 0) val = 8000;
+    if (val < 0) val = 0;
     SetValueLong(_cacheMBTag, "Set cache size", val);
 }
 
@@ -436,7 +436,7 @@ void SettingsParams::Init()
     SetAutoStretchEnabled(true);
     SetValueLong(UseAllCoresTag, "", true);
     SetNumThreads(4);
-    SetCacheMB(8000);
+    SetCacheMB(0);
 
     SetDefaultSessionDir(string("~"));
     SetDefaultMetadataDir(string("~"));

--- a/include/vapor/DataMgr.h
+++ b/include/vapor/DataMgr.h
@@ -119,7 +119,7 @@ public:
     //!
     //! \param[in] mem_size Size of memory cache to be created, specified
     //! in MEGABYTES!! If 0, not restriction is placed on the cache size; the DataMgr will
-    //! attempt to allocate as much memory is needed. 
+    //! attempt to allocate as much memory is needed.
     //!
     //! \param[in] numthreads Number of parallel execution threads
     //! to be run during encoding and decoding of compressed data. A value

--- a/include/vapor/DataMgr.h
+++ b/include/vapor/DataMgr.h
@@ -118,7 +118,8 @@ public:
     //! \param[in] format A string indicating the format of data collection.
     //!
     //! \param[in] mem_size Size of memory cache to be created, specified
-    //! in MEGABYTES!!
+    //! in MEGABYTES!! If 0, not restriction is placed on the cache size; the DataMgr will
+    //! attempt to allocate as much memory is needed. 
     //!
     //! \param[in] numthreads Number of parallel execution threads
     //! to be run during encoding and decoding of compressed data. A value

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -499,7 +499,7 @@ DataMgr::DataMgr(string format, size_t mem_size, int nthreads)
     _nthreads = nthreads;
     _mem_size = mem_size;
 
-    if (!_mem_size) _mem_size = 100;
+    if (!_mem_size) _mem_size = std::numeric_limits<size_t>::max() / 1048576;
 
     _dc = NULL;
 


### PR DESCRIPTION
Fixes #2678 