### PR TITLE
Issue 2438s5

### DIFF
--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -573,7 +573,7 @@ bool CurvilinearGrid::_insideGridHelperTerrain(double x, double y, double z, con
     if (!Wasp::BinarySearchRange(zcoords, z, k)) return (false);
 
     z0 = zcoords[k];
-    z1 = k < nz-1 ? zcoords[k + 1] : z0;
+    z1 = k < nz - 1 ? zcoords[k + 1] : z0;
 
     zwgt[0] = 1.0 - (z - z0) / (z1 - z0);
     zwgt[1] = 1.0 - zwgt[0];

--- a/lib/vdc/QuadTreeRectangleP.cpp
+++ b/lib/vdc/QuadTreeRectangleP.cpp
@@ -20,7 +20,7 @@ QuadTreeRectangleP::QuadTreeRectangleP(float left, float top, float right, float
 #pragma omp parallel
     {
         nthreads = omp_get_num_threads();
-printf("num threads = %d\n", nthreads);
+        printf("num threads = %d\n", nthreads);
     }
 
     // We split the quadtree along the X-axis to create one subtree for
@@ -45,7 +45,7 @@ QuadTreeRectangleP::QuadTreeRectangleP(size_t max_depth, size_t reserve_size) : 
 #pragma omp parallel
     {
         nthreads = omp_get_num_threads();
-printf("num threads = %d\n", nthreads);
+        printf("num threads = %d\n", nthreads);
     }
 
     float bin_width = (1.0 - 0.0) / ((float)nthreads);

--- a/lib/vdc/StretchedGrid.cpp
+++ b/lib/vdc/StretchedGrid.cpp
@@ -298,8 +298,8 @@ float StretchedGrid::GetValueLinear(const DblArr3 &coords) const
     float verts0[4];
     verts0[0] = AccessIJK(i, j, k);
     verts0[1] = dims[0] > 1 ? AccessIJK(i + 1, j, k) : 0.0;
-    verts0[2] = dims[1] > 1 ? AccessIJK(i, j+1, k) : 0.0;
-    verts0[3] = dims[0] > 1 && dims[1] > 1 ? AccessIJK(i+1, j+1, k) : 0.0;
+    verts0[2] = dims[1] > 1 ? AccessIJK(i, j + 1, k) : 0.0;
+    verts0[3] = dims[0] > 1 && dims[1] > 1 ? AccessIJK(i + 1, j + 1, k) : 0.0;
 
     float v0 = ((verts0[0] * xwgt[0] + verts0[1] * xwgt[1]) * ywgt[0]) + ((verts0[2] * xwgt[0] + verts0[3] * xwgt[1]) * ywgt[1]);
 
@@ -309,9 +309,9 @@ float StretchedGrid::GetValueLinear(const DblArr3 &coords) const
 
     float verts1[4];
     verts1[0] = AccessIJK(i, j, k);
-    verts1[1] = dims[0] > 1 ? AccessIJK(i+1, j, k) : 0.0;
-    verts1[2] = dims[1] > 1 ? AccessIJK(i, j+1, k) : 0.0;
-    verts1[3] = dims[0] > 1 && dims[1] > 1 ? AccessIJK(i+1, j+1, k) : 0.0;
+    verts1[1] = dims[0] > 1 ? AccessIJK(i + 1, j, k) : 0.0;
+    verts1[2] = dims[1] > 1 ? AccessIJK(i, j + 1, k) : 0.0;
+    verts1[3] = dims[0] > 1 && dims[1] > 1 ? AccessIJK(i + 1, j + 1, k) : 0.0;
 
     float v1 = ((verts1[0] * xwgt[0] + verts1[1] * xwgt[1]) * ywgt[0]) + ((verts1[2] * xwgt[0] + verts1[3] * xwgt[1]) * ywgt[1]);
 
@@ -357,21 +357,19 @@ bool StretchedGrid::_insideGrid(double x, double y, double z, size_t &i, size_t 
     if (!Wasp::BinarySearchRange(_xcoords, x, i)) return (false);
 
     if (_xcoords.size() > 1) {
-	    xwgt[0] = 1.0 - (x - _xcoords[i]) / (_xcoords[i + 1] - _xcoords[i]);
-    	xwgt[1] = 1.0 - xwgt[0];
-	}
-    else {
+        xwgt[0] = 1.0 - (x - _xcoords[i]) / (_xcoords[i + 1] - _xcoords[i]);
+        xwgt[1] = 1.0 - xwgt[0];
+    } else {
         xwgt[0] = 1.0;
     }
-	
+
 
     if (!Wasp::BinarySearchRange(_ycoords, y, j)) return (false);
 
     if (_ycoords.size() > 1) {
         ywgt[0] = 1.0 - (y - _ycoords[j]) / (_ycoords[j + 1] - _ycoords[j]);
         ywgt[1] = 1.0 - ywgt[0];
-    }
-    else {
+    } else {
         ywgt[0] = 1.0;
     }
 
@@ -389,8 +387,7 @@ bool StretchedGrid::_insideGrid(double x, double y, double z, size_t &i, size_t 
     if (_zcoords.size() > 1) {
         zwgt[0] = 1.0 - (z - _zcoords[k]) / (_zcoords[k + 1] - _zcoords[k]);
         zwgt[1] = 1.0 - zwgt[0];
-    }
-    else {
+    } else {
         zwgt[0] = 1.0;
     }
 

--- a/share/gitHooks/pre-push
+++ b/share/gitHooks/pre-push
@@ -1,16 +1,37 @@
 #!/bin/sh
 #
 
+DRYRUN='false'
+MAIN='false'
+
+# -d initiates a dry-run where code will be scanned, but changes will not be applied
+# -m initiates a comparison between the local HEAD and 'main', instead of comparing
+#    the the local HEAD with the remote HEAD
+while getopts dm flag;
+do
+    case ${flag} in
+        d) DRYRUN='true' ;;
+        m) MAIN='true' ;;
+    esac
+done
+
+echo "  Running dryrun?    $DRYRUN"
+echo "  Force comparison to main? $MAIN"
+
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 
 # If our current branch does not exist in the remote repository yet, then compare
 # our local changes with main.  Otherwise, compare our local changes with the remote
 # branch.
-if [ `git ls-remote --heads https://github.com/NCAR/VAPOR.git $BRANCH | wc -l` = 0 ]; then
-    COMPARE_BRANCH="main"
-else
-    COMPARE_BRANCH=$BRANCH
+if [ "${MAIN}" != "true" ]; then
+    if [ `git ls-remote --heads https://github.com/NCAR/VAPOR.git $BRANCH | wc -l` = 0 ]; then
+        COMPARE_BRANCH="main"
+    else
+        COMPARE_BRANCH=$BRANCH
+    fi
 fi
+
+echo "  Comparing current changes with branch: $COMPARE_BRANCH"
 
 # If we're on the readTheDocs branch, skip clang-format
 #
@@ -22,21 +43,29 @@ if [ "$BRANCH" = "readTheDocs" ]; then
 else
     for COMMIT in $(git log --pretty=format:%h origin/$COMPARE_BRANCH...$BRANCH); do
         echo "Reading Commit: $COMMIT"
-        for FILE in $(git diff-tree --no-commit-id --name-only -r $COMMIT |grep -E "\.h|\.cpp"); do
+        #for FILE in $(git diff-tree --no-commit-id --name-only -r $COMMIT |grep -E "\.h|\.cpp"); do
+        for FILE in $(git diff --name-only $COMMIT^ $COMMIT |grep -E "\.h|\.cpp"); do
             NUMBERS=""
             for NUMBER in $(git blame --line-porcelain "$FILE" | egrep ^$COMMIT | cut -d' ' -f3); do
                 NUMBERS="$NUMBERS --lines $NUMBER:$NUMBER "
             done
 
             if [ "$NUMBERS" != "" ]; then
-                echo "  Running clang-format on $FILE"
-                clang-format -i $FILE $NUMBERS
-                git add $FILE
+                if [ "${DRYRUN}" = "true" ]; then
+                    echo "dry run activated"
+                    clang-format --dry-run -i $FILE $NUMBERS >> /tmp/clang-format.txt 2>&1
+                else
+                    echo "  Running clang-format on $FILE, line $NUMBERS"
+                    clang-format -i $FILE $NUMBERS
+                    git add $FILE
+                fi
             fi
         done
     done
 
-    git commit -m "clang-format pre-push hook"
+    if [ "${DRYRUN}" = "false" ]; then
+        git commit -m "clang-format pre-push hook"
+    fi
 
     # git commit will return non-zero status if there's nothing to commit.  Make sure
     # we return 0 so git 'push' will still be invoked

--- a/share/gitHooks/pre-push
+++ b/share/gitHooks/pre-push
@@ -1,37 +1,16 @@
 #!/bin/sh
 #
 
-DRYRUN='false'
-MAIN='false'
-
-# -d initiates a dry-run where code will be scanned, but changes will not be applied
-# -m initiates a comparison between the local HEAD and 'main', instead of comparing
-#    the the local HEAD with the remote HEAD
-while getopts dm flag;
-do
-    case ${flag} in
-        d) DRYRUN='true' ;;
-        m) MAIN='true' ;;
-    esac
-done
-
-echo "  Running dryrun?    $DRYRUN"
-echo "  Force comparison to main? $MAIN"
-
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 
 # If our current branch does not exist in the remote repository yet, then compare
 # our local changes with main.  Otherwise, compare our local changes with the remote
 # branch.
