### PR TITLE
Fixed Issue 2785 - Wireframe renderer broken with CAM data

### DIFF
--- a/apps/vaporgui/Statistics.cpp
+++ b/apps/vaporgui/Statistics.cpp
@@ -643,11 +643,6 @@ bool Statistics::_calc3M(std::string varname)
     std::vector<double> minExtent, maxExtent;
     statsParams->GetBox()->GetExtents(minExtent, maxExtent);
 
-    CoordType minExtentCT = {0.0, 0.0, 0.0};
-    CoordType maxExtentCT = {0.0, 0.0, 0.0};
-    Grid::CopyToArr3(minExtent, minExtentCT);
-    Grid::CopyToArr3(maxExtent, maxExtentCT);
-
     float c = 0.0;
     float sum = 0.0;
     float min = std::numeric_limits<float>::max();
@@ -660,7 +655,7 @@ bool Statistics::_calc3M(std::string varname)
             Grid::ConstIterator endItr = grid->cend();
             float               missingVal = grid->GetMissingValue();
 
-            for (Grid::ConstIterator it = grid->cbegin(minExtentCT, maxExtentCT); it != endItr; ++it) {
+            for (Grid::ConstIterator it = grid->cbegin(minExtent, maxExtent); it != endItr; ++it) {
                 if (*it != missingVal) {
                     float val = *it;
                     min = min < val ? min : val;
@@ -704,11 +699,6 @@ bool Statistics::_calcMedian(std::string varname)
     std::vector<double> minExtent, maxExtent;
     statsParams->GetBox()->GetExtents(minExtent, maxExtent);
 
-    CoordType minExtentCT = {0.0, 0.0, 0.0};
-    CoordType maxExtentCT = {0.0, 0.0, 0.0};
-    Grid::CopyToArr3(minExtent, minExtentCT);
-    Grid::CopyToArr3(maxExtent, maxExtentCT);
-
     std::vector<float> buffer;
     for (int ts = minTS; ts <= maxTS; ts++) {
         VAPoR::Grid *grid = currentDmgr->GetVariable(ts, varname, statsParams->GetRefinementLevel(), statsParams->GetCompressionLevel(), minExtent, maxExtent);
@@ -716,7 +706,7 @@ bool Statistics::_calcMedian(std::string varname)
             Grid::ConstIterator endItr = grid->cend();
             float               missingVal = grid->GetMissingValue();
 
-            for (Grid::ConstIterator it = grid->cbegin(minExtentCT, maxExtentCT); it != endItr; ++it) {
+            for (Grid::ConstIterator it = grid->cbegin(minExtent, maxExtent); it != endItr; ++it) {
                 if (*it != missingVal) buffer.push_back(*it);
             }
         }
@@ -749,11 +739,6 @@ bool Statistics::_calcStddev(std::string varname)
     std::vector<double> minExtent, maxExtent;
     statsParams->GetBox()->GetExtents(minExtent, maxExtent);
 
-    CoordType minExtentCT = {0.0, 0.0, 0.0};
-    CoordType maxExtentCT = {0.0, 0.0, 0.0};
-    Grid::CopyToArr3(minExtent, minExtentCT);
-    Grid::CopyToArr3(maxExtent, maxExtentCT);
-
     float c = 0.0;
     float sum = 0.0;
     long  count = 0;
@@ -769,7 +754,7 @@ bool Statistics::_calcStddev(std::string varname)
         if (grid) {
             Grid::ConstIterator endItr = grid->cend();
             float               missingVal = grid->GetMissingValue();
-            for (Grid::ConstIterator it = grid->cbegin(minExtentCT, maxExtentCT); it != endItr; ++it) {
+            for (Grid::ConstIterator it = grid->cbegin(minExtent, maxExtent); it != endItr; ++it) {
                 if (*it != missingVal) {
                     float val = *it;
                     float y = (val - m3[2]) * (val - m3[2]) - c;

--- a/apps/vaporgui/Statistics.cpp
+++ b/apps/vaporgui/Statistics.cpp
@@ -643,6 +643,11 @@ bool Statistics::_calc3M(std::string varname)
     std::vector<double> minExtent, maxExtent;
     statsParams->GetBox()->GetExtents(minExtent, maxExtent);
 
+    CoordType minExtentCT = {0.0, 0.0, 0.0};
+    CoordType maxExtentCT = {0.0, 0.0, 0.0};
+    Grid::CopyToArr3(minExtent, minExtentCT);
+    Grid::CopyToArr3(maxExtent, maxExtentCT);
+
     float c = 0.0;
     float sum = 0.0;
     float min = std::numeric_limits<float>::max();
@@ -655,7 +660,7 @@ bool Statistics::_calc3M(std::string varname)
             Grid::ConstIterator endItr = grid->cend();
             float               missingVal = grid->GetMissingValue();
 
-            for (Grid::ConstIterator it = grid->cbegin(minExtent, maxExtent); it != endItr; ++it) {
+            for (Grid::ConstIterator it = grid->cbegin(minExtentCT, maxExtentCT); it != endItr; ++it) {
                 if (*it != missingVal) {
                     float val = *it;
                     min = min < val ? min : val;
@@ -699,6 +704,11 @@ bool Statistics::_calcMedian(std::string varname)
     std::vector<double> minExtent, maxExtent;
     statsParams->GetBox()->GetExtents(minExtent, maxExtent);
 
+    CoordType minExtentCT = {0.0, 0.0, 0.0};
+    CoordType maxExtentCT = {0.0, 0.0, 0.0};
+    Grid::CopyToArr3(minExtent, minExtentCT);
+    Grid::CopyToArr3(maxExtent, maxExtentCT);
+
     std::vector<float> buffer;
     for (int ts = minTS; ts <= maxTS; ts++) {
         VAPoR::Grid *grid = currentDmgr->GetVariable(ts, varname, statsParams->GetRefinementLevel(), statsParams->GetCompressionLevel(), minExtent, maxExtent);
@@ -706,7 +716,7 @@ bool Statistics::_calcMedian(std::string varname)
             Grid::ConstIterator endItr = grid->cend();
             float               missingVal = grid->GetMissingValue();
 
-            for (Grid::ConstIterator it = grid->cbegin(minExtent, maxExtent); it != endItr; ++it) {
+            for (Grid::ConstIterator it = grid->cbegin(minExtentCT, maxExtentCT); it != endItr; ++it) {
                 if (*it != missingVal) buffer.push_back(*it);
             }
         }
@@ -739,6 +749,11 @@ bool Statistics::_calcStddev(std::string varname)
     std::vector<double> minExtent, maxExtent;
     statsParams->GetBox()->GetExtents(minExtent, maxExtent);
 
+    CoordType minExtentCT = {0.0, 0.0, 0.0};
+    CoordType maxExtentCT = {0.0, 0.0, 0.0};
+    Grid::CopyToArr3(minExtent, minExtentCT);
+    Grid::CopyToArr3(maxExtent, maxExtentCT);
+
     float c = 0.0;
     float sum = 0.0;
     long  count = 0;
@@ -754,7 +769,7 @@ bool Statistics::_calcStddev(std::string varname)
         if (grid) {
             Grid::ConstIterator endItr = grid->cend();
             float               missingVal = grid->GetMissingValue();
-            for (Grid::ConstIterator it = grid->cbegin(minExtent, maxExtent); it != endItr; ++it) {
+            for (Grid::ConstIterator it = grid->cbegin(minExtentCT, maxExtentCT); it != endItr; ++it) {
                 if (*it != missingVal) {
                     float val = *it;
                     float y = (val - m3[2]) * (val - m3[2]) - c;

--- a/include/vapor/ConstantGrid.h
+++ b/include/vapor/ConstantGrid.h
@@ -52,9 +52,9 @@ private:
     //
     std::vector<size_t>        GetCoordDimensions(size_t) const override;
     size_t                     GetGeometryDim() const override;
-    const DimsType             &GetNodeDimensions() const override;
+    const DimsType &           GetNodeDimensions() const override;
     const size_t               GetNumNodeDimensions() const override;
-    const DimsType             &GetCellDimensions() const override;
+    const DimsType &           GetCellDimensions() const override;
     const size_t               GetNumCellDimensions() const override;
     void                       GetBoundingBox(const DimsType &min, const DimsType &max, CoordType &minu, CoordType &maxu) const override {}
     bool                       GetEnclosingRegion(const CoordType &minu, const CoordType &maxu, DimsType &min, DimsType &max) const override { return (false); }

--- a/include/vapor/ConstantGrid.h
+++ b/include/vapor/ConstantGrid.h
@@ -52,9 +52,10 @@ private:
     //
     std::vector<size_t>        GetCoordDimensions(size_t) const override;
     size_t                     GetGeometryDim() const override;
-    const DimsType             GetNodeDimensions() const override;
+    const DimsType             &GetNodeDimensions() const override;
     const size_t               GetNumNodeDimensions() const override;
-    const std::vector<size_t> &GetCellDimensions() const override;
+    const DimsType             &GetCellDimensions() const override;
+    const size_t               GetNumCellDimensions() const override;
     void                       GetBoundingBox(const DimsType &min, const DimsType &max, CoordType &minu, CoordType &maxu) const override {}
     bool                       GetEnclosingRegion(const CoordType &minu, const CoordType &maxu, DimsType &min, DimsType &max) const override { return (false); }
     virtual void               GetUserCoordinates(const DimsType &, CoordType &) const override {}
@@ -73,7 +74,7 @@ private:
     const size_t _topologyDim;    // Not to be confused with _topologyDimension in
                                   // the base Grid class, which is private to Grid.
 
-    mutable std::vector<size_t> _duplicate;
+    mutable VAPoR::DimsType _duplicate;
 
 };    // end ConstantGrid class
 };    // namespace VAPoR

--- a/include/vapor/CurvilinearGrid.h
+++ b/include/vapor/CurvilinearGrid.h
@@ -222,8 +222,8 @@ public:
 
     private:
         const CurvilinearGrid *_cg;
-        DimsType                _index;
-        CoordType               _coords;
+        DimsType               _index;
+        CoordType              _coords;
         ConstIterator          _xCoordItr;
         ConstIterator          _yCoordItr;
         ConstIterator          _zCoordItr;

--- a/include/vapor/CurvilinearGrid.h
+++ b/include/vapor/CurvilinearGrid.h
@@ -222,8 +222,8 @@ public:
 
     private:
         const CurvilinearGrid *_cg;
-        std::vector<size_t>    _index;
-        std::vector<double>    _coords;
+        DimsType                _index;
+        CoordType               _coords;
         ConstIterator          _xCoordItr;
         ConstIterator          _yCoordItr;
         ConstIterator          _zCoordItr;

--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -128,10 +128,10 @@ public:
     //
     virtual size_t GetGeometryDim() const = 0;
 
-    virtual const DimsType             &GetNodeDimensions() const = 0;
+    virtual const DimsType &           GetNodeDimensions() const = 0;
     virtual const size_t               GetNumNodeDimensions() const = 0;
-    virtual const DimsType &GetCellDimensions() const = 0;
-    virtual const size_t GetNumCellDimensions() const = 0;
+    virtual const DimsType &           GetCellDimensions() const = 0;
+    virtual const size_t               GetNumCellDimensions() const = 0;
 
     //! Return the ijk dimensions of grid in blocks
     //!
@@ -920,7 +920,7 @@ public:
     //! N.B. Current only works with node coordinates
     //!
     //
-    typedef const CoordType              ConstCoordType;
+    typedef const CoordType                        ConstCoordType;
     typedef Grid::PolyIterator<ConstCoordType>     ConstCoordItr;
     typedef Grid::AbstractIterator<ConstCoordType> ConstCoordItrAbstract;
 
@@ -934,7 +934,7 @@ public:
     //! The ConstNodeIterator is dereferenced to give the index of
     //! a node within the grid
     //!
-    typedef const DimsType              ConstIndexType;
+    typedef const DimsType                         ConstIndexType;
     typedef Grid::PolyIterator<ConstIndexType>     ConstNodeIterator;
     typedef Grid::AbstractIterator<ConstIndexType> ConstNodeIteratorAbstract;
 
@@ -1105,7 +1105,7 @@ public:
     //
     template<class T> class VDF_API ForwardIterator {
     public:
-        ForwardIterator(T *rg, bool begin = true, const CoordType &minu = {0.0,0.0,0.0}, const CoordType &maxu = {0.0,0.0,0.0});
+        ForwardIterator(T *rg, bool begin = true, const CoordType &minu = {0.0, 0.0, 0.0}, const CoordType &maxu = {0.0, 0.0, 0.0});
         ForwardIterator();
         ForwardIterator(const ForwardIterator<T> &) = default;
         ForwardIterator(ForwardIterator<T> &&rhs);
@@ -1148,12 +1148,12 @@ public:
     private:
         size_t               _ndims;
         std::vector<float *> _blks;
-        DimsType _dims3d;
-        DimsType _bdims3d;
-        DimsType _bs3d;
+        DimsType             _dims3d;
+        DimsType             _bdims3d;
+        DimsType             _bs3d;
         size_t               _blocksize;
         ConstCoordItr        _coordItr;
-        DimsType _index;         // current index into grid
+        DimsType             _index;         // current index into grid
         size_t               _indexL;        // current index into grid
         size_t               _end_indexL;    // Last valid index
         size_t               _xb;            // x index within a block

--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -128,9 +128,10 @@ public:
     //
     virtual size_t GetGeometryDim() const = 0;
 
-    virtual const DimsType             GetNodeDimensions() const = 0;
+    virtual const DimsType             &GetNodeDimensions() const = 0;
     virtual const size_t               GetNumNodeDimensions() const = 0;
-    virtual const std::vector<size_t> &GetCellDimensions() const = 0;
+    virtual const DimsType &GetCellDimensions() const = 0;
+    virtual const size_t GetNumCellDimensions() const = 0;
 
     //! Return the ijk dimensions of grid in blocks
     //!
@@ -799,11 +800,12 @@ public:
     //
     class InsideBox {
     public:
-        InsideBox(const std::vector<double> &min, const std::vector<double> &max) : _min(min), _max(max) {}
+        InsideBox(const CoordType &min, const CoordType &max) : _min(min), _max(max) {}
         InsideBox() {}
 
-        bool operator()(const std::vector<double> &pt) const
+        bool operator()(const CoordType &pt) const
         {
+            if (_min == _max) return (true);
             for (int i = 0; i < _min.size() && i < pt.size(); i++) {
                 if (pt[i] < _min[i] || pt[i] > _max[i]) return (false);
             }
@@ -811,17 +813,18 @@ public:
         }
         bool operator()(const double pt[]) const
         {
+            if (_min == _max) return (true);
             for (int i = 0; i < _min.size(); i++) {
                 if (pt[i] < _min[i] || pt[i] > _max[i]) return (false);
             }
             return (true);
         }
 
-        size_t Size() const { return (_min.size()); }
+        bool Enabled() const { return (_min != _max); }
 
     private:
-        std::vector<double> _min;
-        std::vector<double> _max;
+        CoordType _min;
+        CoordType _max;
     };
 
     //
@@ -917,7 +920,7 @@ public:
     //! N.B. Current only works with node coordinates
     //!
     //
-    typedef const std::vector<double>              ConstCoordType;
+    typedef const CoordType              ConstCoordType;
     typedef Grid::PolyIterator<ConstCoordType>     ConstCoordItr;
     typedef Grid::AbstractIterator<ConstCoordType> ConstCoordItrAbstract;
 
@@ -931,7 +934,7 @@ public:
     //! The ConstNodeIterator is dereferenced to give the index of
     //! a node within the grid
     //!
-    typedef const std::vector<size_t>              ConstIndexType;
+    typedef const DimsType              ConstIndexType;
     typedef Grid::PolyIterator<ConstIndexType>     ConstNodeIterator;
     typedef Grid::AbstractIterator<ConstIndexType> ConstNodeIteratorAbstract;
 
@@ -971,14 +974,15 @@ public:
         virtual std::unique_ptr<ConstNodeIteratorAbstract> clone() const { return std::unique_ptr<ConstNodeIteratorAbstract>(new ConstNodeIteratorSG(*this)); };
 
     protected:
-        std::vector<size_t> _dims;
-        std::vector<size_t> _index;
-        std::vector<size_t> _lastIndex;
+        DimsType _dims;
+        size_t   _nDims;
+        DimsType _index;
+        DimsType _lastIndex;
     };
 
     class ConstNodeIteratorBoxSG : public ConstNodeIteratorSG {
     public:
-        ConstNodeIteratorBoxSG(const Grid *g, const std::vector<double> &minu, const std::vector<double> &maxu);
+        ConstNodeIteratorBoxSG(const Grid *g, const CoordType &minu, const CoordType &maxu);
         ConstNodeIteratorBoxSG(const ConstNodeIteratorBoxSG &rhs);
         ConstNodeIteratorBoxSG();
 
@@ -1004,7 +1008,7 @@ public:
     //!
     virtual ConstNodeIterator ConstNodeBegin() const { return ConstNodeIterator(std::unique_ptr<ConstNodeIteratorAbstract>(new ConstNodeIteratorSG(this, true))); }
 
-    virtual ConstNodeIterator ConstNodeBegin(const std::vector<double> &minu, const std::vector<double> &maxu) const
+    virtual ConstNodeIterator ConstNodeBegin(const CoordType &minu, const CoordType &maxu) const
     {
         return ConstNodeIterator(std::unique_ptr<ConstNodeIteratorAbstract>(new ConstNodeIteratorBoxSG(this, minu, maxu)));
     }
@@ -1037,14 +1041,15 @@ public:
         virtual std::unique_ptr<ConstCellIteratorAbstract> clone() const { return std::unique_ptr<ConstCellIteratorAbstract>(new ConstCellIteratorSG(*this)); };
 
     protected:
-        std::vector<size_t> _dims;
-        std::vector<size_t> _index;
-        std::vector<size_t> _lastIndex;
+        DimsType _dims;
+        size_t   _nDims;
+        DimsType _index;
+        DimsType _lastIndex;
     };
 
     class ConstCellIteratorBoxSG : public ConstCellIteratorSG {
     public:
-        ConstCellIteratorBoxSG(const Grid *g, const std::vector<double> &minu, const std::vector<double> &maxu);
+        ConstCellIteratorBoxSG(const Grid *g, const CoordType &minu, const CoordType &maxu);
         ConstCellIteratorBoxSG(const ConstCellIteratorBoxSG &rhs);
         ConstCellIteratorBoxSG();
 
@@ -1075,7 +1080,7 @@ public:
     //!
     virtual ConstCellIterator ConstCellBegin() const { return ConstCellIterator(std::unique_ptr<ConstCellIteratorAbstract>(new ConstCellIteratorSG(this, true))); }
 
-    virtual ConstCellIterator ConstCellBegin(const std::vector<double> &minu, const std::vector<double> &maxu) const
+    virtual ConstCellIterator ConstCellBegin(const CoordType &minu, const CoordType &maxu) const
     {
         return ConstCellIterator(std::unique_ptr<ConstCellIteratorAbstract>(new ConstCellIteratorBoxSG(this, minu, maxu)));
     }
@@ -1100,7 +1105,7 @@ public:
     //
     template<class T> class VDF_API ForwardIterator {
     public:
-        ForwardIterator(T *rg, bool begin = true, const std::vector<double> &minu = {}, const std::vector<double> &maxu = {});
+        ForwardIterator(T *rg, bool begin = true, const CoordType &minu = {0.0,0.0,0.0}, const CoordType &maxu = {0.0,0.0,0.0});
         ForwardIterator();
         ForwardIterator(const ForwardIterator<T> &) = default;
         ForwardIterator(ForwardIterator<T> &&rhs);
@@ -1143,12 +1148,12 @@ public:
     private:
         size_t               _ndims;
         std::vector<float *> _blks;
-        std::vector<size_t>  _dims3d;
-        std::vector<size_t>  _bdims3d;
-        std::vector<size_t>  _bs3d;
+        DimsType _dims3d;
+        DimsType _bdims3d;
+        DimsType _bs3d;
         size_t               _blocksize;
         ConstCoordItr        _coordItr;
-        std::vector<size_t>  _index;         // current index into grid
+        DimsType _index;         // current index into grid
         size_t               _indexL;        // current index into grid
         size_t               _end_indexL;    // Last valid index
         size_t               _xb;            // x index within a block
@@ -1162,12 +1167,12 @@ public:
     //! Construct a begin iterator that will iterate through elements
     //! inside or on the box defined by \p minu and \p maxu
     //
-    Iterator begin(const std::vector<double> &minu, const std::vector<double> &maxu) { return (Iterator(this, true, minu, maxu)); }
+    Iterator begin(const CoordType &minu, const CoordType &maxu) { return (Iterator(this, true, minu, maxu)); }
     Iterator begin() { return (Iterator(this, true)); }
 
     Iterator end() { return (Iterator(this, false)); }
 
-    ConstIterator cbegin(const std::vector<double> &minu, const std::vector<double> &maxu) const { return (ConstIterator(this, true, minu, maxu)); }
+    ConstIterator cbegin(const CoordType &minu, const CoordType &maxu) const { return (ConstIterator(this, true, minu, maxu)); }
     ConstIterator cbegin() const { return (ConstIterator(this, true)); }
 
     ConstIterator cend() const { return (ConstIterator(this, false)); }
@@ -1176,6 +1181,7 @@ public:
     {
         for (int i = 0; i < src.size() && i < dst.size(); i++) { dst[i] = src[i]; }
     }
+
     template<typename T> static void CopyToArr3(const T *src, size_t n, std::array<T, 3> &dst)
     {
         for (int i = 0; i < n && i < dst.size(); i++) { dst[i] = src[i]; }
@@ -1244,5 +1250,8 @@ private:
 
     virtual void _getUserCoordinatesHelper(const std::vector<double> &coords, double &x, double &y, double &z) const;
 };
+
+template void Grid::CopyToArr3<size_t>(const std::vector<size_t> &src, std::array<size_t, 3> &dst);
+
 };    // namespace VAPoR
 #endif

--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -1185,11 +1185,12 @@ public:
     //
     Iterator begin(const CoordType &minu, const CoordType &maxu) { return (Iterator(this, true, minu, maxu)); }
 
-    Iterator begin(const std::vector<double> &minu, const std::vector<double> &maxu) { 
-		CoordType minuCT, maxuCT;
-		CopyToArr3(minu, minuCT);
-		CopyToArr3(maxu, maxuCT);
-		return begin(minuCT, maxuCT);
+    Iterator begin(const std::vector<double> &minu, const std::vector<double> &maxu)
+    {
+        CoordType minuCT, maxuCT;
+        CopyToArr3(minu, minuCT);
+        CopyToArr3(maxu, maxuCT);
+        return begin(minuCT, maxuCT);
     }
 
     Iterator begin() { return (Iterator(this, true)); }
@@ -1198,11 +1199,12 @@ public:
 
     ConstIterator cbegin(const CoordType &minu, const CoordType &maxu) const { return (ConstIterator(this, true, minu, maxu)); }
 
-    ConstIterator cbegin(const std::vector<double> &minu, const std::vector<double> &maxu) { 
-		CoordType minuCT, maxuCT;
-		CopyToArr3(minu, minuCT);
-		CopyToArr3(maxu, maxuCT);
-		return cbegin(minuCT, maxuCT);
+    ConstIterator cbegin(const std::vector<double> &minu, const std::vector<double> &maxu)
+    {
+        CoordType minuCT, maxuCT;
+        CopyToArr3(minu, minuCT);
+        CopyToArr3(maxu, maxuCT);
+        return cbegin(minuCT, maxuCT);
     }
     ConstIterator cbegin() const { return (ConstIterator(this, true)); }
 

--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -1013,6 +1013,14 @@ public:
         return ConstNodeIterator(std::unique_ptr<ConstNodeIteratorAbstract>(new ConstNodeIteratorBoxSG(this, minu, maxu)));
     }
 
+    virtual ConstNodeIterator ConstNodeBegin(const std::vector<double> &minu, const std::vector<double> &maxu) const
+    {
+        CoordType minuCT, maxuCT;
+        CopyToArr3(minu, minuCT);
+        CopyToArr3(maxu, maxuCT);
+        return ConstNodeBegin(minuCT, maxuCT);
+    }
+
     virtual ConstNodeIterator ConstNodeEnd() const { return ConstNodeIterator(std::unique_ptr<ConstNodeIteratorAbstract>(new ConstNodeIteratorSG(this, false))); }
 
     //
@@ -1083,6 +1091,14 @@ public:
     virtual ConstCellIterator ConstCellBegin(const CoordType &minu, const CoordType &maxu) const
     {
         return ConstCellIterator(std::unique_ptr<ConstCellIteratorAbstract>(new ConstCellIteratorBoxSG(this, minu, maxu)));
+    }
+
+    virtual ConstCellIterator ConstCellBegin(const std::vector<double> &minu, const std::vector<double> &maxu) const
+    {
+        CoordType minuCT, maxuCT;
+        CopyToArr3(minu, minuCT);
+        CopyToArr3(maxu, maxuCT);
+        return ConstCellBegin(minuCT, maxuCT);
     }
 
     virtual ConstCellIterator ConstCellEnd() const { return ConstCellIterator(std::unique_ptr<ConstCellIteratorAbstract>(new ConstCellIteratorSG(this, false))); }
@@ -1168,11 +1184,26 @@ public:
     //! inside or on the box defined by \p minu and \p maxu
     //
     Iterator begin(const CoordType &minu, const CoordType &maxu) { return (Iterator(this, true, minu, maxu)); }
+
+    Iterator begin(const std::vector<double> &minu, const std::vector<double> &maxu) { 
+		CoordType minuCT, maxuCT;
+		CopyToArr3(minu, minuCT);
+		CopyToArr3(maxu, maxuCT);
+		return begin(minuCT, maxuCT);
+    }
+
     Iterator begin() { return (Iterator(this, true)); }
 
     Iterator end() { return (Iterator(this, false)); }
 
     ConstIterator cbegin(const CoordType &minu, const CoordType &maxu) const { return (ConstIterator(this, true, minu, maxu)); }
+
+    ConstIterator cbegin(const std::vector<double> &minu, const std::vector<double> &maxu) { 
+		CoordType minuCT, maxuCT;
+		CopyToArr3(minu, minuCT);
+		CopyToArr3(maxu, maxuCT);
+		return cbegin(minuCT, maxuCT);
+    }
     ConstIterator cbegin() const { return (ConstIterator(this, true)); }
 
     ConstIterator cend() const { return (ConstIterator(this, false)); }

--- a/include/vapor/LayeredGrid.h
+++ b/include/vapor/LayeredGrid.h
@@ -147,7 +147,7 @@ public:
     private:
         const LayeredGrid *          _lg;
         size_t                       _nElements2D;
-        std::vector<double>          _coords;
+        CoordType                    _coords;
         size_t                       _index2D;
         ConstIterator                _zCoordItr;
         StretchedGrid::ConstCoordItr _itr2D;

--- a/include/vapor/RegularGrid.h
+++ b/include/vapor/RegularGrid.h
@@ -96,9 +96,9 @@ public:
         virtual std::unique_ptr<ConstCoordItrAbstract> clone() const { return std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrRG(*this)); };
 
     private:
-        DimsType _index;
-        DimsType _dims;
-        size_t _nDims;
+        DimsType  _index;
+        DimsType  _dims;
+        size_t    _nDims;
         CoordType _minu;
         CoordType _delta;
         CoordType _coords;
@@ -124,7 +124,7 @@ private:
     CoordType           _minu = {{0.0, 0.0, 0.0}};
     CoordType           _maxu = {{0.0, 0.0, 0.0}};
     size_t              _geometryDim;
-    CoordType _delta;    // increment between grid points in user coords
+    CoordType           _delta;    // increment between grid points in user coords
 };
 };    // namespace VAPoR
 #endif

--- a/include/vapor/RegularGrid.h
+++ b/include/vapor/RegularGrid.h
@@ -96,11 +96,12 @@ public:
         virtual std::unique_ptr<ConstCoordItrAbstract> clone() const { return std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrRG(*this)); };
 
     private:
-        std::vector<size_t> _index;
-        std::vector<size_t> _dims;
-        std::vector<double> _minu;
-        std::vector<double> _delta;
-        std::vector<double> _coords;
+        DimsType _index;
+        DimsType _dims;
+        size_t _nDims;
+        CoordType _minu;
+        CoordType _delta;
+        CoordType _coords;
     };
 
     virtual ConstCoordItr ConstCoordBegin() const override { return ConstCoordItr(std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrRG(this, true))); }
@@ -123,7 +124,7 @@ private:
     CoordType           _minu = {{0.0, 0.0, 0.0}};
     CoordType           _maxu = {{0.0, 0.0, 0.0}};
     size_t              _geometryDim;
-    std::vector<double> _delta;    // increment between grid points in user coords
+    CoordType _delta;    // increment between grid points in user coords
 };
 };    // namespace VAPoR
 #endif

--- a/include/vapor/StretchedGrid.h
+++ b/include/vapor/StretchedGrid.h
@@ -136,8 +136,8 @@ public:
 
     private:
         const StretchedGrid *_sg;
-        std::vector<size_t>  _index;
-        std::vector<double>  _coords;
+        DimsType _index;
+        CoordType _coords;
     };
 
     virtual ConstCoordItr ConstCoordBegin() const override { return ConstCoordItr(std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrSG(this, true))); }

--- a/include/vapor/StretchedGrid.h
+++ b/include/vapor/StretchedGrid.h
@@ -136,8 +136,8 @@ public:
 
     private:
         const StretchedGrid *_sg;
-        DimsType _index;
-        CoordType _coords;
+        DimsType             _index;
+        CoordType            _coords;
     };
 
     virtual ConstCoordItr ConstCoordBegin() const override { return ConstCoordItr(std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrSG(this, true))); }

--- a/include/vapor/StructuredGrid.h
+++ b/include/vapor/StructuredGrid.h
@@ -74,7 +74,7 @@ public:
     const size_t   GetNumNodeDimensions() const override;
 
     const DimsType &GetCellDimensions() const override { return (_cellDims); };
-    const size_t   GetNumCellDimensions() const override { return GetNumNodeDimensions(); }
+    const size_t    GetNumCellDimensions() const override { return GetNumNodeDimensions(); }
 
     //! \copydoc Grid::GetCellNodes()
     //!

--- a/include/vapor/StructuredGrid.h
+++ b/include/vapor/StructuredGrid.h
@@ -70,10 +70,11 @@ public:
     static std::string GetClassType() { return ("Structured"); }
     std::string        GetType() const override { return (GetClassType()); }
 
-    const DimsType GetNodeDimensions() const override;
+    const DimsType &GetNodeDimensions() const override;
     const size_t   GetNumNodeDimensions() const override;
 
-    const std::vector<size_t> &GetCellDimensions() const override { return (_cellDims); };
+    const DimsType &GetCellDimensions() const override { return (_cellDims); };
+    const size_t   GetNumCellDimensions() const override { return GetNumNodeDimensions(); }
 
     //! \copydoc Grid::GetCellNodes()
     //!
@@ -111,7 +112,7 @@ public:
 
 protected:
 private:
-    std::vector<size_t> _cellDims;
+    DimsType _cellDims;
 };
 };    // namespace VAPoR
 #endif

--- a/include/vapor/UnstructuredGrid.h
+++ b/include/vapor/UnstructuredGrid.h
@@ -143,16 +143,18 @@ public:
 
     //! Return the grid node dimmensions
     //!
-    const VAPoR::DimsType GetNodeDimensions() const override;
+    const VAPoR::DimsType &GetNodeDimensions() const override;
     const size_t          GetNumNodeDimensions() const override;
 
     //! Return the grid cell dimmensions
     //!
-    const std::vector<size_t> &GetCellDimensions() const override { return (_faceDims); }
+    const DimsType &GetCellDimensions() const override { return (_faceDims); }
+
+    virtual const size_t GetNumCellDimensions() const override  { return (_nDims); }
 
     //! Return the grid edge dimmensions
     //!
-    const std::vector<size_t> &GetEdgeDimensions() const { return (_edgeDims); }
+    const DimsType &GetEdgeDimensions() const { return (_edgeDims); }
 
     //! Get missing element ID
     //!
@@ -196,9 +198,10 @@ protected:
     Location   _location;
 
 private:
-    std::vector<size_t> _vertexDims;
-    std::vector<size_t> _faceDims;
-    std::vector<size_t> _edgeDims;
+    DimsType            _vertexDims;
+    DimsType            _faceDims;
+    DimsType            _edgeDims;
+    size_t              _nDims;
     int                 _missingID;
     int                 _boundaryID;
 };

--- a/include/vapor/UnstructuredGrid.h
+++ b/include/vapor/UnstructuredGrid.h
@@ -150,7 +150,7 @@ public:
     //!
     const DimsType &GetCellDimensions() const override { return (_faceDims); }
 
-    virtual const size_t GetNumCellDimensions() const override  { return (_nDims); }
+    virtual const size_t GetNumCellDimensions() const override { return (_nDims); }
 
     //! Return the grid edge dimmensions
     //!

--- a/include/vapor/UnstructuredGrid2D.h
+++ b/include/vapor/UnstructuredGrid2D.h
@@ -106,11 +106,11 @@ public:
         virtual std::unique_ptr<ConstCoordItrAbstract> clone() const { return std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrU2D(*this)); };
 
     private:
