### PR TITLE
Fixes #2784 - testGrid reports error yet it still passes CircleCI 

### DIFF
--- a/test_apps/smokeTests/gridTools.cpp
+++ b/test_apps/smokeTests/gridTools.cpp
@@ -191,7 +191,7 @@ bool CompareIndexToCoords(VAPoR::Grid *grid,
 
     rms = sqrt(sum / (x * y * z));
 
-    if ((! Wasp::NearlyEqual(rms, 0.0)) || disagreements > 0) rc = false;
+    if ((!Wasp::NearlyEqual(rms, 0.0)) || disagreements > 0) rc = false;
     return rc;
 }
 

--- a/test_apps/smokeTests/gridTools.cpp
+++ b/test_apps/smokeTests/gridTools.cpp
@@ -191,7 +191,7 @@ bool CompareIndexToCoords(VAPoR::Grid *grid,
 
     rms = sqrt(sum / (x * y * z));
 
-    if (rms != 0 || disagreements > 0) rc = false;
+    if ((! Wasp::NearlyEqual(rms, 0.0)) || disagreements > 0) rc = false;
     return rc;
 }
 

--- a/test_apps/smokeTests/smokeTests.py
+++ b/test_apps/smokeTests/smokeTests.py
@@ -198,6 +198,8 @@ def main():
     print()
     makeBaseline = args.makeBaseline
 
+    rc = 0
+
     if ( args.makeBaseline == False and makeBaseline == True ): 
         print( "    Warning: Some or all baseline files for running DataMgr testswere missing.  "
                "    These files are needed as comparisons for the results of the current series "
@@ -212,7 +214,7 @@ def main():
         if ( testGrid(grid) != 0):
             print ("  See artifact file " + grid + ".txt or " + resultsDir + grid + ".txt for mismatches")
             print ("  Failed assertions, if any, are shown above.\n" )
-            sys.exit(-1)
+            rc = 1
  
     for dataType, dataFile in dataMgrs.items():
         baselineFile = resultsDir + dataType + "_baseline.txt"
@@ -223,10 +225,11 @@ def main():
     dataMgr = testDataMgrs( makeBaseline )
     if ( dataMgr != 0 ):
         print( "DataMgr tests failed.  Results are not identical to the baseline." )
-        exit(-1);
+        rc = 1
     else:
         print( "DataMgr tests passed" )
-        exit(0);
+
+    sys.exit(rc)
 
 if __name__ == "__main__":
     main()

--- a/test_apps/smokeTests/smokeTests.py
+++ b/test_apps/smokeTests/smokeTests.py
@@ -209,10 +209,10 @@ def main():
         os.mkdir( resultsDir )
 
     for grid in gridSizes:
-        if ( testGrid(grid) > 0):
+        if ( testGrid(grid) != 0):
             print ("  See artifact file " + grid + ".txt or " + resultsDir + grid + ".txt for mismatches")
             print ("  Failed assertions, if any, are shown above.\n" )
-            #sys.exit(1)
+            sys.exit(-1)
  
     for dataType, dataFile in dataMgrs.items():
         baselineFile = resultsDir + dataType + "_baseline.txt"


### PR DESCRIPTION
Fixes #2764 

This draft PR partially address #2764; it replaces an exact floating point compare (which should not have been used) with an approximate floating point compare. This prevents the 'testGrid' from reporting an error. However, there is still a problem with the python script that calls testGrid, failing to detect the non-zero exit code.