### PR TITLE
Fix Annotation and Transform tables in the Scene tab

### DIFF
--- a/apps/vaporgui/AnnotationEventRouter.cpp
+++ b/apps/vaporgui/AnnotationEventRouter.cpp
@@ -117,7 +117,7 @@ void AnnotationEventRouter::connectAnnotationWidgets()
     connect(_ticWidthCombo, SIGNAL(valueChanged(double)), this, SLOT(setAxisTicWidth(double)));
     connect(axisColorButton, SIGNAL(pressed()), this, SLOT(setAxisColor()));
     connect(axisBackgroundColorButton, SIGNAL(pressed()), this, SLOT(setAxisBackgroundColor()));
-    connect(_annotationVaporTable, SIGNAL(returnPressed()), this, SLOT(axisAnnotationTableChanged()));
+    connect(_annotationVaporTable, SIGNAL(valueChanged(int, int)), this, SLOT(axisAnnotationTableChanged()));
     connect(xTicOrientationCombo, SIGNAL(activated(int)), this, SLOT(setXTicOrientation(int)));
     connect(yTicOrientationCombo, SIGNAL(activated(int)), this, SLOT(setYTicOrientation(int)));
     connect(zTicOrientationCombo, SIGNAL(activated(int)), this, SLOT(setZTicOrientation(int)));

--- a/apps/vaporgui/VaporTable.h
+++ b/apps/vaporgui/VaporTable.h
@@ -83,11 +83,10 @@ public:
 
 public slots:
     void emitCellClicked(int, int);
-    void emitValueChanged();
+    void emitValueChanged(int row = 0, int col = 0);
     void emitReturnPressed();
 
 signals:
-
     void valueChanged(int row, int col);
     void cellClicked(int row, int col);
     void returnPressed();


### PR DESCRIPTION
This fixes #2705, which reports that the AnnotationTable and TransformTable in the Scene tab would not honor user input.

Prior to 3.4.0, each cell in a VaporTable contained a QWidget, typically a QLineEdit or QCheckBox.  The recent fix for #1359 involved replacing QLineEdits with QTableWidgetItems to improve resizing of the RenderHolder (the table that lists renderer instances) and to simplify the class.

Previously, the QLineEdits in table cells would emit signals when their values changed.  Now that they have been removed, we need something to replace their signal emission.  This PR emits the signal when the a table's QTableWidget::cellChanged fires.  See VaporTable.cpp:48

Note - this branch is based off of 987b575, where we bumped Vapor's version number to 3.4.1.  It is not derived from the head of our main branch.  This was done in case we want to apply this fix as a patch that only fixes this bug, and nothing else.

This has been tested on all platforms, documented in [this spreadsheet](https://docs.google.com/spreadsheets/d/1MEwLRPQXk-KUqlvQ9x4yjv6IfYj4zch_CFs3Us3ACPc/edit?usp=sharing).