### PR TITLE
Issue2739 - Enable OMP on circleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,6 @@ jobs:
           name: make release with omp
           command: |
             cd /root/project/build
-            #cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
             cmake -DBUILD_TEST_APPS=ON ..
             make -j7 2>&1 | tee /tmp/debugOutput.txt
             make clean
-            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
             make clean
             cmake -DBUILD_TEST_APPS=ON -DCMAKE_BUILD_TYPE=Release ..
             make -j7 2>&1 | tee /tmp/releaseOutput.txt
             make clean
-            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
 
       - store_artifacts:
@@ -184,13 +184,13 @@ jobs:
             cmake3 -DBUILD_TEST_APPS=ON ..
             make -j7 2>&1 | tee /tmp/debugOutput.txt
             make clean
-            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
             make clean
             cmake -DBUILD_TEST_APPS=ON -DCMAKE_BUILD_TYPE=Release ..
             make -j7 2>&1 | tee /tmp/releaseOutput.txt
             make clean
-            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,14 +31,26 @@ jobs:
             cmake -DBUILD_TEST_APPS=ON ..
             make -j7 2>&1 | tee /tmp/debugOutput.txt
             make clean
+            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
+            make clean
             cmake -DBUILD_TEST_APPS=ON -DCMAKE_BUILD_TYPE=Release ..
             make -j7 2>&1 | tee /tmp/releaseOutput.txt
+            make clean
+            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
 
       - store_artifacts:
           path: /tmp/debugOutput.txt
 
       - store_artifacts:
+          path: /tmp/debugOutputWithOMP.txt
+
+      - store_artifacts:
           path: /tmp/releaseOutput.txt
+
+      - store_artifacts:
+          path: /tmp/releaseOutputWithOMP.txt
 
       - run:
           name: Smoke test
@@ -123,7 +135,7 @@ jobs:
           name: make installer
           command: |
             cd build
-            cmake -DCMAKE_BUILD_TYPE:String=Release -DDIST_INSTALLER:string=ON ..
+            cmake -DCMAKE_BUILD_TYPE:String=Release -DDIST_INSTALLER:string=ON -DUSE_OMP=ON ..
             make -j7
             make installer
             for f in VAPOR3-*.sh ; do mv "$f" "${f/Linux/Ubuntu18-Weekly}" ; done
@@ -168,19 +180,30 @@ jobs:
       - run:
           name: cmake3 and make
           command: |
-            ls -lrth /usr/local/VAPOR-Deps
             cd /root/project/build
             cmake3 -DBUILD_TEST_APPS=ON ..
             make -j7 2>&1 | tee /tmp/debugOutput.txt
             make clean
+            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
+            make clean
             cmake -DBUILD_TEST_APPS=ON -DCMAKE_BUILD_TYPE=Release ..
             make -j7 2>&1 | tee /tmp/releaseOutput.txt
+            make clean
+            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
 
       - store_artifacts:
           path: /tmp/debugOutput.txt
 
       - store_artifacts:
+          path: /tmp/debugOutputWithOMP.txt
+
+      - store_artifacts:
           path: /tmp/releaseOutput.txt
+      
+      - store_artifacts:
+          path: /tmp/releaseOutputWithOMP.txt
 
       - run:
           name: check for Debug warnings
@@ -213,7 +236,7 @@ jobs:
           name: cmake3 and make
           command: |
             cd build
-            cmake3 -DCMAKE_BUILD_TYPE:String=Release -DDIST_INSTALLER:string=ON ..
+            cmake3 -DCMAKE_BUILD_TYPE:String=Release -DDIST_INSTALLER:string=ON -DUSE_OMP=ON ..
             make
             make installer
             for f in VAPOR3-*.sh ; do mv "$f" "${f/Linux/CentOS7-Weekly}" ; done
@@ -324,7 +347,7 @@ jobs:
             cd build
             git pull
             git checkout $CIRCLE_BRANCH
-            /usr/local/bin/cmake -DCPACK_BINARY_DRAGNDROP=ON -DCMAKE_BUILD_TYPE:String=Release -DDIST_INSTALLER:string=ON ..
+            /usr/local/bin/cmake -DCPACK_BINARY_DRAGNDROP=ON -DCMAKE_BUILD_TYPE:String=Release -DDIST_INSTALLER:string=ON -DUSE_OMP=ON ..
             make
             make installer
             for f in VAPOR3-*.dmg ; do mv "$f" "${f/Darwin/Darwin-Weekly}" ; done
@@ -489,10 +512,10 @@ workflows:
       - build_ubuntu18_installer
       - build_centos7_installer
       - build_osx_installer
-#      - build_win10_installer
+      - build_win10_installer
       - release_on_github:
           requires:
             - build_ubuntu18_installer
             - build_centos7_installer
             - build_osx_installer
-#            - build_win10_installer
+            - build_win10_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,29 +25,41 @@ jobs:
       - checkout
 
       - run:
-          name: cmake and make
+          name: make debug
           command: |
             cd build
             cmake -DBUILD_TEST_APPS=ON ..
             make -j7 2>&1 | tee /tmp/debugOutput.txt
             make clean
-            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
-            make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
-            make clean
-            cmake -DBUILD_TEST_APPS=ON -DCMAKE_BUILD_TYPE=Release ..
-            make -j7 2>&1 | tee /tmp/releaseOutput.txt
-            make clean
-            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
-            make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
-
+      
       - store_artifacts:
           path: /tmp/debugOutput.txt
 
+      - run:
+          name: make debug with omp
+          command: |
+            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
+            make clean
+      
       - store_artifacts:
           path: /tmp/debugOutputWithOMP.txt
 
+      - run:
+          name: make release
+          command: |
+            cmake -DBUILD_TEST_APPS=ON -DCMAKE_BUILD_TYPE=Release ..
+            make -j7 2>&1 | tee /tmp/releaseOutput.txt
+            make clean
+      
       - store_artifacts:
           path: /tmp/releaseOutput.txt
+
+      - run:
+          name: make release with omp
+          command: |
+            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
 
       - store_artifacts:
           path: /tmp/releaseOutputWithOMP.txt
@@ -178,30 +190,42 @@ jobs:
       - checkout
 
       - run:
-          name: cmake3 and make
+          name: make debug
           command: |
             cd /root/project/build
             cmake3 -DBUILD_TEST_APPS=ON ..
             make -j7 2>&1 | tee /tmp/debugOutput.txt
             make clean
-            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
-            make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
-            make clean
-            cmake -DBUILD_TEST_APPS=ON -DCMAKE_BUILD_TYPE=Release ..
-            make -j7 2>&1 | tee /tmp/releaseOutput.txt
-            make clean
-            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
-            make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
-
+      
       - store_artifacts:
           path: /tmp/debugOutput.txt
+
+      - run:
+          name: make debug with omp
+          command: |
+            cmake3 -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
+            make clean
 
       - store_artifacts:
           path: /tmp/debugOutputWithOMP.txt
 
+      - run:
+          name: make release
+          command: |
+            cmake -DBUILD_TEST_APPS=ON -DCMAKE_BUILD_TYPE=Release ..
+            make -j7 2>&1 | tee /tmp/releaseOutput.txt
+            make clean
+
       - store_artifacts:
           path: /tmp/releaseOutput.txt
       
+      - run:
+          name: make release with omp
+          command: |
+            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
+
       - store_artifacts:
           path: /tmp/releaseOutputWithOMP.txt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           name: make debug with omp
           command: |
             cd /root/project/build
-            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
             make clean
       
@@ -61,7 +61,7 @@ jobs:
           name: make release with omp
           command: |
             cd /root/project/build
-            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
 
       - store_artifacts:
@@ -207,7 +207,7 @@ jobs:
           name: make debug with omp
           command: |
             cd /root/project/build
-            cmake3 -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            cmake3 -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
             make clean
 
@@ -229,7 +229,8 @@ jobs:
           name: make release with omp
           command: |
             cd /root/project/build
-            cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            #cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
+            cmake -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,29 @@ jobs:
             fi
 
       - run:
+          name: check for Debug OMP warnings
+          command: |
+            if grep -q warning /tmp/debugOutputWithOMP.txt; then
+               cat /tmp/debugOutput.txt
+               exit -1
+            else
+               exit 0
+            fi
+
+      - run:
           name: check for Release warnings
           command: |
             if grep -q warning /tmp/releaseOutput.txt; then
+               cat /tmp/releaseOutput.txt
+               exit -1
+            else
+               exit 0
+            fi
+
+      - run:
+          name: check for Release OMP warnings
+          command: |
+            if grep -q warning /tmp/releaseOutputWithOMP.txt; then
                cat /tmp/releaseOutput.txt
                exit -1
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           name: make debug
           command: |
-            cd build
+            cd /root/project/build
             cmake -DBUILD_TEST_APPS=ON ..
             make -j7 2>&1 | tee /tmp/debugOutput.txt
             make clean
@@ -38,6 +38,7 @@ jobs:
       - run:
           name: make debug with omp
           command: |
+            cd /root/project/build
             cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
             make clean
@@ -48,6 +49,7 @@ jobs:
       - run:
           name: make release
           command: |
+            cd /root/project/build
             cmake -DBUILD_TEST_APPS=ON -DCMAKE_BUILD_TYPE=Release ..
             make -j7 2>&1 | tee /tmp/releaseOutput.txt
             make clean
@@ -58,6 +60,7 @@ jobs:
       - run:
           name: make release with omp
           command: |
+            cd /root/project/build
             cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
 
@@ -203,6 +206,7 @@ jobs:
       - run:
           name: make debug with omp
           command: |
+            cd /root/project/build
             cmake3 -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/debugOutputWithOMP.txt
             make clean
@@ -213,6 +217,7 @@ jobs:
       - run:
           name: make release
           command: |