-        int                 _ncoords;
+        size_t               _ncoords;
         ConstIterator       _xCoordItr;
         ConstIterator       _yCoordItr;
         ConstIterator       _zCoordItr;
-        std::vector<double> _coords;
+        CoordType           _coords;
     };
 
     virtual ConstCoordItr ConstCoordBegin() const override { return ConstCoordItr(std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrU2D(this, true))); }

--- a/include/vapor/UnstructuredGrid2D.h
+++ b/include/vapor/UnstructuredGrid2D.h
@@ -106,7 +106,7 @@ public:
         virtual std::unique_ptr<ConstCoordItrAbstract> clone() const { return std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrU2D(*this)); };
 
     private:
-        size_t               _ncoords;
+        size_t              _ncoords;
         ConstIterator       _xCoordItr;
         ConstIterator       _yCoordItr;
         ConstIterator       _zCoordItr;

--- a/include/vapor/UnstructuredGrid3D.h
+++ b/include/vapor/UnstructuredGrid3D.h
@@ -83,7 +83,7 @@ public:
         ConstIterator             _xCoordItr;
         ConstIterator             _yCoordItr;
         ConstIterator             _zCoordItr;
-        std::vector<double>       _coords;
+        CoordType                 _coords;
     };
 
     virtual ConstCoordItr ConstCoordBegin() const override { return ConstCoordItr(std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrU3D(this, true))); }

