### PR TITLE
patch missed clang-formats

### DIFF
--- a/apps/vaporgui/AnnotationEventRouter.h
+++ b/apps/vaporgui/AnnotationEventRouter.h
@@ -62,9 +62,9 @@ protected slots:
     void axisAnnotationTableChanged();
 
 private:
-    Combo *     _textSizeCombo;
-    Combo *     _digitsCombo;
-    Combo *     _ticWidthCombo;
+    Combo *_textSizeCombo;
+    Combo *_digitsCombo;
+    Combo *_ticWidthCombo;
 
     std::map<std::string, std::string> _visNames;
     std::map<std::string, std::string> _renTypeNames;

--- a/apps/vaporgui/CopyRegionWidget.h
+++ b/apps/vaporgui/CopyRegionWidget.h
@@ -33,7 +33,7 @@ public:
         return tr("This widget contains all widgets "
                   "necessary for copying renderer regions");
     }
-    bool isContainer() const { return true; }
+    bool         isContainer() const { return true; }
     virtual void Update(VAPoR::ParamsMgr *paramsMgr, VAPoR::RenderParams *rParams);
 
 signals:

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -2396,9 +2396,7 @@ void MainForm::_plotClosed()
 
 void MainForm::launchPythonVariables()
 {
-    if (!_pythonVariables) {
-        _pythonVariables = new PythonVariables(this);
-    }
+    if (!_pythonVariables) { _pythonVariables = new PythonVariables(this); }
     if (_controlExec) { _pythonVariables->InitControlExec(_controlExec); }
     _pythonVariables->ShowMe();
 }

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -167,16 +167,16 @@ private:
 
     // Toolbars:
     //
-    QAction *     _tileAction;
-    QAction *     _cascadeAction;
-    QAction *     _homeAction;
-    QAction *     _sethomeAction;
-    QAction *     _viewAllAction;
-    QAction *     _viewRegionAction;
-    QAction *     _stepForwardAction;
-    QAction *     _stepBackAction;
-    QSpinBox *    _interactiveRefinementSpin;
-    QDockWidget * _tabDockWindow;
+    QAction *    _tileAction;
+    QAction *    _cascadeAction;
+    QAction *    _homeAction;
+    QAction *    _sethomeAction;
+    QAction *    _viewAllAction;
+    QAction *    _viewRegionAction;
+    QAction *    _stepForwardAction;
+    QAction *    _stepBackAction;
+    QSpinBox *   _interactiveRefinementSpin;
+    QDockWidget *_tabDockWindow;
 
     bool     _animationCapture = false;
     int      _progressSavedFB = -1;

--- a/apps/vaporgui/PythonVariables.cpp
+++ b/apps/vaporgui/PythonVariables.cpp
@@ -493,10 +493,7 @@ std::vector<string> PythonVariables::_buildInputVars() const
     return inputVars;
 }
 
-void PythonVariables::_closeScript()
-{
-    close();
-}
+void PythonVariables::_closeScript() { close(); }
 
 void PythonVariables::_coordInputVarChanged(int row, int col)
 {

--- a/apps/vaporgui/RenderEventRouter.h
+++ b/apps/vaporgui/RenderEventRouter.h
@@ -31,7 +31,7 @@ class ParamsMgr;
 }    // namespace VAPoR
 
 #ifdef WIN32