+            cd /root/project/build
             cmake -DBUILD_TEST_APPS=ON -DCMAKE_BUILD_TYPE=Release ..
             make -j7 2>&1 | tee /tmp/releaseOutput.txt
             make clean
@@ -223,6 +228,7 @@ jobs:
       - run:
           name: make release with omp
           command: |
+            cd /root/project/build
             cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_FLAGS=-I/usr/local/opt/llvm/include -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/opt/llvm/lib -DBUILD_TEST_APPS=ON -DUSE_OMP=ON ..
             make -j7 2>&1 | tee /tmp/releaseOutputWithOMP.txt
 

--- a/lib/vdc/QuadTreeRectangleP.cpp
+++ b/lib/vdc/QuadTreeRectangleP.cpp
@@ -20,7 +20,6 @@ QuadTreeRectangleP::QuadTreeRectangleP(float left, float top, float right, float
 #pragma omp parallel
     {
         nthreads = omp_get_num_threads();
-        printf("num threads = %d\n", nthreads);
     }
 
     // We split the quadtree along the X-axis to create one subtree for
@@ -45,7 +44,6 @@ QuadTreeRectangleP::QuadTreeRectangleP(size_t max_depth, size_t reserve_size) : 
 #pragma omp parallel
     {
         nthreads = omp_get_num_threads();
-        printf("num threads = %d\n", nthreads);
     }
 
     float bin_width = (1.0 - 0.0) / ((float)nthreads);

--- a/test_apps/smokeTests/smokeTests.py
+++ b/test_apps/smokeTests/smokeTests.py
@@ -127,6 +127,7 @@ def testGrid( grid ):
         print( "  Test failed with exit code " + str(programOutput.returncode) )
     else:
         print( "  Test passed\n" )
+        print( programOutput )
 
     return rc
 

--- a/test_apps/smokeTests/smokeTests.py
+++ b/test_apps/smokeTests/smokeTests.py
@@ -127,7 +127,6 @@ def testGrid( grid ):
         print( "  Test failed with exit code " + str(programOutput.returncode) )
     else:
         print( "  Test passed\n" )
-        print( programOutput )
 
     return rc
 

--- a/test_apps/smokeTests/testResults/cf_baseline.txt
+++ b/test_apps/smokeTests/testResults/cf_baseline.txt
@@ -61,4 +61,4 @@ Time Coordinates:
 
 Time coordinate variable name: time
 Number of time steps: 1
-Elapsed time: 0.159113
+Elapsed time: 0.337482

--- a/test_apps/smokeTests/testResults/vdc_baseline.txt
+++ b/test_apps/smokeTests/testResults/vdc_baseline.txt
@@ -95,7 +95,6 @@ Compression Info for variable CANWAT:
     Refinement Levels:  4
     Compression Ratios: 62 21 4 1
 
-num threads = 1
 Grid test for 2D variable CANWAT:
     # Dimensions:       2
     Dimension Lengths:  315 309
@@ -110,7 +109,6 @@ Compression Info for variable P:
     Refinement Levels:  4
     Compression Ratios: 500 100 10 1
 
-num threads = 1
 Grid test for 3D variable P:
     # Dimensions:       3
     Dimension Lengths:  315 309 34
@@ -151,4 +149,4 @@ Time Coordinates:
 
 Time coordinate variable name: Time
 Number of time steps: 1
-Elapsed time: 17.3104
+Elapsed time: 73.9926

--- a/test_apps/smokeTests/testResults/wrf_baseline.txt
+++ b/test_apps/smokeTests/testResults/wrf_baseline.txt
@@ -95,7 +95,6 @@ Compression Info for variable CANWAT:
     Refinement Levels:  1
     Compression Ratios: 1
 
-num threads = 1
 Grid test for 2D variable CANWAT:
     # Dimensions:       2
     Dimension Lengths:  315 309
@@ -110,7 +109,6 @@ Compression Info for variable P:
     Refinement Levels:  1
     Compression Ratios: 1
 
-num threads = 1
 Grid test for 3D variable P:
     # Dimensions:       3
     Dimension Lengths:  315 309 34
@@ -151,4 +149,4 @@ Time Coordinates:
 
 Time coordinate variable name: Time
 Number of time steps: 1
-Elapsed time: 16.9153
+Elapsed time: 73.9334


### PR DESCRIPTION
This adds OMP compile and warning tests in debug and release mode to CircleCI.

We will now test the following
- Debug compilation with and without OMP
- Debug warnings with and without OMP
- Release compilation with and without OMP
- Release warnings with and without OMP

Note:  This PR also removes a printf statement that slipped into the repo, and resets the smokeTest baseline files. to omit the print output.

Note: #2739 asks for us to enable OpenMP for our CI tests, as well as our builds.  This PR only applies CI tests.  Our installer builds are done on a different branch, named _installers_.  I'll file a separate PR for that branch that enables OpenMP on OSX, Ubuntu, and CentOS.