--- a/include/vapor/UnstructuredGridCoordless.h
+++ b/include/vapor/UnstructuredGridCoordless.h
@@ -83,7 +83,7 @@ public:
         virtual std::unique_ptr<ConstCoordItrAbstract> clone() const { return std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrUCoordless(*this)); };
 
     private:
-        std::vector<double> _coords;
+        CoordType _coords;
     };
 
     virtual ConstCoordItr ConstCoordBegin() const override { return ConstCoordItr(std::unique_ptr<ConstCoordItrAbstract>(new ConstCoordItrUCoordless(this, true))); }

--- a/include/vapor/UnstructuredGridLayered.h
+++ b/include/vapor/UnstructuredGridLayered.h
@@ -88,7 +88,7 @@ public:
         const UnstructuredGridLayered *   _ug;
         UnstructuredGrid2D::ConstCoordItr _itr2D;
         ConstIterator                     _zCoordItr;
-        std::vector<double>               _coords;
+        CoordType                         _coords;
         size_t                            _nElements2D;
         size_t                            _index2D;
     };

--- a/include/vapor/utils.h
+++ b/include/vapor/utils.h
@@ -102,6 +102,7 @@ COMMON_API std::vector<size_t> Dims(const std::vector<size_t> &min, const std::v
 
 //! Return the scalar product of the elements of a vector
 //!
+COMMON_API size_t VProduct(const size_t *a, size_t n);
 COMMON_API size_t VProduct(const std::vector<size_t> &a);
 
 //! Vectorize a coordinate offset. Inverse of VectorizeLinearize

--- a/lib/common/utils.cpp
+++ b/lib/common/utils.cpp
@@ -142,13 +142,17 @@ vector<size_t> Wasp::Dims(const vector<size_t> &min, const vector<size_t> &max)
     return (dims);
 }
 
