### PR TITLE
Fix #2681 Vapor prefs being overridden

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1100,6 +1100,8 @@ void MainForm::sessionOpenHelper(string fileName, bool loadDatasets)
     } else {
         _controlExec->LoadState();
     }
+    
+    GetSettingsParams()->LoadFromSettingsFile();
 
     // Ugh. Load state will of course set open data sets in database
     //

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1100,7 +1100,7 @@ void MainForm::sessionOpenHelper(string fileName, bool loadDatasets)
     } else {
         _controlExec->LoadState();
     }
-    
+
     GetSettingsParams()->LoadFromSettingsFile();
 
     // Ugh. Load state will of course set open data sets in database

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -88,7 +88,7 @@ SettingsParams::SettingsParams(ParamsBase::StateSave *ssave, bool loadFromFile) 
     // Try to get settings params from .settings file
     //
     if (loadFromFile) {
-        bool ok = _loadFromSettingsFile();
+        bool ok = LoadFromSettingsFile() >= 0;
         if (ok) return;
     }
 
@@ -109,7 +109,7 @@ SettingsParams::SettingsParams(ParamsBase::StateSave *ssave, XmlNode *node) : Pa
 
         // Try to get settings params from .settings file
         //
-        bool ok = _loadFromSettingsFile();
+        bool ok = LoadFromSettingsFile() >= 0;
         if (ok)
             return;
         else
@@ -402,7 +402,7 @@ void SettingsParams::SetFidelityDefault2D(long lodDef, long refDef)
     SetValueLongVec(_fidelityDefault2DTag, "Set fidelity 2D default", val);
 }
 
-bool SettingsParams::_loadFromSettingsFile()
+int SettingsParams::LoadFromSettingsFile()
 {
     XmlNode *node = GetNode();
     VAssert(node != NULL);
@@ -416,7 +416,7 @@ bool SettingsParams::_loadFromSettingsFile()
 
     MyBase::EnableErrMsg(enabled);
 
-    return (status);
+    return status ? 0 : -1;
 }
 
 int SettingsParams::SaveSettings() const

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -88,7 +88,7 @@ SettingsParams::SettingsParams(ParamsBase::StateSave *ssave, bool loadFromFile) 
     // Try to get settings params from .settings file
     //
     if (loadFromFile) {
-        bool ok = LoadFromSettingsFile() >= 0;
+        bool ok = LoadFromSettingsFile();
         if (ok) return;
     }
 
@@ -109,7 +109,7 @@ SettingsParams::SettingsParams(ParamsBase::StateSave *ssave, XmlNode *node) : Pa
 
         // Try to get settings params from .settings file
         //
-        bool ok = LoadFromSettingsFile() >= 0;
+        bool ok = LoadFromSettingsFile();
         if (ok)
             return;
         else
@@ -402,7 +402,7 @@ void SettingsParams::SetFidelityDefault2D(long lodDef, long refDef)
     SetValueLongVec(_fidelityDefault2DTag, "Set fidelity 2D default", val);
 }
 
-int SettingsParams::LoadFromSettingsFile()
+bool SettingsParams::LoadFromSettingsFile()
 {
     XmlNode *node = GetNode();
     VAssert(node != NULL);
@@ -416,7 +416,7 @@ int SettingsParams::LoadFromSettingsFile()
 
     MyBase::EnableErrMsg(enabled);
 
-    return status ? 0 : -1;
+    return status;
 }
 
 int SettingsParams::SaveSettings() const

--- a/apps/vaporgui/SettingsParams.h
+++ b/apps/vaporgui/SettingsParams.h
@@ -129,7 +129,7 @@ public:
 
     static const string UseAllCoresTag;
 
-    int LoadFromSettingsFile();
+    bool LoadFromSettingsFile();
 
 private:
     static const string _classType;

--- a/apps/vaporgui/SettingsParams.h
+++ b/apps/vaporgui/SettingsParams.h
@@ -128,7 +128,7 @@ public:
     std::string GetSettingsPath() const;
 
     static const string UseAllCoresTag;
-    
+
     int LoadFromSettingsFile();
 
 private:

--- a/apps/vaporgui/SettingsParams.h
+++ b/apps/vaporgui/SettingsParams.h
@@ -128,6 +128,8 @@ public:
     std::string GetSettingsPath() const;
 
     static const string UseAllCoresTag;
+    
+    int LoadFromSettingsFile();
 
 private:
     static const string _classType;
@@ -159,7 +161,6 @@ private:
     static const string _dontShowIntelDriverWarningTag;
     static const string _settingsNeedsWriteTag;
 
-    bool _loadFromSettingsFile();
     void _swapTildeWithHome(std::string &file) const;
 
     string _settingsPath;


### PR DESCRIPTION
Fix #2681

The constructors are "no-fail" since if the settings file cannot be read, it just initializes with the default settings.