### PR TITLE
Issue 2694 DataMgrUtils::GetGrid needs refactoring to avoid oversubscribed cache

### DIFF
--- a/include/vapor/DataMgr.h
+++ b/include/vapor/DataMgr.h
@@ -683,8 +683,8 @@ private:
 
     std::map<string, BlkExts> _blkExtsCache;
 
-    std::map <const Grid *, vector <float *> > _lockedFloatBlks;
-    std::map <const Grid *, vector <int *> > _lockedIntBlks;
+    std::map<const Grid *, vector<float *>> _lockedFloatBlks;
+    std::map<const Grid *, vector<int *>>   _lockedIntBlks;
 
     // Get the immediate variable dependencies of a variable
     //

--- a/include/vapor/DataMgr.h
+++ b/include/vapor/DataMgr.h
@@ -683,6 +683,9 @@ private:
 
     std::map<string, BlkExts> _blkExtsCache;
 
+    std::map <const Grid *, vector <float *> > _lockedFloatBlks;
+    std::map <const Grid *, vector <int *> > _lockedIntBlks;
+
     // Get the immediate variable dependencies of a variable
     //
     std::vector<string> _get_var_dependencies_1(string varname) const;

--- a/include/vapor/DataMgrUtils.h
+++ b/include/vapor/DataMgrUtils.h
@@ -121,13 +121,14 @@ VDF_API int ConvertLonLatToPCS(string projString, double coords[], int npoints =
 //
 template<typename T>
 VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, const vector<T> &minExtsReq, const vector<T> &maxExtsReq, bool useLowerAccuracy, int *refLevel, int *lod,
-                     std::vector<Grid *> &grids, bool lock=false);
+                     std::vector<Grid *> &grids, bool lock = false);
 
-VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, string varname, const vector<double> &minExtsReq, const vector<double> &maxExtsReq, bool useLowerAccuracy, int *refLevel, int *lod, Grid **gridptr, bool lock=false);
+VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, string varname, const vector<double> &minExtsReq, const vector<double> &maxExtsReq, bool useLowerAccuracy, int *refLevel, int *lod, Grid **gridptr,
+                     bool lock = false);
 
-VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, bool useLowerAccuracy, int *refLevel, int *lod, std::vector<Grid *> &grids, bool lock=false);
+VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, bool useLowerAccuracy, int *refLevel, int *lod, std::vector<Grid *> &grids, bool lock = false);
 
-VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, string varname, bool useLowerAccuracy, int *refLevel, int *lod, Grid **gridptr, bool lock=false);
+VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, string varname, bool useLowerAccuracy, int *refLevel, int *lod, Grid **gridptr, bool lock = false);
 
 VDF_API void UnlockGrids(DataMgr *dataMgr, const std::vector<Grid *> &grids);
 

--- a/include/vapor/DataMgrUtils.h
+++ b/include/vapor/DataMgrUtils.h
@@ -115,16 +115,19 @@ VDF_API int ConvertLonLatToPCS(string projString, double coords[], int npoints =
 //! a lower lod is available.
 //! \param[out] grid is a vector of Grid* pointers, one
 //! for each variable
+//! \param[in] lock : if false, the default, UnlockGrids() will be called on each of the grids
+//! after they are all successfully allocated. Otherwise, the the grids will be locked in
+//! memory until released by an explicit call to UnlockGrids()
 //
 template<typename T>
 VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, const vector<T> &minExtsReq, const vector<T> &maxExtsReq, bool useLowerAccuracy, int *refLevel, int *lod,
-                     std::vector<Grid *> &grids);
+                     std::vector<Grid *> &grids, bool lock=false);
 
-VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, string varname, const vector<double> &minExtsReq, const vector<double> &maxExtsReq, bool useLowerAccuracy, int *refLevel, int *lod, Grid **gridptr);
+VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, string varname, const vector<double> &minExtsReq, const vector<double> &maxExtsReq, bool useLowerAccuracy, int *refLevel, int *lod, Grid **gridptr, bool lock=false);
 
-VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, bool useLowerAccuracy, int *refLevel, int *lod, std::vector<Grid *> &grids);
+VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, bool useLowerAccuracy, int *refLevel, int *lod, std::vector<Grid *> &grids, bool lock=false);
 
-VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, string varname, bool useLowerAccuracy, int *refLevel, int *lod, Grid **gridptr);
+VDF_API int GetGrids(DataMgr *dataMgr, size_t ts, string varname, bool useLowerAccuracy, int *refLevel, int *lod, Grid **gridptr, bool lock=false);
 
 VDF_API void UnlockGrids(DataMgr *dataMgr, const std::vector<Grid *> &grids);
 

