### PR TITLE
#2768 - Fix documentation link

### DIFF
--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -154,7 +154,7 @@ using namespace VAPoR;
 
 const QEvent::Type MainForm::ParamsChangeEvent = (QEvent::Type)QEvent::registerEventType();
 const QEvent::Type MainForm::ParamsIntermediateChangeEvent = (QEvent::Type)QEvent::registerEventType();
-const std::string  MainForm::_documentationURL = "http://www.docs.vapor.ucar.edu";
+const std::string  MainForm::_documentationURL = "https://vapor.readthedocs.io/en/readthedocs/";
 
 namespace {
 


### PR DESCRIPTION
Fixes #2768 by updating the application's "get help" link to our new readTheDocs page.