-if [ "${MAIN}" != "true" ]; then
-    if [ `git ls-remote --heads https://github.com/NCAR/VAPOR.git $BRANCH | wc -l` = 0 ]; then
-        COMPARE_BRANCH="main"
-    else
-        COMPARE_BRANCH=$BRANCH
-    fi
+if [ `git ls-remote --heads https://github.com/NCAR/VAPOR.git $BRANCH | wc -l` = 0 ]; then
+    COMPARE_BRANCH="main"
+else
+    COMPARE_BRANCH=$BRANCH
 fi
-
-echo "  Comparing current changes with branch: $COMPARE_BRANCH"
 
 # If we're on the readTheDocs branch, skip clang-format
 #
@@ -43,29 +22,21 @@ if [ "$BRANCH" = "readTheDocs" ]; then
 else
     for COMMIT in $(git log --pretty=format:%h origin/$COMPARE_BRANCH...$BRANCH); do
         echo "Reading Commit: $COMMIT"
-        #for FILE in $(git diff-tree --no-commit-id --name-only -r $COMMIT |grep -E "\.h|\.cpp"); do
-        for FILE in $(git diff --name-only $COMMIT^ $COMMIT |grep -E "\.h|\.cpp"); do
+        for FILE in $(git diff-tree --no-commit-id --name-only -r $COMMIT |grep -E "\.h|\.cpp"); do
             NUMBERS=""
             for NUMBER in $(git blame --line-porcelain "$FILE" | egrep ^$COMMIT | cut -d' ' -f3); do
                 NUMBERS="$NUMBERS --lines $NUMBER:$NUMBER "
             done
 
             if [ "$NUMBERS" != "" ]; then
