### PR TITLE
Notice Board

### DIFF
--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -99,6 +99,7 @@ AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(
 
         new PSection("Vapor's Startup Settings",
                      {
+                         new PCheckboxHLI<SettingsParams>("Check for and show notices on startup", &SettingsParams::GetAutoCheckForNotices, &SettingsParams::SetAutoCheckForNotices),
                          new PCheckboxHLI<SettingsParams>("Automatically stretch domain", &SettingsParams::GetAutoStretchEnabled, &SettingsParams::SetAutoStretchEnabled),
                          new PCheckbox(SettingsParams::UseAllCoresTag, "Use all available cores for multithreaded tasks"),
                          new PSubGroup({(new PIntegerInputHLI<SettingsParams>("Limit threads to", &SettingsParams::GetNumThreads, &SettingsParams::SetNumThreads))

--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -271,6 +271,10 @@ set (SRCS
     AnimationController.h
     AnimationTab.cpp
     AnimationTab.h
+    CheckForNotices.cpp
+    CheckForNotices.h
+    NoticeBoard.cpp
+    NoticeBoard.h
     ParticleEventRouter.cpp
     ParticleEventRouter.h
 

--- a/apps/vaporgui/CheckForNotices.cpp
+++ b/apps/vaporgui/CheckForNotices.cpp
@@ -55,7 +55,7 @@ void CheckForGHNotices(std::function<void(const std::vector<Notice> &)> callback
                     notice.url = file["download_url"].toString().toStdString();
 
                     if (!STLUtils::Contains(notice.url, "__example-notice")) continue;
-                    
+
                     _noticesToGet.push(notice);
                 }
             } else {

--- a/apps/vaporgui/CheckForNotices.cpp
+++ b/apps/vaporgui/CheckForNotices.cpp
@@ -1,0 +1,99 @@
+#include "CheckForNotices.h"
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QDesktopServices>
+#include <iostream>
+#include <string>
+#include <stack>
+#include <vapor/Version.h>
+#include <vapor/STLUtils.h>
+
+using std::cout;
+using std::endl;
+using std::function;
+using std::string;
+using Wasp::Version;
+
+
+void CheckForGHNotices(std::function<void(const std::vector<Notice> &)> callback)
+{
+    static QNetworkAccessManager *                               manager = nullptr;
+    static std::function<void(const std::vector<Notice> &)> _callback;
+    static std::vector<Notice> _notices;
+    static std::stack<Notice> _noticesToGet;
+    static bool gettingList = true;
+    _callback = callback;
+    
+
+    if (!manager) {
+        manager = new QNetworkAccessManager;
+
+        QObject::connect(manager, &QNetworkAccessManager::finished, manager, [&](QNetworkReply *reply) {
+            if (reply->error()) {
+#ifndef NDEBUG
+                cout << reply->errorString().toStdString() << endl;
+#endif
+                return;
+            }
+            
+#ifdef TESTING_API
+            if (STLUtils::Contains(reply->url().toString().toStdString(), "list.json")) {
+#else
+            if (STLUtils::Contains(reply->url().toString().toStdString(), "api.github.com")) {
+#endif
+                _notices.clear();
+                _noticesToGet = {};
+                QString       content = reply->readAll();
+                QJsonDocument json = QJsonDocument::fromJson(content.toUtf8());
+                QJsonArray    array = json.array();
+                for (const QJsonValue value : array) {
+                    QJsonObject file = value.toObject();
+                    Notice notice;
+                    notice.url = file["download_url"].toString().toStdString();
+                    
+                    if (!STLUtils::Contains(notice.url, "__example-notice"))
+                        _noticesToGet.push(notice);
+                }
+            } else {
+                QString content = reply->readAll();
+                QJsonDocument json = QJsonDocument::fromJson(content.toUtf8());
+                
+#define TIME_FORMAT "yyyy-MM-dd"
+                
+                Notice notice;
+                notice.url = reply->url().toString().toStdString();
+                notice.content = json["content"].toString().toStdString();
+                notice.date = QDate::fromString(json["date"].toString(), TIME_FORMAT);
+                notice.until = QDate::fromString(json["until"].toString(), TIME_FORMAT);
+                
+                auto now = QDate::currentDate();
+                
+                if (notice.date <= now && notice.until >= now)
+                    _notices.push_back(notice);
+            }
+            
+            if (_noticesToGet.empty()) {
+                sort(_notices.begin(), _notices.end(), [](const Notice &a, const Notice &b){ return a.date > b.date; });
+                _callback(_notices);
+            } else {
+                QNetworkRequest req;
+                req.setUrl(QUrl(QString::fromStdString(_noticesToGet.top().url)));
+                _noticesToGet.pop();
+                manager->get(req);
+            }
+        });
+    }
+
+    gettingList = true;
+    QNetworkRequest req;
+#ifdef TESTING_API
+    req.setUrl(QUrl("http://localhost:8000/list.json"));
+#else
+    req.setUrl(QUrl("https://api.github.com/repos/NCAR/VAPOR/contents/share/notices"));
+#endif
+    manager->get(req);
+}

--- a/apps/vaporgui/CheckForNotices.cpp
+++ b/apps/vaporgui/CheckForNotices.cpp
@@ -25,7 +25,6 @@ void CheckForGHNotices(std::function<void(const std::vector<Notice> &)> callback
     static std::function<void(const std::vector<Notice> &)> _callback;
     static std::vector<Notice>                              _notices;
     static std::stack<Notice>                               _noticesToGet;
-    static bool                                             gettingList = true;
     _callback = callback;
 
 
@@ -86,7 +85,6 @@ void CheckForGHNotices(std::function<void(const std::vector<Notice> &)> callback
         });
     }
 
-    gettingList = true;
     QNetworkRequest req;
 #ifdef TESTING_API
     req.setUrl(QUrl("http://localhost:8000/list.json"));

--- a/apps/vaporgui/CheckForNotices.cpp
+++ b/apps/vaporgui/CheckForNotices.cpp
@@ -54,7 +54,9 @@ void CheckForGHNotices(std::function<void(const std::vector<Notice> &)> callback
                     Notice      notice;
                     notice.url = file["download_url"].toString().toStdString();
 
-                    if (!STLUtils::Contains(notice.url, "__example-notice")) _noticesToGet.push(notice);
+                    if (!STLUtils::Contains(notice.url, "__example-notice")) continue;
+                    
+                    _noticesToGet.push(notice);
                 }
             } else {
                 QString       content = reply->readAll();
@@ -89,7 +91,7 @@ void CheckForGHNotices(std::function<void(const std::vector<Notice> &)> callback
 #ifdef TESTING_API
     req.setUrl(QUrl("http://localhost:8000/list.json"));
 #else
-    req.setUrl(QUrl("https://api.github.com/repos/NCAR/VAPOR/contents/share/notices"));
+    req.setUrl(QUrl("https://api.github.com/repos/NCAR/VAPOR-SupportPage/contents/notices"));
 #endif
     manager->get(req);
 }

--- a/apps/vaporgui/CheckForNotices.h
+++ b/apps/vaporgui/CheckForNotices.h
@@ -8,7 +8,7 @@
 struct Notice {
     std::string url;
     std::string content;
-    
+
     QDate date;
     QDate until;
 };

--- a/apps/vaporgui/CheckForNotices.h
+++ b/apps/vaporgui/CheckForNotices.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <functional>
+#include <vector>
+#include <QDateTime>
+
+struct Notice {
+    std::string url;
+    std::string content;
+    
+    QDate date;
+    QDate until;
+};
+
+//! Uses the GitHub API to check for any notices which are json files on the main branch in share/notices.
+//! There is an example file there which specifies the format and features.
+
+void CheckForGHNotices(std::function<void(const std::vector<Notice> &)> callback);

--- a/apps/vaporgui/CheckForUpdate.cpp
+++ b/apps/vaporgui/CheckForUpdate.cpp
@@ -27,7 +27,9 @@ void CheckForUpdate(function<void(bool updateAvailable, UpdateInfo info)> callba
 
         QObject::connect(manager, &QNetworkAccessManager::finished, manager, [&](QNetworkReply *reply) {
             if (reply->error()) {
+#ifndef NDEBUG
                 cout << reply->errorString().toStdString() << endl;
+#endif
                 UpdateInfo info;
                 info.error = true;
                 _callback(false, info);

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -85,6 +85,8 @@
 #include "ParamsWidgetDemo.h"
 #include "AppSettingsMenu.h"
 #include "CheckForUpdate.h"
+#include "NoticeBoard.h"
+#include "CheckForNotices.h"
 
 #include <QProgressDialog>
 #include <QProgressBar>
@@ -479,8 +481,10 @@ MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, Q
     _controlExec->SetSaveStateEnabled(true);
     _controlExec->RebaseStateSave();
 
-    if (interactive && GetSettingsParams()->GetValueLong(SettingsParams::AutoCheckForUpdatesTag, true)) CheckForUpdates();
+    if (interactive && GetSettingsParams()->GetAutoCheckForUpdates()) CheckForUpdates();
+    if (interactive && GetSettingsParams()->GetAutoCheckForNotices()) CheckForNotices();
 }
+
 
 int MainForm::RenderAndExit(int start, int end, const std::string &baseFile, int width, int height)
 {
@@ -594,6 +598,28 @@ void MainForm::CheckForUpdates()
 
         if (!cb->isChecked()) {
             GetSettingsParams()->SetValueLong(SettingsParams::AutoCheckForUpdatesTag, "", false);
+            GetSettingsParams()->SaveSettings();
+        }
+    });
+}
+
+
+void MainForm::CheckForNotices()
+{
+#ifndef NDEBUG
+    return;    // Don't check for notices in debug builds
+#endif
+    
+    CheckForGHNotices([this](const std::vector<Notice> &notices)
+    {
+        if (notices.empty())
+            return;
+        
+        NoticeBoard board(notices);
+        board.exec();
+        
+        if (board.WasDisableCheckingRequested()) {
+            GetSettingsParams()->SetAutoCheckForNotices(false);
             GetSettingsParams()->SaveSettings();
         }
     });

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -609,15 +609,13 @@ void MainForm::CheckForNotices()
 #ifndef NDEBUG
     return;    // Don't check for notices in debug builds
 #endif
-    
-    CheckForGHNotices([this](const std::vector<Notice> &notices)
-    {
-        if (notices.empty())
-            return;
-        
+
+    CheckForGHNotices([this](const std::vector<Notice> &notices) {
+        if (notices.empty()) return;
+
         NoticeBoard board(notices);
         board.exec();
-        
+
         if (board.WasDisableCheckingRequested()) {
             GetSettingsParams()->SetAutoCheckForNotices(false);
             GetSettingsParams()->SaveSettings();

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -317,6 +317,7 @@ private:
     bool                   determineDatasetFormat(const std::vector<std::string> &paths, std::string *fmt) const;
 
     void CheckForUpdates();
+    void CheckForNotices();
 
     bool isOpenGLContextActive() const;
 

--- a/apps/vaporgui/NoticeBoard.cpp
+++ b/apps/vaporgui/NoticeBoard.cpp
@@ -9,22 +9,21 @@
 #include "VPushButton.h"
 #include "VGroup.h"
 
-NoticeBoard::NoticeBoard(const std::vector<Notice> &notices)
-: _notices(notices)
+NoticeBoard::NoticeBoard(const std::vector<Notice> &notices) : _notices(notices)
 {
     setWindowTitle("Notice Board");
     setBaseSize(500, 500);
     auto *layout = new QVBoxLayout;
     setLayout(layout);
-    
+
     _browser = new QTextBrowser;
     layout->addWidget(_browser);
     _browser->setOpenExternalLinks(true);
-    
+
     auto *check = new QCheckBox("Don't check for notices on startup");
     layout->addWidget(check);
-    connect(check, &QCheckBox::stateChanged, this, [this](int b){ this->_wasDisableCheckingRequested = b; });
-    
+    connect(check, &QCheckBox::stateChanged, this, [this](int b) { this->_wasDisableCheckingRequested = b; });
+
     // Qt provides a "QDialogButtonBox" but it is buggy.
     // For example the following:
     // auto *disableButton = box->addButton("Check", QDialogButtonBox::RejectRole);
@@ -37,36 +36,36 @@ NoticeBoard::NoticeBoard(const std::vector<Notice> &notices)
     // [*Check*] [Close] [>] [<]
     // While in itself, the above behaviour is unintuative and confusing,
     // the kicker is that the behavior is not consistent between systems.
-    
+
     auto *buttonsWidget = new QWidget;
     auto *buttons = new QHBoxLayout;
     buttons->setMargin(0);
     buttonsWidget->setLayout(buttons);
     layout->addWidget(buttonsWidget);
-    
+
     auto *prev = new QPushButton("<");
     auto *disp = new QLabel("1/2");
     auto *next = new QPushButton(">");
     auto *clos = new QPushButton("Close");
     clos->setDefault(true);
     _numberDisplay = disp;
-    
+
     buttons->addWidget(prev);
     buttons->addWidget(disp);
     buttons->addWidget(next);
     buttons->addStretch();
     buttons->addWidget(clos);
-    
+
     connect(clos, &QPushButton::clicked, this, &QWidget::close);
-    connect(prev, &QPushButton::clicked, this, [this](){ showNotice(_displayedNotice-1); });
-    connect(next, &QPushButton::clicked, this, [this](){ showNotice(_displayedNotice+1); });
-    
+    connect(prev, &QPushButton::clicked, this, [this]() { showNotice(_displayedNotice - 1); });
+    connect(next, &QPushButton::clicked, this, [this]() { showNotice(_displayedNotice + 1); });
+
     if (notices.size() == 1) {
         prev->hide();
         disp->hide();
         next->hide();
     }
-    
+
     showNotice(0);
 }
 
@@ -75,8 +74,8 @@ void NoticeBoard::showNotice(int i)
 {
     if (i < 0) i = _notices.size() - 1;
     if (i >= _notices.size()) i = 0;
-    
+
     _browser->setText(QString::fromStdString(_notices[i].content));
-    _numberDisplay->setText(QString("%1/%2").arg(i+1).arg(_notices.size()));
+    _numberDisplay->setText(QString("%1/%2").arg(i + 1).arg(_notices.size()));
     _displayedNotice = i;
 }

--- a/apps/vaporgui/NoticeBoard.cpp
+++ b/apps/vaporgui/NoticeBoard.cpp
@@ -1,0 +1,82 @@
+#include "NoticeBoard.h"
+#include "CheckForNotices.h"
+#include <QVBoxLayout>
+#include <QTextBrowser>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QCheckbox>
+#include <cassert>
+#include "VPushButton.h"
+#include "VGroup.h"
+
+NoticeBoard::NoticeBoard(const std::vector<Notice> &notices)
+: _notices(notices)
+{
+    setWindowTitle("Notice Board");
+    setBaseSize(500, 500);
+    auto *layout = new QVBoxLayout;
+    setLayout(layout);
+    
+    _browser = new QTextBrowser;
+    layout->addWidget(_browser);
+    _browser->setOpenExternalLinks(true);
+    
+    auto *check = new QCheckBox("Don't check for notices on startup");
+    layout->addWidget(check);
+    connect(check, &QCheckBox::stateChanged, this, [this](int b){ this->_wasDisableCheckingRequested = b; });
+    
+    // Qt provides a "QDialogButtonBox" but it is buggy.
+    // For example the following:
+    // auto *disableButton = box->addButton("Check", QDialogButtonBox::RejectRole);
+    // box->addButton(QDialogButtonBox::StandardButton::Close);
+    // box->addButton("<", QDialogButtonBox::YesRole);
+    // box->addButton(">", QDialogButtonBox::YesRole);
+    // Results in:
+    // [*Close*] [Check] [>] [<]
+    // While if you swap the first 2 lines you get:
+    // [*Check*] [Close] [>] [<]
+    // While in itself, the above behaviour is unintuative and confusing,
+    // the kicker is that the behavior is not consistent between systems.
+    
+    auto *buttonsWidget = new QWidget;
+    auto *buttons = new QHBoxLayout;
+    buttons->setMargin(0);
+    buttonsWidget->setLayout(buttons);
+    layout->addWidget(buttonsWidget);
+    
+    auto *prev = new QPushButton("<");
+    auto *disp = new QLabel("1/2");
+    auto *next = new QPushButton(">");
+    auto *clos = new QPushButton("Close");
+    clos->setDefault(true);
+    _numberDisplay = disp;
+    
+    buttons->addWidget(prev);
+    buttons->addWidget(disp);
+    buttons->addWidget(next);
+    buttons->addStretch();
+    buttons->addWidget(clos);
+    
+    connect(clos, &QPushButton::clicked, this, &QWidget::close);
+    connect(prev, &QPushButton::clicked, this, [this](){ showNotice(_displayedNotice-1); });
+    connect(next, &QPushButton::clicked, this, [this](){ showNotice(_displayedNotice+1); });
+    
+    if (notices.size() == 1) {
+        prev->hide();
+        disp->hide();
+        next->hide();
+    }
+    
+    showNotice(0);
+}
+
+
+void NoticeBoard::showNotice(int i)
+{
+    if (i < 0) i = _notices.size() - 1;
+    if (i >= _notices.size()) i = 0;
+    
+    _browser->setText(QString::fromStdString(_notices[i].content));
+    _numberDisplay->setText(QString("%1/%2").arg(i+1).arg(_notices.size()));
+    _displayedNotice = i;
+}

--- a/apps/vaporgui/NoticeBoard.cpp
+++ b/apps/vaporgui/NoticeBoard.cpp
@@ -4,7 +4,7 @@
 #include <QTextBrowser>
 #include <QDialogButtonBox>
 #include <QLabel>
-#include <QCheckbox>
+#include <QCheckBox>
 #include <cassert>
 #include "VPushButton.h"
 #include "VGroup.h"

--- a/apps/vaporgui/NoticeBoard.h
+++ b/apps/vaporgui/NoticeBoard.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QDialog>
+
+struct Notice;
+class QTextBrowser;
+class QLabel;
+
+class NoticeBoard : public QDialog {
+    bool _wasDisableCheckingRequested = false;
+    const std::vector<Notice> _notices;
+    int _displayedNotice;
+    
+    QTextBrowser *_browser;
+    QLabel *_numberDisplay;
+    
+    void showNotice(int i);
+    
+public:
+    NoticeBoard(const std::vector<Notice> &notices);
+    bool WasDisableCheckingRequested() const { return _wasDisableCheckingRequested; }
+};

--- a/apps/vaporgui/NoticeBoard.h
+++ b/apps/vaporgui/NoticeBoard.h
@@ -7,15 +7,15 @@ class QTextBrowser;
 class QLabel;
 
 class NoticeBoard : public QDialog {
-    bool _wasDisableCheckingRequested = false;
+    bool                      _wasDisableCheckingRequested = false;
     const std::vector<Notice> _notices;
-    int _displayedNotice;
-    
+    int                       _displayedNotice;
+
     QTextBrowser *_browser;
-    QLabel *_numberDisplay;
-    
+    QLabel *      _numberDisplay;
+
     void showNotice(int i);
-    
+
 public:
     NoticeBoard(const std::vector<Notice> &notices);
     bool WasDisableCheckingRequested() const { return _wasDisableCheckingRequested; }

--- a/apps/vaporgui/SettingsParams.cpp
+++ b/apps/vaporgui/SettingsParams.cpp
@@ -69,6 +69,7 @@ const string SettingsParams::_settingsNeedsWriteTag = "SettingsNeedsWrite";
 
 const string SettingsParams::UseAllCoresTag = "UseAllCoresTag";
 const string SettingsParams::AutoCheckForUpdatesTag = "AutoCheckForUpdatesTag";
+const string SettingsParams::AutoCheckForNoticesTag = "AutoCheckForNoticesTag";
 
 //
 // Register class with object factory!!!
@@ -404,8 +405,9 @@ void SettingsParams::SetFidelityDefault2D(long lodDef, long refDef)
 }
 
 void SettingsParams::SetAutoCheckForUpdates(bool b) { SetValueLong(AutoCheckForUpdatesTag, "", b); }
-
 bool SettingsParams::GetAutoCheckForUpdates() const { return GetValueLong(AutoCheckForUpdatesTag, true); }
+void SettingsParams::SetAutoCheckForNotices(bool b) { SetValueLong(AutoCheckForNoticesTag, "", b); }
+bool SettingsParams::GetAutoCheckForNotices() const { return GetValueLong(AutoCheckForNoticesTag, true); }
 
 bool SettingsParams::LoadFromSettingsFile()
 {
@@ -457,6 +459,7 @@ void SettingsParams::Init()
     SetAutoStretchEnabled(true);
     SetValueLong(UseAllCoresTag, "", true);
     SetValueLong(AutoCheckForUpdatesTag, "", true);
+    SetValueLong(AutoCheckForNoticesTag, "", true);
     SetNumThreads(4);
     SetCacheMB(defaultCacheSize);
 

--- a/apps/vaporgui/SettingsParams.h
+++ b/apps/vaporgui/SettingsParams.h
@@ -129,9 +129,12 @@ public:
 
     void SetAutoCheckForUpdates(bool b);
     bool GetAutoCheckForUpdates() const;
+    void SetAutoCheckForNotices(bool b);
+    bool GetAutoCheckForNotices() const;
 
     static const string UseAllCoresTag;
     static const string AutoCheckForUpdatesTag;
+    static const string AutoCheckForNoticesTag;
 
     bool LoadFromSettingsFile();
 

--- a/share/notices/__example-notice.json
+++ b/share/notices/__example-notice.json
@@ -1,0 +1,15 @@
+{
+    "_comment-1": "This is an example notice. It will be ingored by Vapor",
+
+    "_comment-2": "This is the date at which the notice will be displayed to users",
+    "_comment-3": "The time format is yyyy-MM-dd by Qt's specification",
+	"date": "2021-06-01",
+
+    "_comment-4": "This is the date at which the notice will no longer be displayed to users",
+	"until": "2021-09-27",
+
+
+    "_comment-5": "This is the content of the notice. It uses a subset of HTML that is supported by QTextBrowser",
+
+	"content": "<br> <center><h1>Notice</h1></center> <hr> <br> <h2>Vapor's homepage: <a href='http://www.vapor.ucar.edu'>Link</a></h2>"
+}


### PR DESCRIPTION
In [NCAR/VAPOR-SupportPage](https://github.com/NCAR/VAPOR-SupportPage)/notices folder, notices can be placed in JSON files. These files contain the content of the notice, a start date at which the notice will be displayed, and an end date at which the notice will stop being displayed. There is an example notice there already explaining the format (Vapor will ignore this notice). The content supports a subset of HTML and allows for creating posts similar to that on GitHub. It also allows for integrating external links. Simply placing a file in [NCAR/VAPOR-SupportPage](https://github.com/NCAR/VAPOR-SupportPage)/notices in the master branch will have it be displayed on startup of Vapor as it will query the files from GitHub in the background after the application launches and once all the files have been queried, it will display them to the user in a popup. If there are multiple notices, Vapor will sort them from newest to oldest and display a navigation toolbar. The popup provides a checkbox which disables the feature (which can also be done in the settings panel).

The PR is ready for deployment so there are a few steps to pull the example notices from GitHub and display it:
1. Change build configuration to Release
2. Disable the check to ignore `__example-notice` in `CheckForGHNotices()`


![SS](https://user-images.githubusercontent.com/2772687/123381950-980baf00-d54e-11eb-990c-dbd7b5438cc8.png)

Fix #2747