### PR TITLE
Issue 2635: Redirect clang-format

### DIFF
--- a/share/gitHooks/pre-push
+++ b/share/gitHooks/pre-push
@@ -12,7 +12,8 @@ if [ "$BRANCH" = "readTheDocs" ]; then
 #
 else
     for COMMIT in $(git log --pretty=format:%h main...$BRANCH); do
-        for FILE in $(git diff --name-only origin/main |grep -E "\.h|\.cpp"); do
+        echo "Reading Commit: $COMMIT"
+        for FILE in $(git diff-tree --no-commit-id --name-only -r $COMMIT |grep -E "\.h|\.cpp"); do
             NUMBERS=""
             for NUMBER in $(git blame --line-porcelain "$FILE" | egrep ^$COMMIT | cut -d' ' -f3); do
                 NUMBERS="$NUMBERS --lines $NUMBER:$NUMBER "


### PR DESCRIPTION
Redirect clang-format to target files changed in all commits before push, instead of all differing files between the current branch and main.

Fixes #2635 