--- a/lib/render/BarbRenderer.cpp
+++ b/lib/render/BarbRenderer.cpp
@@ -190,9 +190,6 @@ int BarbRenderer::_getVarGrid(int ts, int refLevel, int lod, string varName, std
     if (!varName.empty()) {
         int rc = DataMgrUtils::GetGrids(_dataMgr, ts, varName, minExts, maxExts, true, &refLevel, &lod, &sg);
         if (rc < 0) {
-            for (int i = 0; i < varData.size(); i++) {
-                if (varData[i]) _dataMgr->UnlockGrid(varData[i]);
-            }
             return (rc);
         }
         varData[varData.size() - 1] = sg;
@@ -266,11 +263,6 @@ int BarbRenderer::_generateBarbs()
     _barbCache.clear();
     // Render the barbs
     _operateOnGrid(varData);
-
-    // Release the locks on the data
-    for (int i = 0; i < varData.size(); i++) {
-        if (varData[i]) _dataMgr->UnlockGrid(varData[i]);
-    }
 
     return (rc);
 }

--- a/lib/render/HelloRenderer.cpp
+++ b/lib/render/HelloRenderer.cpp
@@ -120,8 +120,6 @@ int HelloRenderer::_paintGL(bool)
         }
     }
 
-    _dataMgr->UnlockGrid(helloGrid);
-
     // Obtain the line width
     float width = (float)rParams->GetLineThickness();
 

--- a/lib/render/ImageRenderer.cpp
+++ b/lib/render/ImageRenderer.cpp
@@ -498,7 +498,6 @@ int ImageRenderer::_getMeshDisplaced(DataMgr *dataMgr, GLsizei width, GLsizei he
     }
 
     if (hgtGrid) {
-        dataMgr->UnlockGrid(hgtGrid);
         delete hgtGrid;
     }
 

--- a/lib/render/PyEngine.cpp
+++ b/lib/render/PyEngine.cpp
@@ -640,7 +640,6 @@ int PyEngine::DerivedPythonVar::_readRegionAll(int fd, const std::vector<size_t>
     rc = alloc_arrays(inputVarDims, outputVarDims, inputVarArrays, outputVarArrays);
     if (rc < 0) {
         SetErrMsg("Error allocating  memory");
-        DataMgrUtils::UnlockGrids(_dataMgr, variables);
         return (-1);
     }
 
@@ -660,14 +659,12 @@ int PyEngine::DerivedPythonVar::_readRegionAll(int fd, const std::vector<size_t>
     _stdoutString = MyPython::Instance()->PyOut().c_str();
 
     if (rc < 0) {
-        DataMgrUtils::UnlockGrids(_dataMgr, variables);
         free_arrays(inputVarArrays, outputVarArrays);
         return (-1);
     }
 
     copy_region(outputVarArrays[0], region, min, max, outputVarDims[0]);
 
-    DataMgrUtils::UnlockGrids(_dataMgr, variables);
     free_arrays(inputVarArrays, outputVarArrays);
 
     return (0);
@@ -719,7 +716,6 @@ int PyEngine::DerivedPythonVar::_readRegionSubset(int fd, const std::vector<size
     rc = alloc_arrays(inputVarDims, outputVarDims, inputVarArrays, outputVarArrays);
     if (rc < 0) {
         SetErrMsg("Error allocating  memory");
-        DataMgrUtils::UnlockGrids(_dataMgr, variables);
         return (-1);
     }
 
@@ -739,7 +735,6 @@ int PyEngine::DerivedPythonVar::_readRegionSubset(int fd, const std::vector<size
     _stdoutString = MyPython::Instance()->PyOut().c_str();
 
     if (rc < 0) {
-        DataMgrUtils::UnlockGrids(_dataMgr, variables);
         free_arrays(inputVarArrays, outputVarArrays);
         return (-1);
     }
@@ -755,7 +750,6 @@ int PyEngine::DerivedPythonVar::_readRegionSubset(int fd, const std::vector<size
     }
     copy_region(outputVarArrays[0], region, min_roi, max_roi, outputVarDims[0]);
 
-    DataMgrUtils::UnlockGrids(_dataMgr, variables);
     free_arrays(inputVarArrays, outputVarArrays);
 
     return (0);

--- a/lib/render/TwoDDataRenderer.cpp
+++ b/lib/render/TwoDDataRenderer.cpp
@@ -283,7 +283,6 @@ int TwoDDataRenderer::GetMesh(DataMgr *dataMgr, GLfloat **verts, GLfloat **norma
         structuredMesh = false;
     }
 
-    dataMgr->UnlockGrid(g);
     delete g;
 
     if (rc < 0) return (-1);
@@ -541,7 +540,6 @@ int TwoDDataRenderer::_getMeshUnStructuredHelper(DataMgr *dataMgr, const Grid *g
     }
 
     if (hgtGrid) {
-        dataMgr->UnlockGrid(hgtGrid);
         delete hgtGrid;
     }
 
@@ -604,7 +602,6 @@ int TwoDDataRenderer::_getMeshStructuredDisplaced(DataMgr *dataMgr, const Struct
         }
     }
 
-    dataMgr->UnlockGrid(hgtGrid);
     delete hgtGrid;
 
     return (rc);
@@ -729,10 +726,6 @@ const GLvoid *TwoDDataRenderer::_getTexture(DataMgr *dataMgr)
     }
 
     _texStateSet(dataMgr);
-
-    // Unlock the Grid
-    //
-    dataMgr->UnlockGrid(g);
 
     return (texture);
 }

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -1289,11 +1289,10 @@ Grid *DataMgr::_getVariable(size_t ts, string varname, int level, int lod, vecto
         for (int i = 0; i < conn_blkvec.size(); i++) {
             if (conn_blkvec[i]) _unlock_blocks(conn_blkvec[i]);
         }
+    } else {
+        if (blkvec.size()) _lockedFloatBlks[rg] = blkvec;
+        if (conn_blkvec.size()) _lockedIntBlks[rg] = conn_blkvec;
     }
-	else {
-		if (blkvec.size()) _lockedFloatBlks[rg] = blkvec;
-		if (conn_blkvec.size()) _lockedIntBlks[rg] = conn_blkvec;
-	}
 
     return (rg);
 }