-size_t Wasp::VProduct(const vector<size_t> &a)
+size_t Wasp::VProduct(const size_t *a, size_t n)
 {
     size_t ntotal = 1;
 
-    for (int i = 0; i < a.size(); i++) ntotal *= a[i];
+    for (size_t i = 0; i < n; i++) ntotal *= a[i];
 
     return (ntotal);
+}
+
+size_t Wasp::VProduct(const std::vector<size_t> &a) {
+    return(VProduct(a.data(), a.size()));
 }
 
 #define BLOCKSIZE 256

--- a/lib/common/utils.cpp
+++ b/lib/common/utils.cpp
@@ -151,9 +151,7 @@ size_t Wasp::VProduct(const size_t *a, size_t n)
     return (ntotal);
 }
 
-size_t Wasp::VProduct(const std::vector<size_t> &a) {
-    return(VProduct(a.data(), a.size()));
-}
+size_t Wasp::VProduct(const std::vector<size_t> &a) { return (VProduct(a.data(), a.size())); }
 
 #define BLOCKSIZE 256
 

--- a/lib/render/ContourRenderer.cpp
+++ b/lib/render/ContourRenderer.cpp
@@ -116,7 +116,11 @@ int ContourRenderer::_buildCache()
     double mv = grid->GetMissingValue();
     float  Z0 = GetDefaultZ(_dataMgr, _cacheParams.ts);
 
-    Grid::ConstCellIterator it = grid->ConstCellBegin(_cacheParams.boxMin, _cacheParams.boxMax);
+    CoordType boxMin = {0.0, 0.0, 0.0};
+    CoordType boxMax = {0.0, 0.0, 0.0};
+    Grid::CopyToArr3(_cacheParams.boxMin, boxMin);
+    Grid::CopyToArr3(_cacheParams.boxMax, boxMax);
+    Grid::ConstCellIterator it = grid->ConstCellBegin(boxMin, boxMax);
 
     size_t           maxNodes = grid->GetMaxVertexPerCell();
     vector<DimsType> nodes(maxNodes);
