### PR TITLE
Issue2689

### DIFF
--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -9,7 +9,7 @@
 #include "VPushButton.h"
 #include "ErrorReporter.h"
 
-AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable()
+AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(), _params(nullptr)
 {
     _settings = new PGroup({
         new PSection("Automatic Session Recovery",
@@ -42,19 +42,26 @@ AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(
     layout()->addWidget(_settings);
 
     VPushButton *close = new VPushButton("Close");
-    connect(close, &VPushButton::ButtonClicked, this, &QDialog::accept);
+    connect(close, &VPushButton::ButtonClicked, this, &AppSettingsMenu::accept);
     layout()->addWidget(close);
 
     setFocusPolicy(Qt::ClickFocus);
 }
 
-void AppSettingsMenu::Update(VAPoR::ParamsBase *p, VAPoR::ParamsMgr *paramsMgr, VAPoR::DataMgr *dataMgr)
-{
-    SettingsParams *sp = dynamic_cast<SettingsParams *>(p);
-    _settings->Update(sp);
-    int rc = sp->SaveSettings();
+void AppSettingsMenu::accept() {
+    VAssert( _params != nullptr );
+    int rc = _params->SaveSettings();
     if (rc < 0) {
-        std::string settingsPath = sp->GetSettingsPath();
+        std::string settingsPath = _params->GetSettingsPath();
         MSG_ERR("Unable to write to settings file " + settingsPath);
     }
+    QDialog::accept();
+}
+
+void AppSettingsMenu::Update(VAPoR::ParamsBase *p, VAPoR::ParamsMgr *paramsMgr, VAPoR::DataMgr *dataMgr)
+{
+    _params = dynamic_cast<SettingsParams *>(p);
+    VAssert( _params != nullptr );
+
+    _settings->Update(_params);
 }

--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -48,6 +48,14 @@ AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(
     setFocusPolicy(Qt::ClickFocus);
 }
 
+// Handle the pressing of the escape key 
+// Since settings are applied when changed in the gui, 
+// we still want to save the settings file, even if esc is pressed
+void AppSettingsMenu::reject()
+{
+    accept();
+}
+
 void AppSettingsMenu::accept()
 {
     VAssert(_params != nullptr);

--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -48,13 +48,10 @@ AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(
     setFocusPolicy(Qt::ClickFocus);
 }
 
-// Handle the pressing of the escape key 
-// Since settings are applied when changed in the gui, 
+// Handle the pressing of the escape key
+// Since settings are applied when changed in the gui,
 // we still want to save the settings file, even if esc is pressed
-void AppSettingsMenu::reject()
-{
-    accept();
-}
+void AppSettingsMenu::reject() { accept(); }
 
 void AppSettingsMenu::accept()
 {

--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -48,8 +48,9 @@ AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(
     setFocusPolicy(Qt::ClickFocus);
 }
 
-void AppSettingsMenu::accept() {
-    VAssert( _params != nullptr );
+void AppSettingsMenu::accept()
+{
+    VAssert(_params != nullptr);
     int rc = _params->SaveSettings();
     if (rc < 0) {
         std::string settingsPath = _params->GetSettingsPath();
@@ -61,7 +62,7 @@ void AppSettingsMenu::accept() {
 void AppSettingsMenu::Update(VAPoR::ParamsBase *p, VAPoR::ParamsMgr *paramsMgr, VAPoR::DataMgr *dataMgr)
 {
     _params = dynamic_cast<SettingsParams *>(p);
-    VAssert( _params != nullptr );
+    VAssert(_params != nullptr);
 
     _settings->Update(_params);
 }

--- a/apps/vaporgui/AppSettingsMenu.h
+++ b/apps/vaporgui/AppSettingsMenu.h
@@ -10,6 +10,7 @@ class QWidget;
 class SettingsParams;
 class PGroup;
 class PSection;
+class SettingsParams;
 
 //! \class Preferences Menu
 //! \ingroup Public_GUI
@@ -21,8 +22,11 @@ class AppSettingsMenu : public QDialog, public Updateable {
 
 public:
     AppSettingsMenu(QWidget *parent);
-    virtual void Update(VAPoR::ParamsBase *p, VAPoR::ParamsMgr *paramsMgr = nullptr, VAPoR::DataMgr *dataMgr = nullptr);
+    virtual void Update(VAPoR::ParamsBase *p, VAPoR::ParamsMgr *paramsMgr = nullptr, VAPoR::DataMgr *dataMgr = nullptr) override;
 
 private:
+    void accept() override;
+
     PGroup *_settings;
+    SettingsParams* _params;
 };

--- a/apps/vaporgui/AppSettingsMenu.h
+++ b/apps/vaporgui/AppSettingsMenu.h
@@ -28,5 +28,5 @@ private:
     void accept() override;
 
     PGroup *_settings;
-    SettingsParams* _params;
+    SettingsParams *_params;
 };

--- a/apps/vaporgui/AppSettingsMenu.h
+++ b/apps/vaporgui/AppSettingsMenu.h
@@ -26,6 +26,7 @@ public:
 
 private:
     void accept() override;
+    void reject() override;
 
     PGroup *_settings;
     SettingsParams *_params;


### PR DESCRIPTION
Fixes #2689 

This moves the logic for saving the settings file from Update() into the overridden QDialog::accept() function.  The only drawback is that the AppSettingsMenu must hold onto a SettingsParams pointer to execute the file save, but I think this is benign.