@@ -1663,19 +1662,15 @@ void DataMgr::UnlockGrid(const Grid *rg)
     const auto fb = _lockedFloatBlks.find(rg);
     if (fb != _lockedFloatBlks.end()) {
         auto &bvec = fb->second;
-        for (auto b : bvec) {
-            _unlock_blocks(b);
-        }
-		_lockedFloatBlks.erase(fb);
+        for (auto b : bvec) { _unlock_blocks(b); }
+        _lockedFloatBlks.erase(fb);
     }
 
     const auto ib = _lockedIntBlks.find(rg);
     if (ib != _lockedIntBlks.end()) {
         auto &bvec = ib->second;
-        for (auto b : bvec) {
-            _unlock_blocks(b);
-        }
-		_lockedIntBlks.erase(ib);
+        for (auto b : bvec) { _unlock_blocks(b); }
+        _lockedIntBlks.erase(ib);
     }
 }
 

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -1290,6 +1290,10 @@ Grid *DataMgr::_getVariable(size_t ts, string varname, int level, int lod, vecto
             if (conn_blkvec[i]) _unlock_blocks(conn_blkvec[i]);
         }
     }
+	else {
+		if (blkvec.size()) _lockedFloatBlks[rg] = blkvec;
+		if (conn_blkvec.size()) _lockedIntBlks[rg] = conn_blkvec;
+	}
 
     return (rg);
 }
@@ -1655,13 +1659,23 @@ void DataMgr::Clear()
 void DataMgr::UnlockGrid(const Grid *rg)
 {
     SetDiagMsg("DataMgr::UnlockGrid()");
-    const vector<float *> &blks = rg->GetBlks();
-    if (blks.size()) _unlock_blocks(blks[0]);
 
-    const LayeredGrid *lg = dynamic_cast<const LayeredGrid *>(rg);
-    if (lg) {
-        const Grid &rg = lg->GetZRG();
-        if (rg.GetBlks().size()) _unlock_blocks(rg.GetBlks()[0]);
+    const auto fb = _lockedFloatBlks.find(rg);
+    if (fb != _lockedFloatBlks.end()) {
+        auto &bvec = fb->second;
+        for (auto b : bvec) {
+            _unlock_blocks(b);
+        }
+		_lockedFloatBlks.erase(fb);
+    }
+
+    const auto ib = _lockedIntBlks.find(rg);
+    if (ib != _lockedIntBlks.end()) {
+        auto &bvec = ib->second;
+        for (auto b : bvec) {
+            _unlock_blocks(b);
+        }
+		_lockedIntBlks.erase(ib);
     }
 }
 

--- a/lib/vdc/DataMgrUtils.cpp
+++ b/lib/vdc/DataMgrUtils.cpp
@@ -108,7 +108,7 @@ int DataMgrUtils::ConvertLonLatToPCS(string projString, double coords[2], int np
 
 template<typename T>
 int DataMgrUtils::GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, const vector<T> &minExtsReq, const vector<T> &maxExtsReq, bool useLowerAccuracy, int *refLevel, int *lod,
-                           vector<Grid *> &grids)
+                           vector<Grid *> &grids, bool lock)
 {
     grids.clear();
     VAssert(minExtsReq.size() == maxExtsReq.size());
@@ -169,18 +169,24 @@ int DataMgrUtils::GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &va
         grids[i] = rGrid;
     }
 
