### PR TITLE
Update checker

### DIFF
--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -24,6 +24,10 @@ class PUpdateChecker : public PWidget {
     }
     void checkForUpdate()
     {
+        _label->setText("Checking...");
+        _checkButton->setHidden(true);
+        _label->setVisible(true);
+        
         CheckForUpdate([=](bool updateAvailable, UpdateInfo info) {
             if (updateAvailable) {
                 DisplayUpdateAvailable(info);

--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -27,7 +27,7 @@ class PUpdateChecker : public PWidget {
         _label->setText("Checking...");
         _checkButton->setHidden(true);
         _label->setVisible(true);
-        
+
         CheckForUpdate([=](bool updateAvailable, UpdateInfo info) {
             if (updateAvailable) {
                 DisplayUpdateAvailable(info);

--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -10,19 +10,17 @@
 #include "ErrorReporter.h"
 #include "CheckForUpdate.h"
 
-class PUpdateChecker : public PWidget
-{
-    VGroup *_group;
-    QLabel *_label;
+class PUpdateChecker : public PWidget {
+    VGroup *     _group;
+    QLabel *     _label;
     VPushButton *_checkButton;
     VPushButton *_getButton;
-    UpdateInfo _updateInfo;
-    
+    UpdateInfo   _updateInfo;
+
     void updateGUI() const override {}
     void openURL()
     {
-        if (!_updateInfo.url.empty())
-            _updateInfo.OpenURL();
+        if (!_updateInfo.url.empty()) _updateInfo.OpenURL();
     }
     void checkForUpdate()
     {
@@ -37,29 +35,28 @@ class PUpdateChecker : public PWidget
             }
         });
     }
-    
+
 public:
-    PUpdateChecker()
-    : PWidget("", _group = new VGroup)
+    PUpdateChecker() : PWidget("", _group = new VGroup)
     {
         _checkButton = new VPushButton("Check for update");
         _group->Add(_checkButton);
-        
+
         _label = new QLabel;
         _label->setHidden(true);
         _group->Add(_label);
-        
+
         _getButton = new VPushButton("Get Latest Version");
         _getButton->setHidden(true);
         _group->Add(_getButton);
-        
+
         QObject::connect(_checkButton, &VPushButton::ButtonClicked, this, &PUpdateChecker::checkForUpdate);
         QObject::connect(_getButton, &VPushButton::ButtonClicked, this, &PUpdateChecker::openURL);
     }
     void DisplayUpToDate()
     {
         _label->setText("Vapor is up to date");
-        
+
         _checkButton->setHidden(true);
         _label->setVisible(true);
         _getButton->setHidden(true);
@@ -68,7 +65,7 @@ public:
     {
         _updateInfo = info;
         _label->setText(QString::fromStdString("New version available: " + info.version));
-        
+
         _checkButton->setHidden(true);
         _label->setVisible(true);
         _getButton->setVisible(true);
@@ -76,7 +73,7 @@ public:
     void DisplayError()
     {
         _label->setText("Unable to check for new version.");
-        
+
         _checkButton->setHidden(true);
         _label->setVisible(true);
         _getButton->setHidden(true);
@@ -108,14 +105,14 @@ AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(
 
         new PSection("Default Search Paths", {new PDirectorySelectorHLI<SettingsParams>("Session file path", &SettingsParams::GetSessionDir, &SettingsParams::SetSessionDir),
                                               new PDirectorySelectorHLI<SettingsParams>("Data set path", &SettingsParams::GetMetadataDir, &SettingsParams::SetMetadataDir)}),
-        
+
         // clang-format off
         new PSection("Updates", {
             new PCheckboxHLI<SettingsParams>("Automatically check for updates", &SettingsParams::GetAutoCheckForUpdates, &SettingsParams::SetAutoCheckForUpdates),
             new PUpdateChecker,
         }),
         // clang-format on
-        
+
         new PButton("Restore defaults", [](VAPoR::ParamsBase *p) { dynamic_cast<SettingsParams *>(p)->Init(); }),
     });
 

--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -246,6 +246,8 @@ set (SRCS
     RenderEventRouterGUI.h
     BookmarkParams.cpp
     BookmarkParams.h
+    CheckForUpdate.cpp
+    CheckForUpdate.h
 
 	# Need to include all files that request .ui files
 	Statistics.h
@@ -314,7 +316,7 @@ set (UIS
 
 source_group (UIs FILES ${UIS})
 
-find_package(Qt5 REQUIRED COMPONENTS Core OpenGL Widgets Gui DBus )
+find_package(Qt5 REQUIRED COMPONENTS Core OpenGL Widgets Gui DBus Network)
 
 set (CMAKE_AUTOUIC ON) # This needs to appear before adding sources to work properly
 set (CMAKE_AUTOMOC ON)
@@ -349,7 +351,7 @@ endif()
 
 target_link_libraries (
         vapor common vdc wasp render params jpeg ${GLEW} 
-        ${TIFF_LIB} geotiff ${ASSIMP_LIB} Qt5::Widgets Qt5::OpenGL Qt5::Core Qt5::Gui Qt5::DBus 
+        ${TIFF_LIB} geotiff ${ASSIMP_LIB} Qt5::Widgets Qt5::OpenGL Qt5::Core Qt5::Gui Qt5::DBus Qt5::Network
         ${PYTHON_LIB}
 )
 

--- a/apps/vaporgui/CheckForUpdate.cpp
+++ b/apps/vaporgui/CheckForUpdate.cpp
@@ -10,21 +10,21 @@
 #include <string>
 #include <vapor/Version.h>
 
-using std::string;
 using std::cout;
 using std::endl;
 using std::function;
+using std::string;
 using Wasp::Version;
 
 void CheckForUpdate(function<void(bool updateAvailable, UpdateInfo info)> callback)
 {
-    static QNetworkAccessManager *manager = nullptr;
+    static QNetworkAccessManager *                               manager = nullptr;
     static function<void(bool updateAvailable, UpdateInfo info)> _callback;
     _callback = callback;
-    
+
     if (!manager) {
         manager = new QNetworkAccessManager;
-    
+
         QObject::connect(manager, &QNetworkAccessManager::finished, manager, [&](QNetworkReply *reply) {
             if (reply->error()) {
                 cout << reply->errorString().toStdString() << endl;
@@ -33,29 +33,28 @@ void CheckForUpdate(function<void(bool updateAvailable, UpdateInfo info)> callba
                 _callback(false, info);
                 return;
             }
-            
-            string currentVersion = Version::GetVersionString();
-            bool updateAvailable = false;
+
+            string     currentVersion = Version::GetVersionString();
+            bool       updateAvailable = false;
             UpdateInfo info;
-            
-            QString content = reply->readAll();
+
+            QString       content = reply->readAll();
             QJsonDocument json = QJsonDocument::fromJson(content.toUtf8());
-            QJsonArray array = json.array();
+            QJsonArray    array = json.array();
             for (const QJsonValue value : array) {
                 QJsonObject release = value.toObject();
-                bool preRelease = release["prerelease"].toBool();
+                bool        preRelease = release["prerelease"].toBool();
                 info.version = release["tag_name"].toString().toStdString();
                 info.url = release["html_url"].toString().toStdString();
                 updateAvailable = !preRelease && Version::Compare(currentVersion, info.version) < 0;
-                
-                if (updateAvailable)
-                    break;
+
+                if (updateAvailable) break;
             }
-            
+
             _callback(updateAvailable, info);
         });
     }
-    
+
     QNetworkRequest req;
 #ifdef NDEBUG
     req.setUrl(QUrl("https://api.github.com/repos/NCAR/VAPOR/releases"));
@@ -65,7 +64,4 @@ void CheckForUpdate(function<void(bool updateAvailable, UpdateInfo info)> callba
     manager->get(req);
 }
 
-void UpdateInfo::OpenURL()
-{
-    QDesktopServices::openUrl(QUrl(QString::fromStdString(url)));
-}
+void UpdateInfo::OpenURL() { QDesktopServices::openUrl(QUrl(QString::fromStdString(url))); }

--- a/apps/vaporgui/CheckForUpdate.cpp
+++ b/apps/vaporgui/CheckForUpdate.cpp
@@ -1,0 +1,71 @@
+#include "CheckForUpdate.h"
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QDesktopServices>
+#include <iostream>
+#include <string>
+#include <vapor/Version.h>
+
+using std::string;
+using std::cout;
+using std::endl;
+using std::function;
+using Wasp::Version;
+
+void CheckForUpdate(function<void(bool updateAvailable, UpdateInfo info)> callback)
+{
+    static QNetworkAccessManager *manager = nullptr;
+    static function<void(bool updateAvailable, UpdateInfo info)> _callback;
+    _callback = callback;
+    
+    if (!manager) {
+        manager = new QNetworkAccessManager;
+    
+        QObject::connect(manager, &QNetworkAccessManager::finished, manager, [&](QNetworkReply *reply) {
+            if (reply->error()) {
+                cout << reply->errorString().toStdString() << endl;
+                UpdateInfo info;
+                info.error = true;
+                _callback(false, info);
+                return;
+            }
+            
+            string currentVersion = Version::GetVersionString();
+            bool updateAvailable = false;
+            UpdateInfo info;
+            
+            QString content = reply->readAll();
+            QJsonDocument json = QJsonDocument::fromJson(content.toUtf8());
+            QJsonArray array = json.array();
+            for (const QJsonValue value : array) {
+                QJsonObject release = value.toObject();
+                bool preRelease = release["prerelease"].toBool();
+                info.version = release["tag_name"].toString().toStdString();
+                info.url = release["html_url"].toString().toStdString();
+                updateAvailable = !preRelease && Version::Compare(currentVersion, info.version) < 0;
+                
+                if (updateAvailable)
+                    break;
+            }
+            
+            _callback(updateAvailable, info);
+        });
+    }
+    
+    QNetworkRequest req;
+#ifdef NDEBUG
+    req.setUrl(QUrl("https://api.github.com/repos/NCAR/VAPOR/releases"));
+#else
+    req.setUrl(QUrl("http://localhost:8000/api.json"));
+#endif
+    manager->get(req);
+}
+
+void UpdateInfo::OpenURL()
+{
+    QDesktopServices::openUrl(QUrl(QString::fromStdString(url)));
+}

--- a/apps/vaporgui/CheckForUpdate.cpp
+++ b/apps/vaporgui/CheckForUpdate.cpp
@@ -56,10 +56,10 @@ void CheckForUpdate(function<void(bool updateAvailable, UpdateInfo info)> callba
     }
 
     QNetworkRequest req;
-#ifdef NDEBUG
-    req.setUrl(QUrl("https://api.github.com/repos/NCAR/VAPOR/releases"));
-#else
+#ifdef TESTING_API
     req.setUrl(QUrl("http://localhost:8000/api.json"));
+#else
+    req.setUrl(QUrl("https://api.github.com/repos/NCAR/VAPOR/releases"));
 #endif
     manager->get(req);
 }

--- a/apps/vaporgui/CheckForUpdate.h
+++ b/apps/vaporgui/CheckForUpdate.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <functional>
+
+class QNetworkAccessManager;
+
+struct UpdateInfo {
+    std::string version;
+    std::string url;
+    bool error = false;
+    
+    void OpenURL();
+};
+
+void CheckForUpdate(std::function<void(bool updateAvailable, UpdateInfo info)> callback);

--- a/apps/vaporgui/CheckForUpdate.h
+++ b/apps/vaporgui/CheckForUpdate.h
@@ -8,8 +8,8 @@ class QNetworkAccessManager;
 struct UpdateInfo {
     std::string version;
     std::string url;
-    bool error = false;
-    
+    bool        error = false;
+
     void OpenURL();
 };
 

--- a/apps/vaporgui/CheckForUpdate.h
+++ b/apps/vaporgui/CheckForUpdate.h
@@ -13,4 +13,7 @@ struct UpdateInfo {
     void OpenURL();
 };
 
+//! Uses the GitHub API to check Vapor's latest release version and compares it against the current version. If an update
+//! is available, info will be populated.
+
 void CheckForUpdate(std::function<void(bool updateAvailable, UpdateInfo info)> callback);

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -83,6 +83,7 @@
 #include "windowsUtils.h"
 #include "ParamsWidgetDemo.h"
 #include "AppSettingsMenu.h"
+#include "CheckForUpdate.h"
 
 #include <QProgressDialog>
 #include <QProgressBar>
@@ -318,7 +319,7 @@ public:
 
 // Only the main program should call the constructor:
 //
-MainForm::MainForm(vector<QString> files, QApplication *app, QWidget *parent) : QMainWindow(parent)
+MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, QWidget *parent) : QMainWindow(parent)
 {
     _initMembers();
 
@@ -473,6 +474,9 @@ MainForm::MainForm(vector<QString> files, QApplication *app, QWidget *parent) : 
 
     _controlExec->SetSaveStateEnabled(true);
     _controlExec->RebaseStateSave();
+    
+    if (interactive && GetSettingsParams()->GetValueLong(SettingsParams::AutoCheckForUpdatesTag, true))
+        CheckForUpdates();
 }
 
 int MainForm::RenderAndExit(int start, int end, const std::string &baseFile, int width, int height)
@@ -561,6 +565,35 @@ bool MainForm::determineDatasetFormat(const std::vector<std::string> &paths, std
     else
         return false;
     return true;
+}
+
+void MainForm::CheckForUpdates()
+{
+#ifndef NDEBUG
+    return; // Don't check for updates in debug builds
+#endif
+    
+    CheckForUpdate([this](bool updateAvailable, UpdateInfo info) {
+        if (!updateAvailable)
+            return;
+        
+        QCheckBox *cb = new QCheckBox("Automatically check for updates");
+        cb->setChecked(true);
+        QMessageBox popup;
+        popup.setText(QString::fromStdString("A newer version of Vapor is available: " + info.version));
+        QPushButton *get = popup.addButton("Get Latest Version", QMessageBox::ActionRole);
+        popup.addButton("Ok", QMessageBox::AcceptRole);
+        popup.setCheckBox(cb);
+        
+        popup.exec();
+        if (popup.clickedButton() == get)
+            info.OpenURL();
+        
+        if (!cb->isChecked()) {
+            GetSettingsParams()->SetValueLong(SettingsParams::AutoCheckForUpdatesTag, "", false);
+            GetSettingsParams()->SaveSettings();
+        }
+    });
 }
 
 void MainForm::_createAnimationToolBar()

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -474,9 +474,8 @@ MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, Q
 
     _controlExec->SetSaveStateEnabled(true);
     _controlExec->RebaseStateSave();
-    
-    if (interactive && GetSettingsParams()->GetValueLong(SettingsParams::AutoCheckForUpdatesTag, true))
-        CheckForUpdates();
+
+    if (interactive && GetSettingsParams()->GetValueLong(SettingsParams::AutoCheckForUpdatesTag, true)) CheckForUpdates();
 }
 
 int MainForm::RenderAndExit(int start, int end, const std::string &baseFile, int width, int height)
@@ -570,13 +569,12 @@ bool MainForm::determineDatasetFormat(const std::vector<std::string> &paths, std
 void MainForm::CheckForUpdates()
 {
 #ifndef NDEBUG
-    return; // Don't check for updates in debug builds
+    return;    // Don't check for updates in debug builds
 #endif
-    
+
     CheckForUpdate([this](bool updateAvailable, UpdateInfo info) {
-        if (!updateAvailable)
-            return;
-        
+        if (!updateAvailable) return;
+
         QCheckBox *cb = new QCheckBox("Automatically check for updates");
         cb->setChecked(true);
         QMessageBox popup;
@@ -584,11 +582,10 @@ void MainForm::CheckForUpdates()
         QPushButton *get = popup.addButton("Get Latest Version", QMessageBox::ActionRole);
         popup.addButton("Ok", QMessageBox::AcceptRole);
         popup.setCheckBox(cb);
-        
+
         popup.exec();
-        if (popup.clickedButton() == get)
-            info.OpenURL();
-        
+        if (popup.clickedButton() == get) info.OpenURL();
+
         if (!cb->isChecked()) {
             GetSettingsParams()->SetValueLong(SettingsParams::AutoCheckForUpdatesTag, "", false);
             GetSettingsParams()->SaveSettings();

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -76,7 +76,7 @@ class MainForm : public QMainWindow {
     Q_OBJECT
 
 public:
-    MainForm(vector<QString> files, QApplication *app, bool interactive=true, QWidget *parent = 0);
+    MainForm(vector<QString> files, QApplication *app, bool interactive = true, QWidget *parent = 0);
     ~MainForm();
 
     int RenderAndExit(int start, int end, const std::string &baseFile, int width, int height);
@@ -313,7 +313,7 @@ private:
 
     template<class T> bool isDatasetValidFormat(const std::vector<std::string> &paths) const;
     bool                   determineDatasetFormat(const std::vector<std::string> &paths, std::string *fmt) const;
-    
+
     void CheckForUpdates();
 
     bool isOpenGLContextActive() const;

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -76,7 +76,7 @@ class MainForm : public QMainWindow {
     Q_OBJECT
 
 public:
-    MainForm(vector<QString> files, QApplication *app, QWidget *parent = 0);
+    MainForm(vector<QString> files, QApplication *app, bool interactive=true, QWidget *parent = 0);
     ~MainForm();
 
     int RenderAndExit(int start, int end, const std::string &baseFile, int width, int height);
@@ -313,6 +313,8 @@ private:
 
     template<class T> bool isDatasetValidFormat(const std::vector<std::string> &paths) const;
     bool                   determineDatasetFormat(const std::vector<std::string> &paths, std::string *fmt) const;
+    
+    void CheckForUpdates();
 
     bool isOpenGLContextActive() const;
 

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -403,15 +403,9 @@ void SettingsParams::SetFidelityDefault2D(long lodDef, long refDef)
     SetValueLongVec(_fidelityDefault2DTag, "Set fidelity 2D default", val);
 }
 
-void SettingsParams::SetAutoCheckForUpdates(bool b)
-{
-    SetValueLong(AutoCheckForUpdatesTag, "", b);
-}
+void SettingsParams::SetAutoCheckForUpdates(bool b) { SetValueLong(AutoCheckForUpdatesTag, "", b); }
 
-bool SettingsParams::GetAutoCheckForUpdates() const
-{
-    return GetValueLong(AutoCheckForUpdatesTag, true);
-}
+bool SettingsParams::GetAutoCheckForUpdates() const { return GetValueLong(AutoCheckForUpdatesTag, true); }
 
 bool SettingsParams::LoadFromSettingsFile()
 {

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -68,6 +68,7 @@ const string SettingsParams::_dontShowIntelDriverWarningTag = "DontShowIntelDriv
 const string SettingsParams::_settingsNeedsWriteTag = "SettingsNeedsWrite";
 
 const string SettingsParams::UseAllCoresTag = "UseAllCoresTag";
+const string SettingsParams::AutoCheckForUpdatesTag = "AutoCheckForUpdatesTag";
 
 //
 // Register class with object factory!!!
@@ -402,6 +403,16 @@ void SettingsParams::SetFidelityDefault2D(long lodDef, long refDef)
     SetValueLongVec(_fidelityDefault2DTag, "Set fidelity 2D default", val);
 }
 
+void SettingsParams::SetAutoCheckForUpdates(bool b)
+{
+    SetValueLong(AutoCheckForUpdatesTag, "", b);
+}
+
+bool SettingsParams::GetAutoCheckForUpdates() const
+{
+    return GetValueLong(AutoCheckForUpdatesTag, true);
+}
+
 bool SettingsParams::LoadFromSettingsFile()
 {
     XmlNode *node = GetNode();
@@ -451,6 +462,7 @@ void SettingsParams::Init()
 
     SetAutoStretchEnabled(true);
     SetValueLong(UseAllCoresTag, "", true);
+    SetValueLong(AutoCheckForUpdatesTag, "", true);
     SetNumThreads(4);
     SetCacheMB(defaultCacheSize);
 

--- a/apps/vaporgui/SettingsParams.h
+++ b/apps/vaporgui/SettingsParams.h
@@ -126,7 +126,7 @@ public:
     static const string _sessionAutoSaveEnabledTag;
 
     std::string GetSettingsPath() const;
-    
+
     void SetAutoCheckForUpdates(bool b);
     bool GetAutoCheckForUpdates() const;
 

--- a/apps/vaporgui/SettingsParams.h
+++ b/apps/vaporgui/SettingsParams.h
@@ -126,8 +126,12 @@ public:
     static const string _sessionAutoSaveEnabledTag;
 
     std::string GetSettingsPath() const;
+    
+    void SetAutoCheckForUpdates(bool b);
+    bool GetAutoCheckForUpdates() const;
 
     static const string UseAllCoresTag;
+    static const string AutoCheckForUpdatesTag;
 
     bool LoadFromSettingsFile();
 

--- a/apps/vaporgui/main.cpp
+++ b/apps/vaporgui/main.cpp
@@ -175,7 +175,7 @@ int           main(int argc, char **argv)
 
     vector<QString> files;
     for (int i = 1; i < argc; i++) { files.push_back(argv[i]); }
-    MainForm *mw = new MainForm(files, app);
+    MainForm *mw = new MainForm(files, app, !opt.render);
 
     // StartupParams* sParams = new StartupParams(0);
 


### PR DESCRIPTION
It uses the GitHub API to query our releases and parses them to find the newest non-prerelease version. By default it will check for new versions upon startup in the background (i.e. the application won't hang over a slow connection). If a newer version is available, it prompts the user to download it, providing a button that takes the user directly to the download page of that release, as well as a checkbox to prevent further notifications about new versions. The version can be manually checked in the settings panel as well. Automatic version checking is disabled when running Vapor in batch mode, as well as in debug builds.

### Popup
![popup](https://user-images.githubusercontent.com/2772687/117622867-5787db80-b130-11eb-9906-47eb8c1efeb5.png)

### Settings Panel
![settings](https://user-images.githubusercontent.com/2772687/117622918-63739d80-b130-11eb-9304-9c232ea54ee9.png)

### Settings New Version Available
![settings new](https://user-images.githubusercontent.com/2772687/117622942-6cfd0580-b130-11eb-819a-f7de4b5dbbda.png)

### Settings Error Fetching Version
![settings error](https://user-images.githubusercontent.com/2772687/117622974-74bcaa00-b130-11eb-8faa-971ec9ef1970.png)



Fix #2597