### PR TITLE
Issue 2635: Redirect clang-format

### DIFF
--- a/include/vapor/FlowRenderer.h
+++ b/include/vapor/FlowRenderer.h
@@ -20,6 +20,7 @@ class RENDER_API FlowRenderer final : public Renderer {
 public:
     FlowRenderer(const ParamsMgr *pm, std::string &winName, std::string &dataSetName, std::string &instName, DataMgr *dataMgr);
 
+    // Rule of five
     ~FlowRenderer();
     FlowRenderer(const FlowRenderer &) = delete;
     FlowRenderer(const FlowRenderer &&) = delete;

--- a/include/vapor/FlowRenderer.h
+++ b/include/vapor/FlowRenderer.h
@@ -20,7 +20,6 @@ class RENDER_API FlowRenderer final : public Renderer {
 public:
     FlowRenderer(const ParamsMgr *pm, std::string &winName, std::string &dataSetName, std::string &instName, DataMgr *dataMgr);
 
-    // Rule of five
     ~FlowRenderer();
     FlowRenderer(const FlowRenderer &) = delete;
     FlowRenderer(const FlowRenderer &&) = delete;

--- a/share/gitHooks/pre-push
+++ b/share/gitHooks/pre-push
@@ -12,7 +12,8 @@ if [ "$BRANCH" = "readTheDocs" ]; then
 #
 else
     for COMMIT in $(git log --pretty=format:%h main...$BRANCH); do
-        for FILE in $(git diff --name-only origin/main |grep -E "\.h|\.cpp"); do
+        echo "Reading Commit: $COMMIT"
+        for FILE in $(git diff-tree --no-commit-id --name-only -r $COMMIT |grep -E "\.h|\.cpp"); do
             NUMBERS=""
             for NUMBER in $(git blame --line-porcelain "$FILE" | egrep ^$COMMIT | cut -d' ' -f3); do
                 NUMBERS="$NUMBERS --lines $NUMBER:$NUMBER "

--- a/share/gitHooks/pre-push
+++ b/share/gitHooks/pre-push
@@ -3,6 +3,15 @@
 
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 
+# If our current branch does not exist in the remote repository yet, then compare
+# our local changes with main.  Otherwise, compare our local changes with the remote
+# branch.
+if [ `git ls-remote --heads https://github.com/NCAR/VAPOR.git $BRANCH | wc -l` = 0 ]; then
+    COMPARE_BRANCH="main"
+else
+    COMPARE_BRANCH=$BRANCH
+fi
+
 # If we're on the readTheDocs branch, skip clang-format
 #
 if [ "$BRANCH" = "readTheDocs" ]; then
@@ -11,7 +20,7 @@ if [ "$BRANCH" = "readTheDocs" ]; then
 # Otherwise format the changed lines in all commits up to this push
 #
 else
-    for COMMIT in $(git log --pretty=format:%h origin/$BRANCH...$BRANCH); do
+    for COMMIT in $(git log --pretty=format:%h origin/$COMPARE_BRANCH...$BRANCH); do
         echo "Reading Commit: $COMMIT"
         for FILE in $(git diff-tree --no-commit-id --name-only -r $COMMIT |grep -E "\.h|\.cpp"); do
             NUMBERS=""

--- a/share/gitHooks/pre-push
+++ b/share/gitHooks/pre-push
@@ -11,7 +11,7 @@ if [ "$BRANCH" = "readTheDocs" ]; then
 # Otherwise format the changed lines in all commits up to this push
 #
 else
-    for COMMIT in $(git log --pretty=format:%h main...$BRANCH); do
+    for COMMIT in $(git log --pretty=format:%h origin/$BRANCH...$BRANCH); do
         echo "Reading Commit: $COMMIT"
         for FILE in $(git diff-tree --no-commit-id --name-only -r $COMMIT |grep -E "\.h|\.cpp"); do
             NUMBERS=""


### PR DESCRIPTION
Redirect clang-format's pre-push hook to scan through commits (and their changed files) that do not exist on the remote branch.

If the current local branch does not exist on the remote repository (ie this is the first time we're pushing) then the hook scans through local commits that do not exist on the main branch.

Fixes #2635