@@ -126,8 +130,8 @@ int ContourRenderer::_buildCache()
 
     Grid::ConstCellIterator end = grid->ConstCellEnd();
     for (; it != end; ++it) {
-        const vector<size_t> &cell = *it;
-        grid->GetCellNodes(cell.data(), nodes);
+        const DimsType &cell = *it;
+        grid->GetCellNodes(cell, nodes);
 
         bool hasMissing = false;
         for (int i = 0; i < nodes.size(); i++) {

--- a/lib/render/ContourRenderer.cpp
+++ b/lib/render/ContourRenderer.cpp
@@ -116,11 +116,7 @@ int ContourRenderer::_buildCache()
     double mv = grid->GetMissingValue();
     float  Z0 = GetDefaultZ(_dataMgr, _cacheParams.ts);
 
-    CoordType boxMin = {0.0, 0.0, 0.0};
-    CoordType boxMax = {0.0, 0.0, 0.0};
-    Grid::CopyToArr3(_cacheParams.boxMin, boxMin);
-    Grid::CopyToArr3(_cacheParams.boxMax, boxMax);
-    Grid::ConstCellIterator it = grid->ConstCellBegin(boxMin, boxMax);
+    Grid::ConstCellIterator it = grid->ConstCellBegin(_cacheParams.boxMin, _cacheParams.boxMax);
 
     size_t           maxNodes = grid->GetMaxVertexPerCell();
     vector<DimsType> nodes(maxNodes);

--- a/lib/render/ParticleRenderer.cpp
+++ b/lib/render/ParticleRenderer.cpp
@@ -134,12 +134,18 @@ int ParticleRenderer::_paintGL(bool)
     lgl->Color3f(1, 1, 1);
     lgl->Begin(showDir ? GL_LINES : GL_POINTS);
 
+    CoordType minExtCT = {0.0, 0.0, 0.0};
+    CoordType maxExtCT = {0.0, 0.0, 0.0};
+
+    Grid::CopyToArr3(minExt, minExtCT);
+    Grid::CopyToArr3(maxExt, maxExtCT);
+
     long                        renderedParticles = 0;
-    auto                        node = grid->ConstNodeBegin(minExt, maxExt);
+    auto                        node = grid->ConstNodeBegin(minExtCT, maxExtCT);
     auto                        nodeEnd = grid->ConstNodeEnd();
-    vector<double>              coordsBuf(3);
+    CoordType                   coordsBuf;
     vector<Grid::ConstIterator> dirs;
-    for (auto g : vecGrids) dirs.push_back(g->cbegin(minExt, maxExt));
+    for (auto g : vecGrids) dirs.push_back(g->cbegin(minExtCT, maxExtCT));
     for (size_t i = 0; node != nodeEnd; ++node, ++i) {
         if (i % stride) {
             if (showDir)

--- a/lib/render/TwoDDataRenderer.cpp
+++ b/lib/render/TwoDDataRenderer.cpp
@@ -422,7 +422,7 @@ int TwoDDataRenderer::_getMeshUnStructured(DataMgr *dataMgr, const Grid *g, doub
     Grid::ConstCellIterator citr;
     Grid::ConstCellIterator endcitr = g->ConstCellEnd();
     for (citr = g->ConstCellBegin(); citr != endcitr; ++citr) {
-        const vector<size_t> &cell = *citr;
+        const DimsType &cell = *citr;
         g->GetCellNodes(DimsType{cell[0], 0, 0}, nodes);
 
         if (nodes.size() < 3) continue;    // degenerate
@@ -488,7 +488,7 @@ int TwoDDataRenderer::_getMeshUnStructuredHelper(DataMgr *dataMgr, const Grid *g
     Grid::ConstNodeIterator endnitr = g->ConstNodeEnd();
     size_t                  voffset = 0;
     for (nitr = g->ConstNodeBegin(); nitr != endnitr; ++nitr) {
-        vector<double> coords;
+        CoordType coords;
 
         g->GetUserCoordinates(*nitr, coords);
 
@@ -523,7 +523,7 @@ int TwoDDataRenderer::_getMeshUnStructuredHelper(DataMgr *dataMgr, const Grid *g
     Grid::ConstCellIterator endcitr = g->ConstCellEnd();
     size_t                  index = 0;
     for (citr = g->ConstCellBegin(); citr != endcitr; ++citr) {
-        const vector<size_t> &cell = *citr;
+        const DimsType &cell = *citr;
         g->GetCellNodes(DimsType{cell[0], 0, 0}, nodes);
 
         if (nodes.size() < 3) continue;    // degenerate

--- a/lib/render/VolumeOSPRay.cpp
+++ b/lib/render/VolumeOSPRay.cpp
@@ -745,9 +745,9 @@ OSPVolume VolumeOSPRay::_loadVolumeUnstructured(const Grid *grid)
     const auto           nodeDims = grid->GetDimensions();
     size_t               nodeDim = grid->GetNumDimensions();
     const size_t         nVerts = nodeDims[0] * nodeDims[1];
-    const vector<size_t> cellDims = grid->GetCellDimensions();
+    const DimsType       &cellDims = grid->GetCellDimensions();
     const size_t         nCells = cellDims[0] * cellDims[1];
-    VAssert(nodeDim == 2 && cellDims.size() == 2);
+    VAssert(nodeDim == 2);
 
     float  missingValue = grid->HasMissingData() ? grid->GetMissingValue() : NAN;
     size_t maxNodes = grid->GetMaxVertexPerCell();
@@ -788,8 +788,8 @@ OSPVolume VolumeOSPRay::_loadVolumeUnstructured(const Grid *grid)
             delete[] cdata;
             return nullptr;
         }
-        const vector<size_t> &cell = *cellIt;
-        grid->GetCellNodes(cell.data(), nodes);
+        const DimsType &cell = *cellIt;
+        grid->GetCellNodes(cell, nodes);
         int numNodes = nodes.size();
 
         if (numNodes == 4) {

--- a/lib/render/VolumeOSPRay.cpp
+++ b/lib/render/VolumeOSPRay.cpp
@@ -745,7 +745,7 @@ OSPVolume VolumeOSPRay::_loadVolumeUnstructured(const Grid *grid)
     const auto           nodeDims = grid->GetDimensions();
     size_t               nodeDim = grid->GetNumDimensions();
     const size_t         nVerts = nodeDims[0] * nodeDims[1];
-    const DimsType       &cellDims = grid->GetCellDimensions();
+    const DimsType &     cellDims = grid->GetCellDimensions();
     const size_t         nCells = cellDims[0] * cellDims[1];
     VAssert(nodeDim == 2);
 

--- a/lib/render/WireFrameRenderer.cpp
+++ b/lib/render/WireFrameRenderer.cpp
@@ -196,7 +196,7 @@ void WireFrameRenderer::_buildCacheVertices(const Grid *grid, const Grid *height
 
         // Create an entry in nodeMap
         //
-        size_t index = Wasp::LinearizeCoords(*nodeItr, dims);
+        size_t index = Wasp::LinearizeCoords((*nodeItr).data(), dims.data(), dims.size());
 
         if (vertices.size() > std::numeric_limits<GLuint>::max()) {
 #ifndef NDEBUG
@@ -232,7 +232,7 @@ size_t WireFrameRenderer::_buildCacheConnectivity(const Grid *grid, const vector
     vector<DimsType> cellNodeIndices(maxVertsPerCell);
     vector<GLuint>   cellNodeIndicesLinear(maxVertsPerCell);
 
-    size_t numCells = Wasp::VProduct(grid->GetCellDimensions());
+    size_t numCells = Wasp::VProduct(grid->GetCellDimensions().data(), grid->GetNumCellDimensions());
     size_t maxLineIndices = numCells * (layered ? maxVertsPerCell / 2 * 3 : maxVertsPerCell * 2);
 
     // Pre-allocate memory for (much) better performance.

--- a/lib/vdc/ConstantGrid.cpp
+++ b/lib/vdc/ConstantGrid.cpp
@@ -39,17 +39,17 @@ std::vector<size_t> ConstantGrid::GetCoordDimensions(size_t) const
 
 size_t ConstantGrid::GetGeometryDim() const { return 3; }
 
-const VAPoR::DimsType ConstantGrid::GetNodeDimensions() const { return (GetDimensions()); }
+const VAPoR::DimsType &ConstantGrid::GetNodeDimensions() const { return (GetDimensions()); }
 
 const size_t ConstantGrid::GetNumNodeDimensions() const { return (GetNumDimensions()); }
 
-const std::vector<size_t> &ConstantGrid::GetCellDimensions() const
+const VAPoR::DimsType &ConstantGrid::GetCellDimensions() const
 {
-    auto tmp = GetDimensions();
-    _duplicate = {tmp[0], tmp[1], tmp[2]};
-    _duplicate.resize(GetNumDimensions());
+    _duplicate = GetDimensions();
     return _duplicate;
 }
+
+const size_t ConstantGrid::GetNumCellDimensions() const { return (GetNumDimensions()); }
 
 bool ConstantGrid::GetIndicesCell(const VAPoR::CoordType &coords, VAPoR::DimsType &indices) const { return false; }
 

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -323,7 +323,10 @@ void CurvilinearGrid::ConstCoordItrCG::next(const long &offset)
 
     DimsType maxIndex = {0, 0, 0};
 
-    for (int i = 0; i < ndims; i++) maxIndex[i] = dims[i] - 1;
+    for (int i = 0; i < ndims; i++) {
+        VAssert(dims[i] > 0);
+        maxIndex[i] = dims[i] - 1;
+    }
 
     long maxIndexL = Wasp::LinearizeCoords(maxIndex.data(), dims.data(), ndims);
     long newIndexL = Wasp::LinearizeCoords(_index.data(), dims.data(), ndims) + offset;

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -224,7 +224,7 @@ CurvilinearGrid::ConstCoordItrCG::ConstCoordItrCG(const CurvilinearGrid *cg, boo
     _cg = cg;
     auto dims = _cg->GetDimensions();
     auto ndims = _cg->GetNumDimensions();
-    _index = vector<size_t>(ndims, 0);
+    _index = {0,0,0};
     _terrainFollowing = _cg->_terrainFollowing;
     if (begin) {
         _xCoordItr = _cg->_xrg.cbegin();
@@ -237,14 +237,14 @@ CurvilinearGrid::ConstCoordItrCG::ConstCoordItrCG(const CurvilinearGrid *cg, boo
         _index[ndims - 1] = dims[ndims - 1];
         return;
     }
-    _coords.push_back(*_xCoordItr);
-    _coords.push_back(*_yCoordItr);
+    _coords[0] = *_xCoordItr;
+    _coords[1] = *_yCoordItr;
 
     if (ndims == 3) {
         if (_terrainFollowing) {
-            _coords.push_back(*_zCoordItr);
+            _coords[2] = *_zCoordItr;
         } else {
-            _coords.push_back(_cg->_zcoords[0]);
+            _coords[2] = _cg->_zcoords[0];
         }
     }
 }
@@ -263,8 +263,8 @@ CurvilinearGrid::ConstCoordItrCG::ConstCoordItrCG(const ConstCoordItrCG &rhs) : 
 CurvilinearGrid::ConstCoordItrCG::ConstCoordItrCG() : ConstCoordItrAbstract()
 {
     _cg = NULL;
-    _index.clear();
-    _coords.clear();
+    _index = {0,0,0};
+    _coords = {0.0,0.0,0.0};
 }
 
 void CurvilinearGrid::ConstCoordItrCG::next()
@@ -314,28 +314,28 @@ void CurvilinearGrid::ConstCoordItrCG::next()
 
 void CurvilinearGrid::ConstCoordItrCG::next(const long &offset)
 {
-    if (!_index.size()) return;
 
     auto dims = _cg->GetDimensions();
     auto ndims = _cg->GetNumDimensions();
 
-    vector<size_t> maxIndex;
-    maxIndex.reserve(3);
+    if (! ndims) return;
 
-    for (int i = 0; i < ndims; i++) maxIndex.push_back(dims[i] - 1);
+    DimsType maxIndex = {0,0,0};
+
+    for (int i = 0; i < ndims; i++) maxIndex[i] = dims[i] - 1;
 
     long maxIndexL = Wasp::LinearizeCoords(maxIndex.data(), dims.data(), ndims);
     long newIndexL = Wasp::LinearizeCoords(_index.data(), dims.data(), ndims) + offset;
     if (newIndexL < 0) { newIndexL = 0; }
     if (newIndexL > maxIndexL) {
-        _index = vector<size_t>(ndims, 0);
+        _index = {0,0,0};
         _index[ndims - 1] = dims[ndims - 1];
         return;
     }
 
     size_t index2DL = _index[1] * dims[0] + _index[0];
 
-    _index.assign(ndims, 0);
+    _index = {0,0,0};
     Wasp::VectorizeCoords(newIndexL, dims.data(), _index.data(), ndims);
 
     VAssert(_index[1] * dims[0] + _index[0] >= index2DL);
@@ -347,7 +347,7 @@ void CurvilinearGrid::ConstCoordItrCG::next(const long &offset)
     _coords[0] = *_xCoordItr;
     _coords[1] = *_yCoordItr;
 
-    if (dims.size() == 2) return;
+    if (ndims == 2) return;
 
     if (_terrainFollowing) {
         _zCoordItr += offset;
@@ -672,7 +672,7 @@ bool CurvilinearGrid::_insideGrid(double x, double y, double z, size_t &i, size_
 
 std::shared_ptr<QuadTreeRectangleP> CurvilinearGrid::_makeQuadTreeRectangle() const
 {
-    const vector<size_t> &dims = GetCellDimensions();
+    const DimsType &dims = GetCellDimensions();
     size_t                reserve_size = dims[0] * dims[1];
 
     CoordType minu, maxu;

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -224,7 +224,7 @@ CurvilinearGrid::ConstCoordItrCG::ConstCoordItrCG(const CurvilinearGrid *cg, boo
     _cg = cg;
     auto dims = _cg->GetDimensions();
     auto ndims = _cg->GetNumDimensions();
-    _index = {0,0,0};
+    _index = {0, 0, 0};
     _terrainFollowing = _cg->_terrainFollowing;
     if (begin) {
         _xCoordItr = _cg->_xrg.cbegin();
@@ -263,8 +263,8 @@ CurvilinearGrid::ConstCoordItrCG::ConstCoordItrCG(const ConstCoordItrCG &rhs) : 
 CurvilinearGrid::ConstCoordItrCG::ConstCoordItrCG() : ConstCoordItrAbstract()
 {
     _cg = NULL;
-    _index = {0,0,0};
-    _coords = {0.0,0.0,0.0};
+    _index = {0, 0, 0};
+    _coords = {0.0, 0.0, 0.0};
 }
 
 void CurvilinearGrid::ConstCoordItrCG::next()
@@ -318,9 +318,9 @@ void CurvilinearGrid::ConstCoordItrCG::next(const long &offset)
     auto dims = _cg->GetDimensions();
     auto ndims = _cg->GetNumDimensions();
 
-    if (! ndims) return;
+    if (!ndims) return;
 
-    DimsType maxIndex = {0,0,0};
+    DimsType maxIndex = {0, 0, 0};
 
     for (int i = 0; i < ndims; i++) maxIndex[i] = dims[i] - 1;
 
@@ -328,14 +328,14 @@ void CurvilinearGrid::ConstCoordItrCG::next(const long &offset)
     long newIndexL = Wasp::LinearizeCoords(_index.data(), dims.data(), ndims) + offset;
     if (newIndexL < 0) { newIndexL = 0; }
     if (newIndexL > maxIndexL) {
-        _index = {0,0,0};
+        _index = {0, 0, 0};
         _index[ndims - 1] = dims[ndims - 1];
         return;
     }
 
     size_t index2DL = _index[1] * dims[0] + _index[0];
 
-    _index = {0,0,0};
+    _index = {0, 0, 0};
     Wasp::VectorizeCoords(newIndexL, dims.data(), _index.data(), ndims);
 
     VAssert(_index[1] * dims[0] + _index[0] >= index2DL);
@@ -672,7 +672,7 @@ bool CurvilinearGrid::_insideGrid(double x, double y, double z, size_t &i, size_
 
 std::shared_ptr<QuadTreeRectangleP> CurvilinearGrid::_makeQuadTreeRectangle() const
 {
-    const DimsType &dims = GetCellDimensions();
+    const DimsType &      dims = GetCellDimensions();
     size_t                reserve_size = dims[0] * dims[1];
 
     CoordType minu, maxu;

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -225,6 +225,7 @@ CurvilinearGrid::ConstCoordItrCG::ConstCoordItrCG(const CurvilinearGrid *cg, boo
     auto dims = _cg->GetDimensions();
     auto ndims = _cg->GetNumDimensions();
     _index = {0, 0, 0};
+    _coords = {0.0, 0.0, 0.0};
     _terrainFollowing = _cg->_terrainFollowing;
     if (begin) {
         _xCoordItr = _cg->_xrg.cbegin();

--- a/lib/vdc/DCMPAS.cpp
+++ b/lib/vdc/DCMPAS.cpp
@@ -803,6 +803,7 @@ int DCMPAS::_readRegionEdgeVariable(MPASFileObject *w, const vector<size_t> &min
 
     vector<size_t> minAll, maxAll;
     for (int i = 0; i < dims.size(); i++) {
+        VAssert(dims[i] > 0);
         minAll.push_back(0);
         maxAll.push_back(dims[i] - 1);
     }

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -376,6 +376,7 @@ void map_blk_to_vox(const vector<size_t> &bs, const vector<size_t> &dims, const 
     vmax.clear();
 
     for (int i = 0; i < bs.size(); i++) {
+        VAssert(dims[i] > 0);
         vmin.push_back(bmin[i] * bs[i]);
         vmax.push_back(bmax[i] * bs[i] + bs[i] - 1);
         if (vmin[i] >= dims[i]) vmin[i] = dims[i] - 1;
@@ -1814,6 +1815,7 @@ int DataMgr::_get_unblocked_region_from_fs(size_t ts, string varname, int level,
         //
         vector<size_t> file_min, file_max;
         for (int i = 0; i < dims.size(); i++) {
+            VAssert(dims[i] > 0);
             vector<float> weights;
             downsample_compute_weights(dims[i], grid_dims[i], weights);
             int loffset = (int)weights[0];

--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -135,9 +135,9 @@ void blockit(const float *data, const vector<size_t> &dims, const vector<size_t>
     size_t block_size = vproduct(bs);
 
     vector<size_t> bdims;
-    for (int i = 0; i < bs.size(); i++) { 
+    for (int i = 0; i < bs.size(); i++) {
         VAssert(dims[i] > 0);
-        bdims.push_back(((dims[i] - 1) / bs[i]) + 1); 
+        bdims.push_back(((dims[i] - 1) / bs[i]) + 1);
     }
 
     size_t nbz = bdims.size() > 2 ? bdims[2] : 1;

--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -135,7 +135,10 @@ void blockit(const float *data, const vector<size_t> &dims, const vector<size_t>
     size_t block_size = vproduct(bs);
 
     vector<size_t> bdims;
-    for (int i = 0; i < bs.size(); i++) { bdims.push_back(((dims[i] - 1) / bs[i]) + 1); }
+    for (int i = 0; i < bs.size(); i++) { 
+        VAssert(dims[i] > 0);
+        bdims.push_back(((dims[i] - 1) / bs[i]) + 1); 
+    }
 
     size_t nbz = bdims.size() > 2 ? bdims[2] : 1;
     size_t nby = bdims.size() > 1 ? bdims[1] : 1;

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -266,8 +266,8 @@ Grid::ConstNodeIteratorSG::ConstNodeIteratorSG(const Grid *g, bool begin) : Cons
 {
     _dims = g->GetNodeDimensions();
     _nDims = g->GetNumNodeDimensions();
-    _index = {0,0,0};
-    _lastIndex = {0,0,0};
+    _index = {0, 0, 0};
+    _lastIndex = {0, 0, 0};
     if (_nDims) _lastIndex[_nDims - 1] = _dims[_nDims - 1];
 
     if (!begin) { _index = _lastIndex; }
@@ -283,15 +283,15 @@ Grid::ConstNodeIteratorSG::ConstNodeIteratorSG(const ConstNodeIteratorSG &rhs) :
 
 Grid::ConstNodeIteratorSG::ConstNodeIteratorSG() : ConstNodeIteratorAbstract()
 {
-    _dims = {1,1,1};
+    _dims = {1, 1, 1};
     _nDims = 0;
-    _index = {0,0,0};
-    _lastIndex = {0,0,0};
+    _index = {0, 0, 0};
+    _lastIndex = {0, 0, 0};
 }
 
 void Grid::ConstNodeIteratorSG::next()
 {
-    if (! _nDims) return;
+    if (!_nDims) return;
 
     _index[0]++;
     if (_index[0] < _dims[0] || _nDims == 1) { return; }
@@ -360,9 +360,9 @@ Grid::ConstCellIteratorSG::ConstCellIteratorSG(const Grid *g, bool begin) : Cons
 {
     _dims = g->GetCellDimensions();
     _nDims = g->GetNumCellDimensions();
-    _index = {0,0,0};
+    _index = {0, 0, 0};
     _lastIndex = _index;
-    _lastIndex[_nDims - 1] = _dims[_nDims- 1];
+    _lastIndex[_nDims - 1] = _dims[_nDims - 1];
     if (!begin) { _index = _lastIndex; }
 }
 
@@ -376,10 +376,10 @@ Grid::ConstCellIteratorSG::ConstCellIteratorSG(const ConstCellIteratorSG &rhs) :
 
 Grid::ConstCellIteratorSG::ConstCellIteratorSG() : ConstCellIteratorAbstract()
 {
-    _dims = {1,1,1};
+    _dims = {1, 1, 1};
     _nDims = 0;
-    _index = {0,0,0};
-    _lastIndex = {0,0,0};
+    _index = {0, 0, 0};
+    _lastIndex = {0, 0, 0};
 }
 
 void Grid::ConstCellIteratorSG::next()
@@ -514,7 +514,7 @@ template<class T> Grid::ForwardIterator<T>::ForwardIterator(T *rg, bool begin, c
     }
     _blocksize = Wasp::VProduct(_bs3d.data(), _bs3d.size());
 
-    _index = {0,0,0};
+    _index = {0, 0, 0};
     _indexL = 0;
 
     _end_indexL = 0;
@@ -561,7 +561,7 @@ template<class T> Grid::ForwardIterator<T>::ForwardIterator()
     _bs3d = {1, 1, 1};
     _blocksize = 1;
     //_coordItr = xx;
-    _index = {0,0,0};
+    _index = {0, 0, 0};
     _indexL = 0;
     _end_indexL = 0;
     _xb = 0;

--- a/lib/vdc/GridHelper.cpp
+++ b/lib/vdc/GridHelper.cpp
@@ -144,6 +144,7 @@ RegularGrid *GridHelper::_make_grid_regular(const vector<size_t> &dims, const ve
 
     vector<double> minu, maxu;
     for (int i = 0; i < dims.size(); i++) {
+        VAssert(dims[i] > 0);
         float *coords = blkvec[i + 1];
         minu.push_back(coords[0]);
         maxu.push_back(coords[dims[i] - 1]);

--- a/lib/vdc/LayeredGrid.cpp
+++ b/lib/vdc/LayeredGrid.cpp
@@ -328,7 +328,7 @@ LayeredGrid::ConstCoordItrLayered::ConstCoordItrLayered(const LayeredGrid *lg, b
 {
     _lg = lg;
     _nElements2D = lg->GetDimensions()[0] * lg->GetDimensions()[1];
-    _coords = vector<double>(3, 0.0);
+    _coords = {0.0, 0.0, 0.0};
 
     if (begin) {
         _index2D = 0;
@@ -351,7 +351,7 @@ LayeredGrid::ConstCoordItrLayered::ConstCoordItrLayered(const ConstCoordItrLayer
     _itr2D = rhs._itr2D;
 }
 
-LayeredGrid::ConstCoordItrLayered::ConstCoordItrLayered() : ConstCoordItrAbstract() { _coords.clear(); }
+LayeredGrid::ConstCoordItrLayered::ConstCoordItrLayered() : ConstCoordItrAbstract() { _coords = {0.0, 0.0, 0.0}; }
 
 void LayeredGrid::ConstCoordItrLayered::next()
 {

--- a/lib/vdc/NetCDFCollection.cpp
+++ b/lib/vdc/NetCDFCollection.cpp
@@ -352,6 +352,7 @@ vector<size_t> NetCDFCollection::GetSpatialDims(string varname) const
     for (int i = 0; i < mydims.size(); i++) {
         dims.push_back(mydims[i]);
         for (int j = 0; j < _staggeredDims.size(); j++) {
+            VAssert(mydims[i] > 0);
             if (dimnames[i].compare(_staggeredDims[j]) == 0) { dims[i] = mydims[i] - 1; }
         }
     }

--- a/lib/vdc/QuadTreeRectangleP.cpp
+++ b/lib/vdc/QuadTreeRectangleP.cpp
@@ -160,7 +160,7 @@ bool QuadTreeRectangleP::Insert(std::vector<class QuadTreeRectangle<float, pType
 
 bool QuadTreeRectangleP::Insert(const Grid *grid, size_t ncells)
 {
-    if (ncells == 0) { ncells = Wasp::VProduct(grid->GetCellDimensions()); }
+    if (ncells == 0) { ncells = Wasp::VProduct(grid->GetCellDimensions().data(), grid->GetNumCellDimensions()); }
 
     // parRectangles and parPayloads will contain the rectangles and their
     // payloads that need to be inserted into each substree
@@ -172,7 +172,7 @@ bool QuadTreeRectangleP::Insert(const Grid *grid, size_t ncells)
         parPayloads[i].reserve(ncells / _qtrs.size());
     }
 
-    int ncellindices = grid->GetCellDimensions().size();
+    int ncellindices = grid->GetNumCellDimensions();
 
 // Populate parRectangles and parPayloads with the data that will
 // be used to contruct the quadtree

--- a/lib/vdc/RegularGrid.cpp
+++ b/lib/vdc/RegularGrid.cpp
@@ -222,6 +222,7 @@ void RegularGrid::GetUserCoordinates(const DimsType &indices, CoordType &coords)
 
     for (int i = 0; i < GetNumDimensions(); i++) {
         size_t index = cIndices[i];
+        VAssert(dims[i] > 0);
 
         if (index >= dims[i]) { index = dims[i] - 1; }
 
@@ -240,6 +241,7 @@ bool RegularGrid::GetIndicesCell(const CoordType &coords, DimsType &indices) con
 
     VAssert(GetGeometryDim() <= 3);
     for (int i = 0; i < GetGeometryDim(); i++) {
+        VAssert(dims[i] > 0);
         if (cCoords[i] < _minu[i] || cCoords[i] > _maxu[i]) { return (false); }
 
         if (_delta[i] != 0.0) {

--- a/lib/vdc/RegularGrid.cpp
+++ b/lib/vdc/RegularGrid.cpp
@@ -22,7 +22,7 @@ void RegularGrid::_SetExtents(const vector<double> &minu, const vector<double> &
 {
     VAssert(minu.size() == maxu.size());
 
-    _delta.clear();
+    _delta = {0.0, 0.0, 0.0};
     _geometryDim = minu.size();
 
     CopyToArr3(minu, _minu);
@@ -31,9 +31,9 @@ void RegularGrid::_SetExtents(const vector<double> &minu, const vector<double> &
     auto dims = GetDimensions();
     for (int i = 0; i < GetNumDimensions(); i++) {
         if (dims[i] > 1) {
-            _delta.push_back((_maxu[i] - _minu[i]) / (double)(dims[i] - 1));
+            _delta[i] = (_maxu[i] - _minu[i]) / (double)(dims[i] - 1);
         } else {
-            _delta.push_back(0.0);
+            _delta[i] = 0.0;
         }
     }
 }
@@ -273,22 +273,21 @@ bool RegularGrid::InsideGrid(const CoordType &coords) const
 
 RegularGrid::ConstCoordItrRG::ConstCoordItrRG(const RegularGrid *rg, bool begin) : ConstCoordItrAbstract()
 {
-    auto tmp = rg->GetDimensions();
-    _dims = {tmp[0], tmp[1], tmp[2]};
-    _dims.resize(rg->GetNumDimensions());
+    _dims = rg->GetDimensions();
+    _nDims = rg->GetNumDimensions();
     _delta = rg->_delta;
+    _minu = rg->_minu;
+    _coords = rg->_minu;
+    _index = {0,0,0};
 
-    Grid::CopyFromArr3(rg->_minu, _minu);
-    Grid::CopyFromArr3(rg->_minu, _coords);
-
-    _index = vector<size_t>(_dims.size(), 0);
-    if (!begin) { _index[_dims.size() - 1] = _dims[_dims.size() - 1]; }
+    if (!begin) { _index[_nDims - 1] = _dims[_nDims - 1]; }
 }
 
 RegularGrid::ConstCoordItrRG::ConstCoordItrRG(const ConstCoordItrRG &rhs) : ConstCoordItrAbstract()
 {
     _index = rhs._index;
     _dims = rhs._dims;
+    _nDims = rhs._nDims;
     _minu = rhs._minu;
     _delta = rhs._delta;
     _coords = rhs._coords;
@@ -296,11 +295,11 @@ RegularGrid::ConstCoordItrRG::ConstCoordItrRG(const ConstCoordItrRG &rhs) : Cons
 
 RegularGrid::ConstCoordItrRG::ConstCoordItrRG() : ConstCoordItrAbstract()
 {
-    _index.clear();
-    _dims.clear();
-    _minu.clear();
-    _delta.clear();
-    _coords.clear();
+    _index = {0,0,0};
+    _dims = {1,1,1};
+    _minu = {0.0,0.0,0.0};
+    _delta = {0.0,0.0,0.0};
+    _coords = {0.0,0.0,0.0};
 }
 
 void RegularGrid::ConstCoordItrRG::next()
@@ -316,7 +315,7 @@ void RegularGrid::ConstCoordItrRG::next()
 
     if (_index[1] < _dims[1]) { return; }
 
-    if (_dims.size() == 2) { return; }
+    if (_nDims == 2) { return; }
 
     _index[1] = 0;
     _coords[1] = _minu[1];
@@ -326,22 +325,22 @@ void RegularGrid::ConstCoordItrRG::next()
 
 void RegularGrid::ConstCoordItrRG::next(const long &offset)
 {
-    if (!_index.size()) return;
+    if (!_nDims) return;
 
-    static vector<size_t> maxIndex(_dims.size());
+    static DimsType maxIndex = {0,0,0};
     ;
-    for (int i = 0; i < _dims.size(); i++) maxIndex[i] = _dims[i] - 1;
+    for (int i = 0; i < _nDims; i++) maxIndex[i] = _dims[i] - 1;
 
-    long maxIndexL = Wasp::LinearizeCoords(maxIndex, _dims);
-    long newIndexL = Wasp::LinearizeCoords(_index, _dims) + offset;
+    long maxIndexL = Wasp::LinearizeCoords(maxIndex.data(), _dims.data(), _dims.size());
+    long newIndexL = Wasp::LinearizeCoords(_index.data(), _dims.data(), _dims.size()) + offset;
     if (newIndexL < 0) { newIndexL = 0; }
     if (newIndexL > maxIndexL) {
-        _index = vector<size_t>(_dims.size(), 0);
-        _index[_dims.size() - 1] = _dims[_dims.size() - 1];
+        _index = {0,0,0};
+        _index[_nDims - 1] = _dims[_nDims - 1];
         return;
     }
 
-    _index = Wasp::VectorizeCoords(newIndexL, _dims);
+    Wasp::VectorizeCoords(newIndexL, _dims.data(), _index.data(), _dims.size());
 
     for (int i = 0; i < _dims.size(); i++) { _coords[i] = _index[i] * _delta[i] + _minu[i]; }
 }

--- a/lib/vdc/RegularGrid.cpp
+++ b/lib/vdc/RegularGrid.cpp
@@ -278,7 +278,7 @@ RegularGrid::ConstCoordItrRG::ConstCoordItrRG(const RegularGrid *rg, bool begin)
     _delta = rg->_delta;
     _minu = rg->_minu;
     _coords = rg->_minu;
-    _index = {0,0,0};
+    _index = {0, 0, 0};
 
     if (!begin) { _index[_nDims - 1] = _dims[_nDims - 1]; }
 }
@@ -295,11 +295,11 @@ RegularGrid::ConstCoordItrRG::ConstCoordItrRG(const ConstCoordItrRG &rhs) : Cons
 
 RegularGrid::ConstCoordItrRG::ConstCoordItrRG() : ConstCoordItrAbstract()
 {
-    _index = {0,0,0};
-    _dims = {1,1,1};
-    _minu = {0.0,0.0,0.0};
-    _delta = {0.0,0.0,0.0};
-    _coords = {0.0,0.0,0.0};
+    _index = {0, 0, 0};
+    _dims = {1, 1, 1};
+    _minu = {0.0, 0.0, 0.0};
+    _delta = {0.0, 0.0, 0.0};
+    _coords = {0.0, 0.0, 0.0};
 }
 
 void RegularGrid::ConstCoordItrRG::next()
@@ -327,7 +327,7 @@ void RegularGrid::ConstCoordItrRG::next(const long &offset)
 {
     if (!_nDims) return;
 
-    static DimsType maxIndex = {0,0,0};
+    static DimsType maxIndex = {0, 0, 0};
     ;
     for (int i = 0; i < _nDims; i++) maxIndex[i] = _dims[i] - 1;
 
@@ -335,7 +335,7 @@ void RegularGrid::ConstCoordItrRG::next(const long &offset)
     long newIndexL = Wasp::LinearizeCoords(_index.data(), _dims.data(), _dims.size()) + offset;
     if (newIndexL < 0) { newIndexL = 0; }
     if (newIndexL > maxIndexL) {
-        _index = {0,0,0};
+        _index = {0, 0, 0};
         _index[_nDims - 1] = _dims[_nDims - 1];
         return;
     }

--- a/lib/vdc/StretchedGrid.cpp
+++ b/lib/vdc/StretchedGrid.cpp
@@ -152,15 +152,16 @@ bool StretchedGrid::InsideGrid(const CoordType &coords) const
 StretchedGrid::ConstCoordItrSG::ConstCoordItrSG(const StretchedGrid *sg, bool begin) : ConstCoordItrAbstract()
 {
     _sg = sg;
-    auto dims = _sg->GetDimensions();
-    auto ndims = _sg->GetNumDimensions();
+    _index = {0,0,0};
+    _coords = {0.0, 0.0, 0.0};
+    size_t ndims = sg->GetGeometryDim();
+    const DimsType &dims = sg->GetDimensions();
 
-    _index = vector<size_t>(ndims, 0);
     if (!begin) { _index[ndims - 1] = dims[ndims - 1]; }
 
-    _coords.push_back(_sg->_xcoords[0]);
-    _coords.push_back(_sg->_ycoords[0]);
-    if (ndims == 3) { _coords.push_back(_sg->_zcoords[0]); }
+    _coords[0] = _sg->_xcoords[0];
+    _coords[1] = _sg->_ycoords[0];
+    if (ndims == 3) { _coords[2] = _sg->_zcoords[0]; }
 }
 
 StretchedGrid::ConstCoordItrSG::ConstCoordItrSG(const ConstCoordItrSG &rhs) : ConstCoordItrAbstract()
@@ -173,8 +174,8 @@ StretchedGrid::ConstCoordItrSG::ConstCoordItrSG(const ConstCoordItrSG &rhs) : Co
 StretchedGrid::ConstCoordItrSG::ConstCoordItrSG() : ConstCoordItrAbstract()
 {
     _sg = NULL;
-    _index.clear();
-    _coords.clear();
+    _index = {0,0,0};
+    _coords = {0.0,0.0,0.0};
 }
 
 void StretchedGrid::ConstCoordItrSG::next()
@@ -227,12 +228,12 @@ void StretchedGrid::ConstCoordItrSG::next(const long &offset)
     long newIndexL = Wasp::LinearizeCoords(_index.data(), dims.data(), ndims) + offset;
     if (newIndexL < 0) { newIndexL = 0; }
     if (newIndexL > maxIndexL) {
-        _index = vector<size_t>(ndims, 0);
+        _index = {0,0,0};
         _index[ndims - 1] = dims[ndims - 1];
         return;
     }
 
-    _index.assign(ndims, 0);
+    _index = {0,0,0};
     Wasp::VectorizeCoords(newIndexL, dims.data(), _index.data(), ndims);
 
     _coords[0] = _sg->_xcoords[_index[0]];

--- a/lib/vdc/StretchedGrid.cpp
+++ b/lib/vdc/StretchedGrid.cpp
@@ -152,9 +152,9 @@ bool StretchedGrid::InsideGrid(const CoordType &coords) const
 StretchedGrid::ConstCoordItrSG::ConstCoordItrSG(const StretchedGrid *sg, bool begin) : ConstCoordItrAbstract()
 {
     _sg = sg;
-    _index = {0,0,0};
+    _index = {0, 0, 0};
     _coords = {0.0, 0.0, 0.0};
-    size_t ndims = sg->GetGeometryDim();
+    size_t          ndims = sg->GetGeometryDim();
     const DimsType &dims = sg->GetDimensions();
 
     if (!begin) { _index[ndims - 1] = dims[ndims - 1]; }
@@ -174,8 +174,8 @@ StretchedGrid::ConstCoordItrSG::ConstCoordItrSG(const ConstCoordItrSG &rhs) : Co
 StretchedGrid::ConstCoordItrSG::ConstCoordItrSG() : ConstCoordItrAbstract()
 {
     _sg = NULL;
-    _index = {0,0,0};
-    _coords = {0.0,0.0,0.0};
+    _index = {0, 0, 0};
+    _coords = {0.0, 0.0, 0.0};
 }
 
 void StretchedGrid::ConstCoordItrSG::next()
@@ -228,12 +228,12 @@ void StretchedGrid::ConstCoordItrSG::next(const long &offset)
     long newIndexL = Wasp::LinearizeCoords(_index.data(), dims.data(), ndims) + offset;
     if (newIndexL < 0) { newIndexL = 0; }
     if (newIndexL > maxIndexL) {
-        _index = {0,0,0};
+        _index = {0, 0, 0};
         _index[ndims - 1] = dims[ndims - 1];
         return;
     }
 
-    _index = {0,0,0};
+    _index = {0, 0, 0};
     Wasp::VectorizeCoords(newIndexL, dims.data(), _index.data(), ndims);
 
     _coords[0] = _sg->_xcoords[_index[0]];

--- a/lib/vdc/StructuredGrid.cpp
+++ b/lib/vdc/StructuredGrid.cpp
@@ -167,6 +167,7 @@ bool StructuredGrid::GetNodeCells(const DimsType &indices, std::vector<DimsType>
     // Check if invalid indices
     //
     for (int i = 0; i < GetGeometryDim(); i++) {
+        VAssert(dims[i] > 0);
         if (indices[i] > (dims[i] - 1)) return (false);
     }
 

--- a/lib/vdc/StructuredGrid.cpp
+++ b/lib/vdc/StructuredGrid.cpp
@@ -25,16 +25,14 @@ StructuredGrid::StructuredGrid(const vector<size_t> &dims, const vector<size_t> 
 {
     VAssert(bs.size() == 2 || bs.size() == 3);
 
-    auto tmp = Grid::GetDimensions();
-    _cellDims = {tmp[0], tmp[1], tmp[2]};
-    _cellDims.resize(Grid::GetNumDimensions());
+    _cellDims = Grid::GetDimensions();
     for (int i = 0; i < _cellDims.size(); i++) {
         _cellDims[i]--;
         if (_cellDims[i] < 1) _cellDims[i] = 1;
     }
 }
 
-const DimsType StructuredGrid::GetNodeDimensions() const { return GetDimensions(); }
+const DimsType &StructuredGrid::GetNodeDimensions() const { return GetDimensions(); }
 
 const size_t StructuredGrid::GetNumNodeDimensions() const { return GetNumDimensions(); }
 

--- a/lib/vdc/UnstructuredGrid.cpp
+++ b/lib/vdc/UnstructuredGrid.cpp
@@ -33,9 +33,9 @@ UnstructuredGrid::UnstructuredGrid(const std::vector<size_t> &vertexDims, const 
     //
     VAssert(location == NODE || location == CELL);
 
-    _vertexDims = {1,1,1};
-    _faceDims = {1,1,1};
-    _edgeDims = {1,1,1};
+    _vertexDims = {1, 1, 1};
+    _faceDims = {1, 1, 1};
+    _edgeDims = {1, 1, 1};
     _nDims = vertexDims.size();
 
     CopyToArr3(vertexDims, _vertexDims);
@@ -60,10 +60,7 @@ UnstructuredGrid::UnstructuredGrid(const std::vector<size_t> &vertexDims, const 
 }
 
 
-const VAPoR::DimsType &UnstructuredGrid::GetNodeDimensions() const
-{
-    return(_vertexDims);
-}
+const VAPoR::DimsType &UnstructuredGrid::GetNodeDimensions() const { return (_vertexDims); }
 
 
 const size_t UnstructuredGrid::GetNumNodeDimensions() const { return _nDims; }

--- a/lib/vdc/UnstructuredGrid2D.cpp
+++ b/lib/vdc/UnstructuredGrid2D.cpp
@@ -258,7 +258,7 @@ float UnstructuredGrid2D::GetValueLinear(const CoordType &coords) const
 UnstructuredGrid2D::ConstCoordItrU2D::ConstCoordItrU2D(const UnstructuredGrid2D *ug, bool begin) : ConstCoordItrAbstract()
 {
     _ncoords = ug->GetGeometryDim();
-    _coords = vector<double>(_ncoords, 0.0);
+    _coords = {0.0, 0.0, 0.0};
     if (begin) {
         _xCoordItr = ug->_xug.cbegin();
         _yCoordItr = ug->_yug.cbegin();

--- a/lib/vdc/UnstructuredGrid3D.cpp
+++ b/lib/vdc/UnstructuredGrid3D.cpp
@@ -173,7 +173,7 @@ float UnstructuredGrid3D::GetValueLinear(const CoordType &coords) const
 UnstructuredGrid3D::ConstCoordItrU3D::ConstCoordItrU3D(const UnstructuredGrid3D *ug, bool begin) : ConstCoordItrAbstract()
 {
     _ug = ug;
-    _coords = vector<double>(3, 0.0);
+    _coords = {0.0, 0.0, 0.0};
     if (begin) {
         _xCoordItr = ug->_xug.cbegin();
         _yCoordItr = ug->_yug.cbegin();

--- a/lib/vdc/UnstructuredGridLayered.cpp
+++ b/lib/vdc/UnstructuredGridLayered.cpp
@@ -230,7 +230,7 @@ float UnstructuredGridLayered::GetValueLinear(const CoordType &coords) const
 UnstructuredGridLayered::ConstCoordItrULayered::ConstCoordItrULayered(const UnstructuredGridLayered *ug, bool begin) : ConstCoordItrAbstract()
 {
     _ug = ug;
-    _coords = vector<double>(3, 0.0);
+    _coords = {0.0, 0.0, 0.0};
     _nElements2D = ug->GetDimensions()[0];
     if (begin) {
         _itr2D = ug->_ug2d.ConstCoordBegin();

--- a/test_apps/datamgr/test_datamgr.cpp
+++ b/test_apps/datamgr/test_datamgr.cpp
@@ -162,7 +162,12 @@ void test_node_iterator(const Grid *g, vector<double> minu, vector<double> maxu)
     Grid::ConstNodeIterator enditr = g->ConstNodeEnd();
 
     float t0 = GetTime();
-    itr = g->ConstNodeBegin(minu, maxu);
+
+    CoordType minuCT = {0.0, 0.0, 0.0};
+    CoordType maxuCT = {0.0, 0.0, 0.0};
+    Grid::CopyToArr3(minu, minuCT);
+    Grid::CopyToArr3(maxu, maxuCT);
+    itr = g->ConstNodeBegin(minuCT, maxuCT);
 
     size_t count = 0;
     for (; itr != enditr; ++itr) { count++; }

--- a/test_apps/grid_iter/test_grid_iter.cpp
+++ b/test_apps/grid_iter/test_grid_iter.cpp
@@ -417,7 +417,11 @@ void test_node_iterator(const StructuredGrid *sg)
     if (opt.roimin == opt.minu && opt.roimax == opt.maxu) {
         itr = sg->ConstNodeBegin();
     } else {
-        itr = sg->ConstNodeBegin(opt.roimin, opt.roimax);
+        CoordType roimin = {0.0, 0.0, 0.0};
+        CoordType roimax = {0.0, 0.0, 0.0};
+        Grid::CopyToArr3(opt.roimin, roimin);
+        Grid::CopyToArr3(opt.roimax, roimax);
+        itr = sg->ConstNodeBegin(roimin, roimax);
     }
     size_t count = 0;
     //    for ( ; itr!=sg->ConstNodeEnd(); ++itr)
@@ -443,7 +447,11 @@ void test_cell_iterator(const StructuredGrid *sg)
     if (opt.roimin == opt.minu && opt.roimax == opt.maxu) {
         itr = sg->ConstCellBegin();
     } else {
-        itr = sg->ConstCellBegin(opt.roimin, opt.roimax);
+        CoordType roimin = {0.0, 0.0, 0.0};
+        CoordType roimax = {0.0, 0.0, 0.0};
+        Grid::CopyToArr3(opt.roimin, roimin);
+        Grid::CopyToArr3(opt.roimax, roimax);
+        itr = sg->ConstCellBegin(roimin, roimax);
     }
 
     size_t count = 0;
@@ -521,7 +529,7 @@ void test_getvalue(StructuredGrid *sg)
     float               maxErr = 0.0;
     for (itr = sg->cbegin(); itr != enditr; ++itr, ++coord_itr) {
         float                 v1 = *itr;
-        const vector<double> &coord = *coord_itr;
+        const CoordType &coord = *coord_itr;
 
         float v2 = sg->GetValue(coord);
 
@@ -547,11 +555,12 @@ void test_roi_iterator()
     RegularGrid *rg = new RegularGrid(dims, bs, blks, minu, maxu);
 
     vector<double> delta;
-    vector<double> roiminu, roimaxu;
+	CoordType roiminu = {0.0, 0.0, 0.0};
+	CoordType roimaxu = {0.0, 0.0, 0.0};
     for (int i = 0; i < minu.size(); i++) {
         delta.push_back(maxu[i] - minu[i] / (dims[i] - 1));
-        roiminu.push_back(minu[i] + (delta[i] / 0.5));
-        roimaxu.push_back(maxu[i] - (delta[i] / 0.5));
+        roiminu[i] = minu[i] + (delta[i] / 0.5);
+        roimaxu[i] = maxu[i] - (delta[i] / 0.5);
     }
 
     size_t idx = 0;

--- a/test_apps/grid_iter/test_grid_iter.cpp
+++ b/test_apps/grid_iter/test_grid_iter.cpp
@@ -529,7 +529,7 @@ void test_getvalue(StructuredGrid *sg)
     float               maxErr = 0.0;
     for (itr = sg->cbegin(); itr != enditr; ++itr, ++coord_itr) {
         float                 v1 = *itr;
-        const CoordType &coord = *coord_itr;
+        const CoordType &     coord = *coord_itr;
 
         float v2 = sg->GetValue(coord);
 
@@ -555,8 +555,8 @@ void test_roi_iterator()
     RegularGrid *rg = new RegularGrid(dims, bs, blks, minu, maxu);
 
     vector<double> delta;
-	CoordType roiminu = {0.0, 0.0, 0.0};
-	CoordType roimaxu = {0.0, 0.0, 0.0};
+    CoordType      roiminu = {0.0, 0.0, 0.0};
+    CoordType      roimaxu = {0.0, 0.0, 0.0};
     for (int i = 0; i < minu.size(); i++) {
         delta.push_back(maxu[i] - minu[i] / (dims[i] - 1));
         roiminu[i] = minu[i] + (delta[i] / 0.5);

--- a/test_apps/smokeTests/gridTools.cpp
+++ b/test_apps/smokeTests/gridTools.cpp
@@ -67,7 +67,7 @@ vector<float *> AllocateBlocks(const vector<size_t> &bs, const vector<size_t> &d
 
 void MakeTriangle(Grid *grid, float minVal, float maxVal)
 {
-    auto dims = grid->GetDimensions();
+    auto   dims = grid->GetDimensions();
     size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
     size_t y = nDims > 1 ? dims[Y] : 1;
@@ -86,7 +86,7 @@ void MakeTriangle(Grid *grid, float minVal, float maxVal)
 
 void MakeConstantField(Grid *grid, float value)
 {
-    auto dims = grid->GetDimensions();
+    auto   dims = grid->GetDimensions();
     size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
     size_t y = nDims > 1 ? dims[Y] : 1;
@@ -101,7 +101,7 @@ void MakeConstantField(Grid *grid, float value)
 
 void MakeRamp(Grid *grid, float minVal, float maxVal)
 {
-    auto dims = grid->GetDimensions();
+    auto   dims = grid->GetDimensions();
     size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
     size_t y = nDims > 1 ? dims[Y] : 1;
@@ -122,7 +122,7 @@ void MakeRamp(Grid *grid, float minVal, float maxVal)
 
 void MakeRampOnAxis(Grid *grid, float minVal, float maxVal, size_t axis = X)
 {
-    auto dims = grid->GetDimensions();
+    auto   dims = grid->GetDimensions();
     size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
     size_t y = nDims > 1 ? dims[Y] : 1;
@@ -161,7 +161,7 @@ bool CompareIndexToCoords(VAPoR::Grid *grid,
     disagreements = 0;
     numMissingValues = 0;
 
-    auto dims = grid->GetDimensions();
+    auto   dims = grid->GetDimensions();
     size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
     size_t y = nDims > 1 ? dims[Y] : 1;
@@ -342,7 +342,7 @@ bool RunTest(Grid *grid)
 
 bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, float maxVal)
 {
-    auto dims = grid->GetDimensions();
+    auto   dims = grid->GetDimensions();
     size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
     size_t y = nDims > 1 ? dims[Y] : 1;

--- a/test_apps/smokeTests/gridTools.cpp
+++ b/test_apps/smokeTests/gridTools.cpp
@@ -67,12 +67,11 @@ vector<float *> AllocateBlocks(const vector<size_t> &bs, const vector<size_t> &d
 
 void MakeTriangle(Grid *grid, float minVal, float maxVal)
 {
-    auto tmp = grid->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-    dims.resize(grid->GetNumDimensions());
+    auto dims = grid->GetDimensions();
+    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = dims.size() > 1 ? dims[Y] : 1;
-    size_t z = dims.size() > 2 ? dims[Z] : 1;
+    size_t y = nDims > 1 ? dims[Y] : 1;
+    size_t z = nDims > 2 ? dims[Z] : 1;
 
     float value = minVal;
     for (size_t k = 0; k < z; k++) {
@@ -87,12 +86,11 @@ void MakeTriangle(Grid *grid, float minVal, float maxVal)
 
 void MakeConstantField(Grid *grid, float value)
 {
-    auto tmp = grid->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-    dims.resize(grid->GetNumDimensions());
+    auto dims = grid->GetDimensions();
+    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = dims.size() > 1 ? dims[Y] : 1;
-    size_t z = dims.size() > 2 ? dims[Z] : 1;
+    size_t y = nDims > 1 ? dims[Y] : 1;
+    size_t z = nDims > 2 ? dims[Z] : 1;
 
     for (size_t k = 0; k < z; k++) {
         for (size_t j = 0; j < y; j++) {
@@ -103,12 +101,11 @@ void MakeConstantField(Grid *grid, float value)
 
 void MakeRamp(Grid *grid, float minVal, float maxVal)
 {
-    auto tmp = grid->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-    dims.resize(grid->GetNumDimensions());
+    auto dims = grid->GetDimensions();
+    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = dims.size() > 1 ? dims[Y] : 1;
-    size_t z = dims.size() > 2 ? dims[Z] : 1;
+    size_t y = nDims > 1 ? dims[Y] : 1;
+    size_t z = nDims > 2 ? dims[Z] : 1;
 
     float increment = (maxVal - minVal) / ((x * y * z - 1) == 0 ? 1 : (x * y * z - 1));
 
@@ -125,12 +122,11 @@ void MakeRamp(Grid *grid, float minVal, float maxVal)
 
 void MakeRampOnAxis(Grid *grid, float minVal, float maxVal, size_t axis = X)
 {
-    auto tmp = grid->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-    dims.resize(grid->GetNumDimensions());
+    auto dims = grid->GetDimensions();
+    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = dims.size() > 1 ? dims[Y] : 1;
-    size_t z = dims.size() > 2 ? dims[Z] : 1;
+    size_t y = nDims > 1 ? dims[Y] : 1;
+    size_t z = nDims > 2 ? dims[Z] : 1;
 
     float xIncrement = axis == X ? (maxVal - minVal) / (dims[X] - 1) : 0;
     float yIncrement = axis == Y ? (maxVal - minVal) / (dims[Y] - 1) : 0;
@@ -165,12 +161,11 @@ bool CompareIndexToCoords(VAPoR::Grid *grid,
     disagreements = 0;
     numMissingValues = 0;
 
-    auto tmp = grid->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-    dims.resize(grid->GetNumDimensions());
+    auto dims = grid->GetDimensions();
+    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = dims.size() > 1 ? dims[Y] : 1;
-    size_t z = dims.size() > 2 ? dims[Z] : 1;
+    size_t y = nDims > 1 ? dims[Y] : 1;
+    size_t z = nDims > 2 ? dims[Z] : 1;
 
     double peak = 0.f;
     double sum = 0;
@@ -218,19 +213,14 @@ bool TestConstNodeIterator(const Grid *g, size_t &count, size_t &expectedCount, 
 
     itr = g->ConstNodeBegin();
 
-    auto tmp = g->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
+    auto dims = g->GetDimensions();
     for (auto dim : dims) expectedCount *= dim;
 
     for (; itr != enditr; ++itr) {
-        std::vector<size_t> ijk = Wasp::VectorizeCoords(count, dims);
         DimsType            ijk3 = {0, 0, 0};
-        std::copy_n(ijk.begin(), ijk3.size(), ijk3.begin());
+        Wasp::VectorizeCoords(count, dims.data(), ijk3.data(), dims.size());
 
-        DimsType itr3 = {0, 0, 0};
-        std::copy_n((*itr).begin(), (*itr).size(), itr3.begin());
-
-        double itrData = g->GetValueAtIndex(itr3);
+        double itrData = g->GetValueAtIndex(*itr);
         double gridData = g->GetValueAtIndex(ijk3);
 
         if (!Wasp::NearlyEqual(itrData, gridData)) { disagreements++; }
@@ -257,13 +247,12 @@ bool TestIterator(Grid *g, size_t &count, size_t &expectedCount, size_t &disagre
 
     itr = g->begin();
 
-    auto tmp = g->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-    dims.resize(g->GetNumDimensions());
+    auto dims = g->GetDimensions();
     for (auto dim : dims) expectedCount *= dim;
 
     for (; itr != enditr; ++itr) {
-        std::vector<size_t> ijk = Wasp::VectorizeCoords(count, dims);
+        DimsType ijk;
+        Wasp::VectorizeCoords(count, dims.data(), ijk.data(), dims.size());
 
         if (!Wasp::NearlyEqual(*itr, g->GetValueAtIndex(ijk))) { disagreements++; }
 
@@ -289,13 +278,12 @@ bool TestConstCoordItr(const Grid *g, size_t &count, size_t &expectedCount, size
 
     itr = g->ConstCoordBegin();
 
-    auto tmp = g->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
+    auto dims = g->GetDimensions();
     for (auto dim : dims) expectedCount *= dim;
 
     for (; itr != enditr; ++itr) {
-        std::vector<size_t> ijkVec = Wasp::VectorizeCoords(count, dims);
-        DimsType            ijk = {ijkVec[X], ijkVec[Y], ijkVec[Z]};
+        DimsType ijk;
+        Wasp::VectorizeCoords(count, dims.data(), ijk.data(), dims.size());
         CoordType           coords;
 
         bool disagree = false;
@@ -354,12 +342,11 @@ bool RunTest(Grid *grid)
 
 bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, float maxVal)
 {
-    auto tmp = grid->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-    dims.resize(grid->GetNumDimensions());
+    auto dims = grid->GetDimensions();
+    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = dims.size() > 1 ? dims[Y] : 1;
-    size_t z = dims.size() > 2 ? dims[Z] : 1;
+    size_t y = nDims > 1 ? dims[Y] : 1;
+    size_t z = nDims > 2 ? dims[Z] : 1;
 
     bool        rc = true;
     std::string type = grid->GetType();


### PR DESCRIPTION
Fixed #2785 

Refactored Grid iterators to use std::array instead of std:vector, making the iterators consistent with the rest of the Grid API