### PR TITLE
Partially addresses Issue 2765 - complete refactoring of Grid class

### DIFF
--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -94,11 +94,9 @@ public:
     //! the constructor. If the parameter has less than 3 values, then
     //! number 1 will be filled.
     //!
-    DimsType GetDimensions() const
+    const DimsType &GetDimensions() const
     {
-        auto tmp = DimsType{1, 1, 1};
-        std::copy(_dims.begin(), _dims.end(), tmp.begin());
-        return tmp;
+        return _dims;
     }
 
     //! Return the useful number of dimensions of grid connectivity array
@@ -106,7 +104,7 @@ public:
     //! \param[out] dims The number of values of \p dims parameter provided to
     //! the constructor.
     //!
-    size_t GetNumDimensions() const { return _dims.size(); }
+    size_t GetNumDimensions() const { return _nDims; }
 
     //! Return the dimensions of the specified coordinate variable
     //!
@@ -1229,7 +1227,8 @@ protected:
     }
 
 private:
-    std::vector<size_t>  _dims;                   // dimensions of grid arrays
+    DimsType              _dims;                   // dimensions of grid arrays
+    size_t               _nDims;
     DimsType             _bs = {{1, 1, 1}};       // dimensions of each block
     DimsType             _bdims = {{1, 1, 1}};    // dimensions (specified in blocks) of ROI
     std::vector<size_t>  _bsDeprecated;           // legacy API

--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -94,10 +94,7 @@ public:
     //! the constructor. If the parameter has less than 3 values, then
     //! number 1 will be filled.
     //!
-    const DimsType &GetDimensions() const
-    {
-        return _dims;
-    }
+    const DimsType &GetDimensions() const { return _dims; }
 
     //! Return the useful number of dimensions of grid connectivity array
     //!
@@ -1227,7 +1224,7 @@ protected:
     }
 
 private:
-    DimsType              _dims;                   // dimensions of grid arrays
+    DimsType             _dims;    // dimensions of grid arrays
     size_t               _nDims;
     DimsType             _bs = {{1, 1, 1}};       // dimensions of each block
     DimsType             _bdims = {{1, 1, 1}};    // dimensions (specified in blocks) of ROI

--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -85,7 +85,7 @@ public:
     //!
     Grid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const std::vector<float *> &blks, size_t topology_dimension);
 
-    Grid() = default;
+    Grid();
     virtual ~Grid() = default;
 
     //! Return the dimensions of grid connectivity array

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -21,6 +21,12 @@
 using namespace std;
 using namespace VAPoR;
 
+Grid::Grid()
+{
+    _dims = {1, 1, 1};
+    _nDims = 0;
+}
+
 Grid::Grid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const std::vector<float *> &blks, size_t topology_dimension)
 {
     VAssert(dims.size() == bs.size());

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -44,6 +44,7 @@ Grid::Grid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const
     VAssert(blks.size() == 0 ||    // dataless
             blks.size() == std::accumulate(_bdims.begin(), _bdims.end(), 1, std::multiplies<size_t>()));
 
+    assert( dims.size() <= 3 ); // will help debug.
     _dims = {1, 1, 1};
     _nDims = dims.size();
     std::copy(dims.begin(), dims.begin() + dims.size(), _dims.begin());

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -44,7 +44,7 @@ Grid::Grid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const
     VAssert(blks.size() == 0 ||    // dataless
             blks.size() == std::accumulate(_bdims.begin(), _bdims.end(), 1, std::multiplies<size_t>()));
 
-    assert( dims.size() <= 3 ); // will help debug.
+    assert(dims.size() <= 3);    // will help debug.
     _dims = {1, 1, 1};
     _nDims = dims.size();
     std::copy(dims.begin(), dims.begin() + dims.size(), _dims.begin());

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -38,8 +38,8 @@ Grid::Grid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const
     VAssert(blks.size() == 0 ||    // dataless
             blks.size() == std::accumulate(_bdims.begin(), _bdims.end(), 1, std::multiplies<size_t>()));
 
-	_dims = {1,1,1};
-	_nDims = dims.size();
+    _dims = {1, 1, 1};
+    _nDims = dims.size();
     std::copy(dims.begin(), dims.begin() + dims.size(), _dims.begin());
     _periodic = vector<bool>(topology_dimension, false);
     _topologyDimension = topology_dimension;

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -38,7 +38,9 @@ Grid::Grid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const
     VAssert(blks.size() == 0 ||    // dataless
             blks.size() == std::accumulate(_bdims.begin(), _bdims.end(), 1, std::multiplies<size_t>()));
 
-    _dims = dims;
+	_dims = {1,1,1};
+	_nDims = dims.size();
+    std::copy(dims.begin(), dims.begin() + dims.size(), _dims.begin());
     _periodic = vector<bool>(topology_dimension, false);
     _topologyDimension = topology_dimension;
     _missingValue = INFINITY;
@@ -46,7 +48,7 @@ Grid::Grid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const
     _interpolationOrder = 0;
     _nodeIDOffset = 0;
     _cellIDOffset = 0;
-    _minAbs = vector<size_t>(_dims.size(), 0);
+    _minAbs = vector<size_t>(_nDims, 0);
 
     //
     // Shallow  copy blocks


### PR DESCRIPTION
This PR simply changes the internal representation of Grid::_dims to DimsType, which matches the public API and provides a modest (~10%) performance gain our testGrid and testData benchmarks. 