-                if [ "${DRYRUN}" = "true" ]; then
-                    echo "dry run activated"
-                    clang-format --dry-run -i $FILE $NUMBERS >> /tmp/clang-format.txt 2>&1
-                else
-                    echo "  Running clang-format on $FILE, line $NUMBERS"
-                    clang-format -i $FILE $NUMBERS
-                    git add $FILE
-                fi
+                echo "  Running clang-format on $FILE"
+                clang-format -i $FILE $NUMBERS
+                git add $FILE
             fi
         done
     done
 
-    if [ "${DRYRUN}" = "false" ]; then
-        git commit -m "clang-format pre-push hook"
-    fi
+    git commit -m "clang-format pre-push hook"
 
     # git commit will return non-zero status if there's nothing to commit.  Make sure
     # we return 0 so git 'push' will still be invoked

--- a/test_apps/datamgr/test_datamgr.cpp
+++ b/test_apps/datamgr/test_datamgr.cpp
@@ -185,7 +185,7 @@ void test_get_value(Grid *g)
 
     size_t ecount = 0;
 #if defined(_OPENMP)
-    int    requested_num_threads = get_num_ompthreads();
+    int requested_num_threads = get_num_ompthreads();
 #endif
 #pragma omp parallel num_threads(requested_num_threads)
     {

--- a/test_apps/smokeTests/testGrid.cpp
+++ b/test_apps/smokeTests/testGrid.cpp
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
     }
 
     // Test Unstructured Grid 2D
