### PR TITLE
Curvilinear grid DVR performance unusable/hangs on casper #2727

### DIFF
--- a/apps/vaporgui/GUIStateParams.cpp
+++ b/apps/vaporgui/GUIStateParams.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include <iostream>
+#include <cassert>
 #include <QDir>
 
 #include "MouseModeParams.h"

--- a/apps/vaporgui/PCornerSelector.cpp
+++ b/apps/vaporgui/PCornerSelector.cpp
@@ -2,6 +2,7 @@
 #include "VCheckBox.h"
 #include <vapor/ColorbarPbase.h>
 #include <QFrame>
+#include <cassert>
 #include <QGridLayout>
 
 

--- a/apps/vaporgui/VComboBox.cpp
+++ b/apps/vaporgui/VComboBox.cpp
@@ -1,5 +1,6 @@
 #include "VComboBox.h"
 #include <QStandardItemModel>
+#include <cassert>
 
 VComboBox::VComboBox(const std::vector<std::string> &values) : VHBoxWidget()
 {

--- a/lib/render/VolumeCellTraversal.cpp
+++ b/lib/render/VolumeCellTraversal.cpp
@@ -359,12 +359,20 @@ int VolumeCellTraversal::LoadData(const Grid *grid)
 
 int VolumeCellTraversal::_getHeuristicBBLevels() const
 {
-    const int levels = _BBLevels;
+    int levels = _BBLevels;
 
-    if (levels == 12) return levels - 4;
-    if (levels >= 9) return levels - 3;
-    if (levels >= 7) return levels - 2;
-    if (levels >= 2) return levels - 1;
+    if (levels == 12) levels -= 4;
+    else if (levels >= 9) levels -= 3;
+    else if (levels >= 7) levels -= 2;
+    else if (levels >= 2) levels -= 1;
+    
+    // Nvidia's loop optimizer has an exponential Big-O complexity in
+    // relation to nesting and anything over 6 takes too long to compile.
+    GLManager::Vendor vendor = GLManager::GetVendor();
+    if (vendor == GLManager::Vendor::Nvidia)
+        if (levels > 6)
+            levels = 6;
+    
     return levels;
 }
 

--- a/lib/render/VolumeCellTraversal.cpp
+++ b/lib/render/VolumeCellTraversal.cpp
@@ -361,18 +361,21 @@ int VolumeCellTraversal::_getHeuristicBBLevels() const
 {
     int levels = _BBLevels;
 
-    if (levels == 12) levels -= 4;
-    else if (levels >= 9) levels -= 3;
-    else if (levels >= 7) levels -= 2;
-    else if (levels >= 2) levels -= 1;
-    
+    if (levels == 12)
+        levels -= 4;
+    else if (levels >= 9)
+        levels -= 3;
+    else if (levels >= 7)
+        levels -= 2;
+    else if (levels >= 2)
+        levels -= 1;
+
     // Nvidia's loop optimizer has an exponential Big-O complexity in
     // relation to nesting and anything over 6 takes too long to compile.
     GLManager::Vendor vendor = GLManager::GetVendor();
     if (vendor == GLManager::Vendor::Nvidia)
-        if (levels > 6)
-            levels = 6;
-    
+        if (levels > 6) levels = 6;
+
     return levels;
 }
 


### PR DESCRIPTION
Fix #2727

The hang was being caused by a bug in the Nvidia GLSL compiler. If you let it run it would eventually compile and then render just fine but it would likely take a few hours to compile the shader.

![s](https://user-images.githubusercontent.com/2772687/118752544-8254ec80-b820-11eb-81d9-64f31623eb41.png)