+    if (! lock) {
+        for (auto g : grids) {
+			if (g) dataMgr->UnlockGrid(g);
+        }
+    }
+
     // obtained all of the grids needed
     return 0;
 }
 
 template VDF_API int DataMgrUtils::GetGrids<size_t>(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, const vector<size_t> &minExtsReq, const vector<size_t> &maxExtsReq,
-                                                    bool useLowerAccuracy, int *refLevel, int *lod, vector<Grid *> &grids);
+                                                    bool useLowerAccuracy, int *refLevel, int *lod, vector<Grid *> &grids, bool lock);
 
 template VDF_API int DataMgrUtils::GetGrids<double>(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, const vector<double> &minExtsReq, const vector<double> &maxExtsReq,
-                                                    bool useLowerAccuracy, int *refLevel, int *lod, vector<Grid *> &grids);
+                                                    bool useLowerAccuracy, int *refLevel, int *lod, vector<Grid *> &grids, bool lock);
 
 int DataMgrUtils::GetGrids(DataMgr *dataMgr, size_t ts, string varname, const vector<double> &minExtsReq, const vector<double> &maxExtsReq, bool useLowerAccuracy, int *refLevel, int *lod,
-                           Grid **gridptr)
+                           Grid **gridptr, bool lock)
 {
     *gridptr = NULL;
 
@@ -192,14 +198,14 @@ int DataMgrUtils::GetGrids(DataMgr *dataMgr, size_t ts, string varname, const ve
     vector<string> varnames;
     varnames.push_back(varname);
     vector<Grid *> grids;
-    int            rc = GetGrids(dataMgr, ts, varnames, minExtsReq, maxExtsReq, useLowerAccuracy, refLevel, lod, grids);
+    int            rc = GetGrids(dataMgr, ts, varnames, minExtsReq, maxExtsReq, useLowerAccuracy, refLevel, lod, grids, lock);
     if (rc < 0) return (rc);
 
     *gridptr = grids[0];
     return (0);
 }
 
-int DataMgrUtils::GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, bool useLowerAccuracy, int *refLevel, int *lod, vector<Grid *> &grids)
+int DataMgrUtils::GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &varnames, bool useLowerAccuracy, int *refLevel, int *lod, vector<Grid *> &grids, bool lock)
 {
     grids.clear();
 
@@ -208,17 +214,17 @@ int DataMgrUtils::GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &va
 
     for (int i = 0; i < 3; i++) { maxExtsReq.push_back(std::numeric_limits<double>::max()); }
 
-    return (DataMgrUtils::GetGrids(dataMgr, ts, varnames, minExtsReq, maxExtsReq, useLowerAccuracy, refLevel, lod, grids));
+    return (DataMgrUtils::GetGrids(dataMgr, ts, varnames, minExtsReq, maxExtsReq, useLowerAccuracy, refLevel, lod, grids, lock));
 }
 
-int DataMgrUtils::GetGrids(DataMgr *dataMgr, size_t ts, string varname, bool useLowerAccuracy, int *refLevel, int *lod, Grid **gridptr)
+int DataMgrUtils::GetGrids(DataMgr *dataMgr, size_t ts, string varname, bool useLowerAccuracy, int *refLevel, int *lod, Grid **gridptr, bool lock)
 {
     *gridptr = NULL;
 
     vector<string> varnames;
     varnames.push_back(varname);
     vector<Grid *> grids;
-    int            rc = GetGrids(dataMgr, ts, varnames, useLowerAccuracy, refLevel, lod, grids);
+    int            rc = GetGrids(dataMgr, ts, varnames, useLowerAccuracy, refLevel, lod, grids, lock);
     if (rc < 0) return (rc);
 
     *gridptr = grids[0];

--- a/lib/vdc/DataMgrUtils.cpp
+++ b/lib/vdc/DataMgrUtils.cpp
@@ -169,9 +169,9 @@ int DataMgrUtils::GetGrids(DataMgr *dataMgr, size_t ts, const vector<string> &va
         grids[i] = rGrid;
     }
 
-    if (! lock) {
+    if (!lock) {
         for (auto g : grids) {
-			if (g) dataMgr->UnlockGrid(g);
+            if (g) dataMgr->UnlockGrid(g);
         }
     }
 


### PR DESCRIPTION
Fixes #2694 

This PR does the following:

1. A "lock" flag has been added (and documented) to the  DataMgrUtils::GetGrids(), making it consistent with the DataMgr::GetVariable method. A default value of False is set. I.e. Grid(s) returned by GetGrids are unlocked by default. N.B. if multiple Grids are fetched by GetGrids() they are locked internally to ensure all the requested Grids can be returned. If the lock flag is not set, the Grids are unlocked prior to returning from GetGrids().
2. Removes the now superfluous explicit calls to DataMgrUtils::UnlockGrids() that were found throughout the application. 
3. Addresses an unreported memory leak in the DataMgr::UnlockGrid() that resulted in some of the data held by a Grid not being freed.