-    // Annoying unreferenced formal parameter warning
+     // Annoying unreferenced formal parameter warning
     #pragma warning(disable : 4100)
 #endif
 

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -76,9 +76,9 @@ const string SettingsParams::AutoCheckForUpdatesTag = "AutoCheckForUpdatesTag";
 static ParamsRegistrar<SettingsParams> registrar(SettingsParams::GetClassType());
 
 namespace {
-string SettingsFile = ".vapor3_settings";
+string       SettingsFile = ".vapor3_settings";
 const size_t defaultCacheSize = 0;
-}
+}    // namespace
 
 SettingsParams::SettingsParams(ParamsBase::StateSave *ssave, bool loadFromFile) : ParamsBase(ssave, _classType)
 {

--- a/apps/vaporgui/VaporTable.cpp
+++ b/apps/vaporgui/VaporTable.cpp
@@ -81,9 +81,7 @@ void VaporTable::Update(int rows, int cols, std::vector<std::string> values, std
 
     addCheckboxes(values);
 
-    if ((rows < 1) || (cols < 1)) {
-        _activeRow = -1;
-    }
+    if ((rows < 1) || (cols < 1)) { _activeRow = -1; }
     if (_activeRow >= rows) { _activeRow = rows - 1; }
 
     if (_highlightFlags & ROWS) highlightActiveRow(_activeRow);

--- a/apps/vaporgui/VizWin.cpp
+++ b/apps/vaporgui/VizWin.cpp
@@ -524,8 +524,8 @@ std::vector<double> VizWin::_getScreenCoords(QMouseEvent *e) const
 
 string VizWin::_getCurrentMouseMode() const
 {
-    ParamsMgr *      paramsMgr = _controlExec->GetParamsMgr();
-    GUIStateParams * guiP = (GUIStateParams *)paramsMgr->GetParams(GUIStateParams::GetClassType());
+    ParamsMgr *     paramsMgr = _controlExec->GetParamsMgr();
+    GUIStateParams *guiP = (GUIStateParams *)paramsMgr->GetParams(GUIStateParams::GetClassType());
 
     string activeTab = guiP->ActiveTab();
     if (activeTab == RenderEventRouterGUI::GeometryTabName || activeTab == FlowEventRouter::SeedingTabName)

--- a/include/vapor/MyBase.h
+++ b/include/vapor/MyBase.h
@@ -359,7 +359,7 @@ COMMON_API double ran1(long *);
 #endif
 
 #if defined(WIN32)
-    // Note: win32 won't seek beyond 32 bits
+      // Note: win32 won't seek beyond 32 bits
     #define FSEEK64 fseek
 #endif
 

--- a/lib/render/BarbRenderer.cpp
+++ b/lib/render/BarbRenderer.cpp
@@ -191,9 +191,7 @@ int BarbRenderer::_getVarGrid(int ts, int refLevel, int lod, string varName, std
 
     if (!varName.empty()) {
         int rc = DataMgrUtils::GetGrids(_dataMgr, ts, varName, minExts, maxExts, true, &refLevel, &lod, &sg);
-        if (rc < 0) {
-            return (rc);
-        }
+        if (rc < 0) { return (rc); }
         varData[varData.size() - 1] = sg;
     }
 

--- a/lib/render/ContourRenderer.cpp
+++ b/lib/render/ContourRenderer.cpp
@@ -100,7 +100,7 @@ int ContourRenderer::_buildCache()
     ContourParams *cParams = (ContourParams *)GetActiveParams();
     _saveCacheParams();
 
-    vector<VertexData>           vertices;
+    vector<VertexData> vertices;
 
     if (cParams->GetVariableName().empty()) { return 0; }
     vector<double> contours = cParams->GetContourValues(_cacheParams.varName);

--- a/lib/render/ImageRenderer.cpp
+++ b/lib/render/ImageRenderer.cpp
@@ -497,9 +497,7 @@ int ImageRenderer::_getMeshDisplaced(DataMgr *dataMgr, GLsizei width, GLsizei he
         rc = _getMeshDisplacedNoGeo(dataMgr, hgtGrid, width, height, minBox, maxBox);
     }
 
-    if (hgtGrid) {
-        delete hgtGrid;
-    }
+    if (hgtGrid) { delete hgtGrid; }
 
     return (rc);
 }

--- a/lib/render/TwoDDataRenderer.cpp
+++ b/lib/render/TwoDDataRenderer.cpp
@@ -539,9 +539,7 @@ int TwoDDataRenderer::_getMeshUnStructuredHelper(DataMgr *dataMgr, const Grid *g
         }
     }
 
-    if (hgtGrid) {
-        delete hgtGrid;
-    }
+    if (hgtGrid) { delete hgtGrid; }
 
     return (0);
 }

--- a/lib/render/Visualizer.cpp
+++ b/lib/render/Visualizer.cpp
@@ -504,7 +504,7 @@ int Visualizer::_captureImage(std::string path)
     _framebuffer.GetSize(&width, &height);
 
     vector<unsigned char> framebuffer(3 * width * height);
-    int            writeReturn = -1;
+    int                   writeReturn = -1;
     _getPixelData(framebuffer.data());
 
     if (STLUtils::BeginsWith(path, ":RAM:")) {

--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -825,10 +825,7 @@ DerivedCoordVar_CF1D::DerivedCoordVar_CF1D(string derivedVarName, DC *dc, string
     _coordVarInfo = DC::CoordVar(_derivedVarName, units, DC::XType::FLOAT, vector<bool>(1, false), axis, true, vector<string>(1, dimName), "");
 }
 
-int DerivedCoordVar_CF1D::Initialize()
-{
-    return (0);
-}
+int DerivedCoordVar_CF1D::Initialize() { return (0); }
 
 bool DerivedCoordVar_CF1D::GetBaseVarInfo(DC::BaseVar &var) const
 {
@@ -864,7 +861,6 @@ int DerivedCoordVar_CF1D::GetDimLensAtLevel(int level, std::vector<size_t> &dims
 
 int DerivedCoordVar_CF1D::OpenVariableRead(size_t ts, int level, int lod)
 {
-
     DC::FileTable::FileObject *f = new DC::FileTable::FileObject(ts, _derivedVarName, level, lod);
 
     return (_fileTable.AddEntry(f));

--- a/test_apps/smokeTests/testGrid.cpp
+++ b/test_apps/smokeTests/testGrid.cpp
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
 
     std::vector<size_t> dims2d = {opt.dims[X], opt.dims[Y]};
 
-    int rc = EXIT_SUCCESS;
+    int  rc = EXIT_SUCCESS;
     bool regularRC = true;
     bool stretchedRC = true;
     bool layeredRC = true;


### PR DESCRIPTION
Some lines on main are non-conformant with our clang-format spec.  This patches those lines.

Some of these non-conformant lines can be attributed to the pre-push git-hook we're using to enforce clang-format.

There are other lines that I can't explain, such as MainForm.h:170, which was last modified in 2017.  This line should be passing, as it was when we modified the repository to adhere to our spec back in January 2021.