-    if (std::find(opt.grids.begin(), opt.grids.end(), "Unstructured2D") != opt.grids.end() && opt.dims[0] > 1 && opt.dims[1] > 1 ) {
+    if (std::find(opt.grids.begin(), opt.grids.end(), "Unstructured2D") != opt.grids.end() && opt.dims[0] > 1 && opt.dims[1] > 1) {
         double              t0 = Wasp::GetTime();
         UnstructuredGrid2D *g = MakeUnstructuredGrid2D(opt.dims, opt.bs, minu, maxu);
         double              t1 = Wasp::GetTime() - t0;

--- a/test_apps/smokeTests/testResults/cf_baseline.txt
+++ b/test_apps/smokeTests/testResults/cf_baseline.txt
@@ -61,4 +61,4 @@ Time Coordinates:
 
 Time coordinate variable name: time
 Number of time steps: 1
-Elapsed time: 0.31866
+Elapsed time: 0.159113

--- a/test_apps/smokeTests/testResults/cf_baseline.txt
+++ b/test_apps/smokeTests/testResults/cf_baseline.txt
@@ -60,4 +60,4 @@ Time Coordinates:
 
 Time coordinate variable name: time
 Number of time steps: 1
-Elapsed time: 0.318985
+Elapsed time: 0.31866

--- a/test_apps/smokeTests/testResults/cf_baseline.txt
+++ b/test_apps/smokeTests/testResults/cf_baseline.txt
@@ -46,6 +46,7 @@ Grid test for 3D variable dbz:
     Missing value count:                                 0
     GetValueAtIndex() vs GetValue() disagreement count:  0
     Time:                                                0
+
 Projection String:  
 
 Coordinate Variables:

--- a/test_apps/smokeTests/testResults/vdc_baseline.txt
+++ b/test_apps/smokeTests/testResults/vdc_baseline.txt
@@ -147,4 +147,4 @@ Time Coordinates:
 
 Time coordinate variable name: Time
 Number of time steps: 1
-Elapsed time: 65.0358
+Elapsed time: 65.5336

--- a/test_apps/smokeTests/testResults/vdc_baseline.txt
+++ b/test_apps/smokeTests/testResults/vdc_baseline.txt
@@ -95,6 +95,7 @@ Compression Info for variable CANWAT:
     Refinement Levels:  4
     Compression Ratios: 62 21 4 1
 
+num threads = 1
 Grid test for 2D variable CANWAT:
     # Dimensions:       2
     Dimension Lengths:  315 309
@@ -104,10 +105,12 @@ Grid test for 2D variable CANWAT:
     Missing value count:                                 0
     GetValueAtIndex() vs GetValue() disagreement count:  0
     Time:                                                0
+
 Compression Info for variable P:
     Refinement Levels:  4
     Compression Ratios: 500 100 10 1
 
+num threads = 1
 Grid test for 3D variable P:
     # Dimensions:       3
     Dimension Lengths:  315 309 34
@@ -148,4 +151,4 @@ Time Coordinates:
 
 Time coordinate variable name: Time
 Number of time steps: 1
-Elapsed time: 65.5336
+Elapsed time: 17.3104

--- a/test_apps/smokeTests/testResults/vdc_baseline.txt
+++ b/test_apps/smokeTests/testResults/vdc_baseline.txt
@@ -117,6 +117,7 @@ Grid test for 3D variable P:
     Missing value count:                                 0
     GetValueAtIndex() vs GetValue() disagreement count:  0
     Time:                                                0
+
 Projection String:  +proj=merc +lon_0=-85 +lat_ts=30 +ellps=WGS84
 
 Coordinate Variables:

--- a/test_apps/smokeTests/testResults/wrf_baseline.txt
+++ b/test_apps/smokeTests/testResults/wrf_baseline.txt
@@ -117,6 +117,7 @@ Grid test for 3D variable P:
     Missing value count:                                 0
     GetValueAtIndex() vs GetValue() disagreement count:  0
     Time:                                                0
+
 Projection String:  +proj=merc +lon_0=-85 +lat_ts=30 +ellps=WGS84
 
 Coordinate Variables:

--- a/test_apps/smokeTests/testResults/wrf_baseline.txt
+++ b/test_apps/smokeTests/testResults/wrf_baseline.txt
@@ -147,4 +147,4 @@ Time Coordinates:
 
 Time coordinate variable name: Time
 Number of time steps: 1
-Elapsed time: 64.6885
+Elapsed time: 64.5783

--- a/test_apps/smokeTests/testResults/wrf_baseline.txt
+++ b/test_apps/smokeTests/testResults/wrf_baseline.txt
@@ -95,6 +95,7 @@ Compression Info for variable CANWAT:
     Refinement Levels:  1
     Compression Ratios: 1
 
+num threads = 1
 Grid test for 2D variable CANWAT:
     # Dimensions:       2
     Dimension Lengths:  315 309
@@ -104,10 +105,12 @@ Grid test for 2D variable CANWAT:
     Missing value count:                                 0
     GetValueAtIndex() vs GetValue() disagreement count:  0
     Time:                                                0
+
 Compression Info for variable P:
     Refinement Levels:  1
     Compression Ratios: 1
 
+num threads = 1
 Grid test for 3D variable P:
     # Dimensions:       3
     Dimension Lengths:  315 309 34
@@ -148,4 +151,4 @@ Time Coordinates:
 
 Time coordinate variable name: Time
 Number of time steps: 1
-Elapsed time: 64.5783
+Elapsed time: 16.9153


### PR DESCRIPTION
@clyne This PR does 2 things:

1) It updates our "baseline" files for the smoke tests, which have had minor format and information changes.  The 'diff' that we run between our test results and these baseline files is why the tests were reporting mismatches.

2) It applies clang-format to the files that were missed during the pre-push hook.  I have a separate PR that fixes the hook, which was applying clang-format to all commits, but not all merge-commits.  More details in #2736