### PR TITLE
Issue2798 - BOV Reader

### DIFF
--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -10,7 +10,7 @@ namespace VAPoR {
 
 class BOVCollection : public Wasp::MyBase {
 public:
-    enum class parseCodes { ERROR = -1, NOT_FOUND = 0, FOUND = 1 };
+    enum class parseCodes { PARSE_ERROR = -1, NOT_FOUND = 0, FOUND = 1 };
 
     BOVCollection();
     int Initialize(const std::vector<std::string> &paths);

--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -81,7 +81,6 @@ private:
     int _sizeOfFormat(DC::XType) const;
 
     int _invalidFileSizeError(size_t numElements) const;
-    int _fileTooBigError() const;
     int _invalidFileError() const;
     int _invalidDimensionError(const std::string &token) const;
     int _invalidFormatError(const std::string &token) const;

--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -29,7 +29,7 @@ public:
     template<class T> int ReadRegion(std::string varname, size_t ts, const std::vector<size_t> &min, const std::vector<size_t> &max, T region);
 
 private:
-    std::string              _currentFilePath;
+    std::string _currentFilePath;
 
     float                    _time;
     std::vector<float>       _times;

--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -84,6 +84,8 @@ private:
     int  _sizeOfFormat(DC::XType) const;
     void _swapBytes(void *vptr, size_t size, size_t n) const;
 
+    int _invalidFileSizeError(size_t dataSize, size_t fileSize) const;
+    int _cannotStatFileError() const;
     int _invalidFileError(const std::string &token, const std::string &file) const;
     int _invalidDimensionError(const std::string &token) const;
     int _invalidFormatError(const std::string &token) const;

--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -24,7 +24,6 @@ public:
     DC::XType                  GetDataFormat() const;
     std::array<double, 3>      GetBrickOrigin() const;
     std::array<double, 3>      GetBrickSize() const;
-    std::string                GetDataEndian() const;
 
     template<class T> int ReadRegion(std::string varname, size_t ts, const std::vector<size_t> &min, const std::vector<size_t> &max, T region);
 
@@ -53,7 +52,6 @@ private:
     // assigning to "actual" values such as _gridSize, declaired above.
     std::array<size_t, 3> _tmpGridSize;
     DC::XType             _tmpDataFormat;
-    std::string           _tmpDataEndian;
     std::array<double, 3> _tmpBrickOrigin;
     std::array<double, 3> _tmpBrickSize;
     size_t                _tmpByteOffset;
@@ -62,7 +60,6 @@ private:
     bool _formatAssigned;
     bool _brickOriginAssigned;
     bool _brickSizeAssigned;
-    bool _dataEndianAssigned;
     bool _byteOffsetAssigned;
 
     // _dataFileMap allows us to access binary data files with a
@@ -82,14 +79,13 @@ private:
     void _findTokenValue(std::string &line) const;
 
     int  _sizeOfFormat(DC::XType) const;
-    void _swapBytes(void *vptr, size_t size, size_t n) const;
 
-    int _invalidFileSizeError(size_t dataSize, size_t fileSize) const;
-    int _cannotStatFileError() const;
-    int _invalidFileError(const std::string &token, const std::string &file) const;
+    int _invalidFileSizeError(size_t numElements) const;
+    int _byteOffsetError() const;
+    int _fileTooBigError() const;
+    int _invalidFileError() const;
     int _invalidDimensionError(const std::string &token) const;
     int _invalidFormatError(const std::string &token) const;
-    int _invalidEndianError(const std::string &token) const;
     int _failureToReadError(const std::string &token) const;
     int _inconsistentValueError(const std::string &token) const;
     int _invalidValueError(const std::string &token) const;
@@ -127,9 +123,6 @@ private:
     static const std::string _yDim;
     static const std::string _zDim;
     static const std::string _timeDim;
-
-    static const std::string _bigEndianString;
-    static const std::string _littleEndianString;
 
     static const std::string _byteFormatString;
     static const std::string _shortFormatString;

--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -81,7 +81,6 @@ private:
     int _sizeOfFormat(DC::XType) const;
 
     int _invalidFileSizeError(size_t numElements) const;
-    int _byteOffsetError() const;
     int _fileTooBigError() const;
     int _invalidFileError() const;
     int _invalidDimensionError(const std::string &token) const;

--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -78,7 +78,7 @@ private:
 
     void _findTokenValue(std::string &line) const;
 
-    int  _sizeOfFormat(DC::XType) const;
+    int _sizeOfFormat(DC::XType) const;
 
     int _invalidFileSizeError(size_t numElements) const;
     int _byteOffsetError() const;

--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -29,6 +29,8 @@ public:
     template<class T> int ReadRegion(std::string varname, size_t ts, const std::vector<size_t> &min, const std::vector<size_t> &max, T region);
 
 private:
+    std::string              _currentFilePath;
+
     float                    _time;
     std::vector<float>       _times;
     std::string              _dataFile;
@@ -82,13 +84,14 @@ private:
     int  _sizeOfFormat(DC::XType) const;
     void _swapBytes(void *vptr, size_t size, size_t n) const;
 
-    int _invalidDimensionError(std::string token) const;
-    int _invalidFormatError(std::string token) const;
-    int _invalidEndianError(std::string token) const;
-    int _failureToReadError(std::string token) const;
-    int _inconsistentValueError(std::string token) const;
-    int _invalidValueError(std::string token) const;
-    int _missingValueError(std::string token) const;
+    int _invalidFileError(const std::string &token, const std::string &file) const;
+    int _invalidDimensionError(const std::string &token) const;
+    int _invalidFormatError(const std::string &token) const;
+    int _invalidEndianError(const std::string &token) const;
+    int _failureToReadError(const std::string &token) const;
+    int _inconsistentValueError(const std::string &token) const;
+    int _invalidValueError(const std::string &token) const;
+    int _missingValueError(const std::string &token) const;
 
     static const std::string TIME_TOKEN;
     static const std::string DATA_FILE_TOKEN;

--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -38,14 +38,16 @@ private:
     DC::XType                _dataFormat;
     std::string              _variable;
     std::vector<std::string> _variables;
-    std::string              _dataEndian;
-    std::string              _centering;
     std::array<double, 3>    _brickOrigin;
     std::array<double, 3>    _brickSize;
     size_t                   _byteOffset;
-    bool                     _divideBrick;
-    std::array<size_t, 3>    _dataBricklets;
-    int                      _dataComponents;
+
+    // These values are currently parsed and assigned, but are unimplemented (not used)
+    bool                  _divideBrick;
+    std::string           _dataEndian;
+    std::string           _centering;
+    int                   _dataComponents;
+    std::array<size_t, 3> _dataBricklets;
 
     // Placeholder variables to store values read from BOV descriptor files.
     // These values must be consistent among BOV files, and are validated before
@@ -80,6 +82,7 @@ private:
 
     int _sizeOfFormat(DC::XType) const;
 
+    int _invalidVarNameError() const;
     int _invalidFileSizeError(size_t numElements) const;
     int _invalidFileError() const;
     int _invalidDimensionError(const std::string &token) const;
@@ -94,11 +97,13 @@ private:
     static const std::string GRID_SIZE_TOKEN;
     static const std::string FORMAT_TOKEN;
     static const std::string VARIABLE_TOKEN;
-    static const std::string ENDIAN_TOKEN;
-    static const std::string CENTERING_TOKEN;
     static const std::string ORIGIN_TOKEN;
     static const std::string BRICK_SIZE_TOKEN;
     static const std::string OFFSET_TOKEN;
+
+    // These tokens are currently parsed but are not used
+    static const std::string ENDIAN_TOKEN;
+    static const std::string CENTERING_TOKEN;
     static const std::string DIVIDE_BRICK_TOKEN;
     static const std::string DATA_BRICKLETS_TOKEN;
     static const std::string DATA_COMPONENTS_TOKEN;
@@ -107,15 +112,17 @@ private:
     static const std::string           _defaultFile;
     static const DC::XType             _defaultFormat;
     static const std::string           _defaultVar;
-    static const std::string           _defaultEndian;
-    static const std::string           _defaultCentering;
     static const size_t                _defaultByteOffset;
-    static const size_t                _defaultComponents;
-    static const bool                  _defaultDivBrick;
     static const std::array<double, 3> _defaultOrigin;
     static const std::array<double, 3> _defaultBrickSize;
     static const std::array<size_t, 3> _defaultGridSize;
+
+    // These defaults are currently unimplemented in the BOV reader logic
+    static const std::string           _defaultEndian;
+    static const std::string           _defaultCentering;
+    static const bool                  _defaultDivBrick;
     static const std::array<size_t, 3> _defaultBricklets;
+    static const size_t                _defaultComponents;
 
     static const std::string _xDim;
     static const std::string _yDim;

--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -84,6 +84,7 @@ private:
 
     int _invalidDimensionError(std::string token) const;
     int _invalidFormatError(std::string token) const;
+    int _invalidEndianError(std::string token) const;
     int _failureToReadError(std::string token) const;
     int _inconsistentValueError(std::string token) const;
     int _invalidValueError(std::string token) const;
@@ -121,6 +122,9 @@ private:
     static const std::string _yDim;
     static const std::string _zDim;
     static const std::string _timeDim;
+
+    static const std::string _bigEndianString;
+    static const std::string _littleEndianString;
 
     static const std::string _byteFormatString;
     static const std::string _shortFormatString;

--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -24,23 +24,23 @@ class BOVCollection;
 // # DATA_FILE points to a binary data file.  It can be a full file path, or a path relative to the BOV header.
 // DATA_FILE: bovA1.bin
 //
-// # The data size corresponds to NX,NY,NZ in the above example code.
+// # The data size corresponds to NX,NY,NZ in the above example code.  It must contain three values
 // DATA_SIZE: 10 10 10
 //
 // # Allowable values for DATA_FORMAT are: INT,FLOAT,DOUBLE
 // DATA_FORMAT: FLOAT
 //
-// # VARIABLE is a string that specifies the variable being read in DATA_FILE
+// # VARIABLE is a string that specifies the variable being read in DATA_FILE.  Must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890)
 // VARIABLE: myVariable
 //
-// # BRICK_ORIGIN lets you specify a new coordinate system origin for # the mesh that will be created to suit your data.
+// # BRICK_ORIGIN lets you specify a new coordinate system origin for # the mesh that will be created to suit your data.  It must contain three values.
 // BRICK_ORIGIN: 0. 0. 0.
 //
-// # BRICK_SIZE lets you specify the size of the brick.
+// # BRICK_SIZE lets you specify the size of the brick on X, Y, and Z.  It must contain three values.
 // BRICK_SIZE: 10. 20. 5.
 //
 // # BYTE_OFFSET is optional and lets you specify some number of
-// # bytes to skip at the front of the file. This can be useful for # skipping the 4-byte header that Fortran tends to write to files. # If your file does no
+// # bytes to skip at the front of the file. This can be useful for # skipping the 4-byte header that Fortran tends to write to files. # If your file does not have a header then DO NOT USE BYTE_OFFSET.
 // BYTE_OFFSET: 4
 
 //!
@@ -71,10 +71,12 @@ class BOVCollection;
 //! - DATA_COMPONENTS
 //!
 //! If duplicate key/value pairs exist in a BOV header, the value closest to the bottom of the file will be used.
+//! If duplicate values exist for whatever reason, all entries must be valid (except for DATA_FILE, which gets validated after parsing)
 //! Scientific notation is supported for floating point values like BRICK_ORIGIN and BRICK_SIZE.
 //! Scientific notation is not supported for integer values like DATA_SIZE.
 //! Wild card characters are not currently supported in the DATA_FILE token.
 //! Each .bov file can only refer to a single data file.
+//! VARIABLE must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890)
 //!
 //! \author Scott Pearse
 //! \date    May, 2021

--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -31,11 +31,11 @@ class BOVCollection;
 //! The following BOV tags are optional:
 //! - BRICK_ORIGIN
 //! - BRICK_SIZE
-//! - DATA_ENDIAN
 //! - TIME
 //! - VARIABLE
 //!
 //! The following BOV tags are currently unsupported:
+//! - DATA_ENDIAN
 //! - CENTERING
 //! - BYTE_OFFSET
 //! - DIVIDE_BRICK

--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -29,15 +29,15 @@ class BOVCollection;
 //! - DATA_FORMAT
 //!
 //! The following BOV tags are optional:
-//! - BRICK_ORIGIN
-//! - BRICK_SIZE
-//! - TIME
-//! - VARIABLE
+//! - BRICK_ORIGIN (default: 0., 0., 0.)
+//! - BRICK_SIZE   (default: 1., 1., 1.)
+//! - TIME         (default: 0.)
+//! - VARIABLE     (default: "brickVar")
+//! - BYTE_OFFSET  (default: 0)
 //!
 //! The following BOV tags are currently unsupported:
 //! - DATA_ENDIAN
 //! - CENTERING
-//! - BYTE_OFFSET
 //! - DIVIDE_BRICK
 //! - DATA_BRICKLETS
 //! - DATA_COMPONENTS

--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -30,7 +30,7 @@ class BOVCollection;
 // # Allowable values for DATA_FORMAT are: INT,FLOAT,DOUBLE
 // DATA_FORMAT: FLOAT
 //
-// # VARIABLE is a string that specifies the variable being read in DATA_FILE.  Must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890)
+// # VARIABLE is a string that specifies the variable being read in DATA_FILE.  Must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_-)
 // VARIABLE: myVariable
 //
 // # BRICK_ORIGIN lets you specify a new coordinate system origin for # the mesh that will be created to suit your data.  It must contain three values.
@@ -40,8 +40,8 @@ class BOVCollection;
 // BRICK_SIZE: 10. 20. 5.
 //
 // # BYTE_OFFSET is optional and lets you specify some number of
-// # bytes to skip at the front of the file. This can be useful for # skipping the 4-byte header that Fortran tends to write to files. # If your file does not have a header then DO NOT USE BYTE_OFFSET.
-// BYTE_OFFSET: 4
+// # bytes to skip at the front of the file. This can be useful for # skipping the 4-byte header that Fortran tends to write to files. # If your file does not have a header then DO NOT USE
+// BYTE_OFFSET. BYTE_OFFSET: 4
 
 //!
 //! \class DCBOV
@@ -76,7 +76,7 @@ class BOVCollection;
 //! Scientific notation is not supported for integer values like DATA_SIZE.
 //! Wild card characters are not currently supported in the DATA_FILE token.
 //! Each .bov file can only refer to a single data file.
-//! VARIABLE must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890)
+//! VARIABLE must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_-)
 //!
 //! \author Scott Pearse
 //! \date    May, 2021

--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -16,6 +16,33 @@ namespace VAPoR {
 
 class BOVCollection;
 
+// Example BOV header file, bovA1.bov
+//
+// # TIME is a floating point value specifying the timestep being read in DATA_FILE
+// TIME: 1.1
+//
+// # DATA_FILE points to a binary data file.  It can be a full file path, or a path relative to the BOV header.
+// DATA_FILE: bovA1.bin
+//
+// # The data size corresponds to NX,NY,NZ in the above example code.
+// DATA_SIZE: 10 10 10
+//
+// # Allowable values for DATA_FORMAT are: INT,FLOAT,DOUBLE
+// DATA_FORMAT: FLOAT
+//
+// # VARIABLE is a string that specifies the variable being read in DATA_FILE
+// VARIABLE: myVariable
+//
+// # BRICK_ORIGIN lets you specify a new coordinate system origin for # the mesh that will be created to suit your data.
+// BRICK_ORIGIN: 0. 0. 0.
+//
+// # BRICK_SIZE lets you specify the size of the brick.
+// BRICK_SIZE: 10. 20. 5.
+//
+// # BYTE_OFFSET is optional and lets you specify some number of
+// # bytes to skip at the front of the file. This can be useful for # skipping the 4-byte header that Fortran tends to write to files. # If your file does no
+// BYTE_OFFSET: 4
+
 //!
 //! \class DCBOV
 //! \ingroup Public_VDCBOV
@@ -35,13 +62,15 @@ class BOVCollection;
 //! - VARIABLE     (default: "brickVar")
 //! - BYTE_OFFSET  (default: 0)
 //!
-//! The following BOV tags are currently unsupported:
+//! The following BOV tags are currently unsupported.  They can be included in a BOV header,
+//! but they will be unused.
 //! - DATA_ENDIAN
 //! - CENTERING
 //! - DIVIDE_BRICK
 //! - DATA_BRICKLETS
 //! - DATA_COMPONENTS
 //!
+//! If duplicate key/value pairs exist in a BOV header, the value closest to the bottom of the file will be used.
 //! Scientific notation is supported for floating point values like BRICK_ORIGIN and BRICK_SIZE.
 //! Scientific notation is not supported for integer values like DATA_SIZE.
 //! Wild card characters are not currently supported in the DATA_FILE token.

--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -30,7 +30,7 @@ class BOVCollection;
 // # Allowable values for DATA_FORMAT are: INT,FLOAT,DOUBLE
 // DATA_FORMAT: FLOAT
 //
-// # VARIABLE is a string that specifies the variable being read in DATA_FILE.  Must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_-)
+// # VARIABLE is a string that specifies the variable being read in DATA_FILE.  Must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-)
 // VARIABLE: myVariable
 //
 // # BRICK_ORIGIN lets you specify a new coordinate system origin for # the mesh that will be created to suit your data.  It must contain three values.
@@ -76,7 +76,7 @@ class BOVCollection;
 //! Scientific notation is not supported for integer values like DATA_SIZE.
 //! Wild card characters are not currently supported in the DATA_FILE token.
 //! Each .bov file can only refer to a single data file.
-//! VARIABLE must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_-)
+//! VARIABLE must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-)
 //!
 //! \author Scott Pearse
 //! \date    May, 2021

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -96,7 +96,7 @@ int BOVCollection::Initialize(const std::vector<std::string> &paths)
         // to data files given with a relative path
         _currentFilePath = paths[i];
         size_t found = _currentFilePath.find_last_of("/\\");
-        _currentFilePath = _currentFilePath.substr(0,found);
+        _currentFilePath = _currentFilePath.substr(0, found);
 
         header.open(paths[i]);
         if (header.is_open()) {
@@ -155,13 +155,15 @@ int BOVCollection::_parseHeader(std::ifstream &header)
         rc = _findToken(TIME_TOKEN, line, time);
         if (rc == (int)parseCodes::ERROR)
             return _failureToReadError(TIME_TOKEN);
-        else if (rc == (int)parseCodes::FOUND) _time = time;
+        else if (rc == (int)parseCodes::FOUND)
+            _time = time;
 
         std::string variable;
         rc = _findToken(VARIABLE_TOKEN, line, variable);
         if (rc == (int)parseCodes::ERROR)
             return _invalidValueError(VARIABLE_TOKEN);
-        else if (rc == (int)parseCodes::FOUND) _variable = variable;
+        else if (rc == (int)parseCodes::FOUND)
+            _variable = variable;
 
         rc = _findToken(GRID_SIZE_TOKEN, line, _tmpGridSize);
         if (rc == (int)parseCodes::ERROR) return _failureToReadError(GRID_SIZE_TOKEN);
@@ -198,17 +200,16 @@ int BOVCollection::_validateParsedValues()
     // Validate that the data file exists.
     // If not given an absolute path, construct one
     // from the header file's containing directory.
-    char actualPath[PATH_MAX+1];
-    char* success = realpath(_dataFile.c_str(), actualPath);
+    char  actualPath[PATH_MAX + 1];
+    char *success = realpath(_dataFile.c_str(), actualPath);
     if (success == nullptr) {
         // At this point we can't find the absolute path, so it might be a relative path.
         // Try prepending the directory of the .bov file to the data file
         _dataFile = _currentFilePath + "//" + _dataFile;
         success = realpath(_dataFile.c_str(), actualPath);
-        if (success == nullptr)
-            return _invalidFileError(DATA_FILE_TOKEN, _dataFile);
-    }
-    else _dataFile = std::string(actualPath);
+        if (success == nullptr) return _invalidFileError(DATA_FILE_TOKEN, _dataFile);
+    } else
+        _dataFile = std::string(actualPath);
 
     // Validate grid dimensions
     if (_tmpGridSize[0] < 1 || _tmpGridSize[1] < 1 || _tmpGridSize[2] < 1)
@@ -247,8 +248,7 @@ int BOVCollection::_validateParsedValues()
     }
 
     // Validate endian type
-    if (_tmpDataEndian != _bigEndianString && _tmpDataEndian != _littleEndianString )
-        return _invalidEndianError(ENDIAN_TOKEN);
+    if (_tmpDataEndian != _bigEndianString && _tmpDataEndian != _littleEndianString) return _invalidEndianError(ENDIAN_TOKEN);
     if (_tmpDataEndian != _dataEndian && _dataEndianAssigned == true)
         return _inconsistentValueError(ENDIAN_TOKEN);
     else {
@@ -265,16 +265,15 @@ int BOVCollection::_validateParsedValues()
     }
 
     // Validate file size
-    size_t fileSize;
-    size_t dataSize = _gridSize[0]*_gridSize[1]*_gridSize[2]*_sizeOfFormat(_dataFormat);
+    size_t      fileSize;
+    size_t      dataSize = _gridSize[0] * _gridSize[1] * _gridSize[2] * _sizeOfFormat(_dataFormat);
     struct stat stat_buf;
-    int rc = stat(_dataFile.c_str(), &stat_buf);
+    int         rc = stat(_dataFile.c_str(), &stat_buf);
     if (rc == 0)
         fileSize = stat_buf.st_size;
     else
         return _cannotStatFileError();
-    if (dataSize != fileSize)
-        return _invalidFileSizeError(dataSize, fileSize);
+    if (dataSize != fileSize) return _invalidFileSizeError(dataSize, fileSize);
 
     return 0;
 }
@@ -289,14 +288,19 @@ void BOVCollection::_populateDataFileMap()
     _dataFileMap[_variable][_time] = _dataFile;
 }
 
-int BOVCollection::_cannotStatFileError() const {
+int BOVCollection::_cannotStatFileError() const
+{
     SetErrMsg(("Unable to get file status for " + _dataFile).c_str());
     return -1;
 }
 
-int BOVCollection::_invalidFileSizeError(size_t dataSize, size_t fileSize) const {
-    SetErrMsg(("Data file " + _dataFile + " of size " + to_string(fileSize) + " bytes does not match the size of the the data "
-        "specified in BOV header (" + to_string(dataSize) + " bytes).").c_str());
+int BOVCollection::_invalidFileSizeError(size_t dataSize, size_t fileSize) const
+{
+    SetErrMsg(("Data file " + _dataFile + " of size " + to_string(fileSize)
+               + " bytes does not match the size of the the data "
+                 "specified in BOV header ("
+               + to_string(dataSize) + " bytes).")
+                  .c_str());
     return -1;
 }
 
@@ -381,7 +385,7 @@ template<> int BOVCollection::_findToken<DC::XType>(const std::string &token, st
 
     while (line[line.length() - 1] == ' ')    // If last char is a space, pop it
         line.pop_back();
-    
+
 
     size_t pos = line.find(token);
     if (pos != std::string::npos) {    // We found the token
@@ -455,7 +459,7 @@ template<typename T> int BOVCollection::_findToken(const std::string &token, std
             break;
         }
     }
-            
+
     while (line[line.length() - 1] == ' ')    // If last char is a space, pop it
         line.pop_back();
 
@@ -577,7 +581,7 @@ template<class T> int BOVCollection::ReadRegion(std::string varname, size_t ts, 
             }
 
             if (needSwap) { _swapBytes(readBuffer, formatSize, count); }
-            
+
             if (_dataFormat == DC::XType::INT32) {
                 int *castBuffer = (int *)readBuffer;
                 for (int i = 0; i < count; i++) { *region++ = (typename std::remove_pointer<T>::type)castBuffer[i]; }

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -11,9 +11,12 @@
 #include "vapor/utils.h"
 #include <stdio.h>
 
-#ifdef _WINDOWS
+#ifdef WIN32
+    #include <Windows.h>
     #define _USE_MATH_DEFINES
     #pragma warning(disable : 4251 4100)
+#else
+    #include <limits.h>
 #endif
 #include <cmath>
 

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -67,8 +67,8 @@ const std::string BOVCollection::_doubleFormatString = "DOUBLE";
 
 BOVCollection::BOVCollection()
 : _time(_defaultTime), _dataFile(_defaultFile), _dataFormat(_defaultFormat), _variable(_defaultVar), _dataEndian(_defaultEndian), _centering(_defaultCentering), _byteOffset(_defaultByteOffset),
-  _divideBrick(_defaultDivBrick), _dataComponents(_defaultComponents), _tmpDataFormat(_defaultFormat), _tmpByteOffset(_defaultByteOffset), _gridSizeAssigned(false),
-  _formatAssigned(false), _brickOriginAssigned(false), _brickSizeAssigned(false), _byteOffsetAssigned(false), _timeDimension(_timeDim)
+  _divideBrick(_defaultDivBrick), _dataComponents(_defaultComponents), _tmpDataFormat(_defaultFormat), _tmpByteOffset(_defaultByteOffset), _gridSizeAssigned(false), _formatAssigned(false),
+  _brickOriginAssigned(false), _brickSizeAssigned(false), _byteOffsetAssigned(false), _timeDimension(_timeDim)
 {
     _dataFiles.clear();
     _times.clear();
@@ -170,26 +170,36 @@ int BOVCollection::_parseHeader(std::ifstream &header)
         }
 
         rc = _findToken(GRID_SIZE_TOKEN, line, _tmpGridSize);
-        if (rc == (int)parseCodes::ERROR) return _failureToReadError(GRID_SIZE_TOKEN);
-        else if (rc == (int)parseCodes::FOUND) continue;
+        if (rc == (int)parseCodes::ERROR)
+            return _failureToReadError(GRID_SIZE_TOKEN);
+        else if (rc == (int)parseCodes::FOUND)
+            continue;
 
         rc = _findToken(FORMAT_TOKEN, line, _tmpDataFormat);
-        if (rc == (int)parseCodes::ERROR) return _failureToReadError(FORMAT_TOKEN);
-        else if (rc == (int)parseCodes::FOUND) continue;
+        if (rc == (int)parseCodes::ERROR)
+            return _failureToReadError(FORMAT_TOKEN);
+        else if (rc == (int)parseCodes::FOUND)
+            continue;
 
         // Optional tokens.  If their values are invalid, SetErrMsg, and return -1.
         //
         rc = _findToken(ORIGIN_TOKEN, line, _tmpBrickOrigin);
-        if (rc == (int)parseCodes::ERROR) return _invalidValueError(ORIGIN_TOKEN);
-        else if (rc == (int)parseCodes::FOUND) continue;
+        if (rc == (int)parseCodes::ERROR)
+            return _invalidValueError(ORIGIN_TOKEN);
+        else if (rc == (int)parseCodes::FOUND)
+            continue;
 
         rc = _findToken(BRICK_SIZE_TOKEN, line, _tmpBrickSize);
-        if (rc == (int)parseCodes::ERROR) return _invalidValueError(BRICK_SIZE_TOKEN);
-        else if (rc == (int)parseCodes::FOUND) continue;
+        if (rc == (int)parseCodes::ERROR)
+            return _invalidValueError(BRICK_SIZE_TOKEN);
+        else if (rc == (int)parseCodes::FOUND)
+            continue;
 
         rc = _findToken(OFFSET_TOKEN, line, _tmpByteOffset);
-        if (rc == (int)parseCodes::ERROR) return _invalidValueError(OFFSET_TOKEN);
-        else if (rc == (int)parseCodes::FOUND) continue;
+        if (rc == (int)parseCodes::ERROR)
+            return _invalidValueError(OFFSET_TOKEN);
+        else if (rc == (int)parseCodes::FOUND)
+            continue;
 
         // All other variables are currently unused.
         //
@@ -249,11 +259,9 @@ int BOVCollection::_validateParsedValues()
     }
 
     // If _dataFile is not an absolute path, prepend with the BOV header's path
-    if (!Wasp::FileUtils::IsPathAbsolute(_dataFile)) {
-        _dataFile = _currentFilePath + "//" + _dataFile;
-    }
+    if (!Wasp::FileUtils::IsPathAbsolute(_dataFile)) { _dataFile = _currentFilePath + "//" + _dataFile; }
 
-    // Validate that the file is not a directory   
+    // Validate that the file is not a directory
     FILE *fp = fopen(_dataFile.c_str(), "r+");
     if (fp == nullptr) return _invalidFileError();
     fclose(fp);
@@ -271,19 +279,19 @@ int BOVCollection::_validateParsedValues()
     }
 
     // Validate the data file's size
-    int formatSize = _sizeOfFormat(_dataFormat);
+    int    formatSize = _sizeOfFormat(_dataFormat);
     size_t count = _gridSize[0] * _gridSize[1] * _gridSize[2];
-    auto readBuffer = std::unique_ptr<unsigned char[]>(new unsigned char[count * formatSize]);
+    auto   readBuffer = std::unique_ptr<unsigned char[]>(new unsigned char[count * formatSize]);
     size_t numElements = fread(readBuffer.get(), formatSize, count, fp);
     if (numElements != count) {
         fclose(fp);
-        return _invalidFileSizeError( numElements );
+        return _invalidFileSizeError(numElements);
     }
     if (ferror(fp)) {
         fclose(fp);
         return _invalidFileError();
     }
-    
+
     // If we can read another byte in the file, the file is too big
     if (fread(readBuffer.get(), formatSize, 1, fp) != 0) {
         fclose(fp);
@@ -305,12 +313,14 @@ void BOVCollection::_populateDataFileMap()
     _dataFileMap[_variable][_time] = _dataFile;
 }
 
-int BOVCollection::_fileTooBigError() const {
+int BOVCollection::_fileTooBigError() const
+{
     SetErrMsg((_dataFile + " contains more data than specified in BOV header.").c_str());
     return -1;
 }
 
-int BOVCollection::_byteOffsetError() const {
+int BOVCollection::_byteOffsetError() const
+{
     SetErrMsg(("Seeking by " + to_string(_byteOffset) + " bytes results in error: " + strerror(errno)).c_str());
     return -1;
 }
@@ -319,7 +329,8 @@ int BOVCollection::_invalidFileSizeError(size_t numElements) const
 {
     SetErrMsg(("Data file " + _dataFile + ", which has " + to_string(numElements)
                + " values, does not match the size of the the data and offset "
-                 "specified in BOV header.").c_str());
+                 "specified in BOV header.")
+                  .c_str());
     return -1;
 }
 
@@ -445,11 +456,9 @@ template<typename T> int BOVCollection::_findToken(const std::string &token, std
 
         if (verbose) { std::cout << std::setw(20) << token << " " << value << std::endl; }
 
-        if (ss.fail()) {
-            return (int)parseCodes::ERROR;
-        }
+        if (ss.fail()) { return (int)parseCodes::ERROR; }
         // If there is more than one value, throw error
-        if (ss.eof() == false) return (int)parseCodes::ERROR; 
+        if (ss.eof() == false) return (int)parseCodes::ERROR;
 
         return (int)parseCodes::FOUND;
     }
@@ -486,7 +495,7 @@ template<typename T> int BOVCollection::_findToken(const std::string &token, std
         }
 
         // If there are more than 3 values, throw error
-        if(!lineStream.eof()) return (int)parseCodes::ERROR;
+        if (!lineStream.eof()) return (int)parseCodes::ERROR;
 
         if (verbose) {
             std::cout << std::setw(20) << token << " ";

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -17,7 +17,7 @@
     #define _USE_MATH_DEFINES
     #pragma warning(disable : 4251 4100)
 #else
-    #include <limits.h>
+    #include <climits>
 #endif
 #include <cmath>
 

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <fstream>
 #include <type_traits>
-#include <sys/stat.h>
 #include "vapor/VAssert.h"
 #include "vapor/utils.h"
 #include "vapor/FileUtils.h"
@@ -260,11 +259,6 @@ int BOVCollection::_validateParsedValues()
 
     // If _dataFile is not an absolute path, prepend with the BOV header's path
     if (!Wasp::FileUtils::IsPathAbsolute(_dataFile)) { _dataFile = _currentFilePath + "//" + _dataFile; }
-
-    // Validate that the file is not a directory
-    FILE *fp = fopen(_dataFile.c_str(), "r+");
-    if (fp == nullptr) return _invalidFileError();
-    fclose(fp);
 
     // Validate whether we can open the data file
     fp = fopen(_dataFile.c_str(), "rb");

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -143,7 +143,7 @@ int BOVCollection::_parseHeader(std::ifstream &header)
         // the BOV.  Try to find them, and report errors if we can't.
         //
         rc = _findToken(DATA_FILE_TOKEN, line, dataFile);
-        if (rc == (int)parseCodes::ERROR)
+        if (rc == (int)parseCodes::PARSE_ERROR)
             return _failureToReadError(DATA_FILE_TOKEN);
         else if (rc == (int)parseCodes::FOUND) {
             _dataFile = dataFile;
@@ -152,7 +152,7 @@ int BOVCollection::_parseHeader(std::ifstream &header)
 
         double time;
         rc = _findToken(TIME_TOKEN, line, time);
-        if (rc == (int)parseCodes::ERROR)
+        if (rc == (int)parseCodes::PARSE_ERROR)
             return _failureToReadError(TIME_TOKEN);
         else if (rc == (int)parseCodes::FOUND) {
             _time = time;
@@ -161,7 +161,7 @@ int BOVCollection::_parseHeader(std::ifstream &header)
 
         std::string variable;
         rc = _findToken(VARIABLE_TOKEN, line, variable);
-        if (rc == (int)parseCodes::ERROR)
+        if (rc == (int)parseCodes::PARSE_ERROR)
             return _invalidValueError(VARIABLE_TOKEN);
         else if (rc == (int)parseCodes::FOUND) {
             _variable = variable;
@@ -169,13 +169,13 @@ int BOVCollection::_parseHeader(std::ifstream &header)
         }
 
         rc = _findToken(GRID_SIZE_TOKEN, line, _tmpGridSize);
-        if (rc == (int)parseCodes::ERROR)
+        if (rc == (int)parseCodes::PARSE_ERROR)
             return _failureToReadError(GRID_SIZE_TOKEN);
         else if (rc == (int)parseCodes::FOUND)
             continue;
 
         rc = _findToken(FORMAT_TOKEN, line, _tmpDataFormat);
-        if (rc == (int)parseCodes::ERROR)
+        if (rc == (int)parseCodes::PARSE_ERROR)
             return _failureToReadError(FORMAT_TOKEN);
         else if (rc == (int)parseCodes::FOUND)
             continue;
@@ -183,19 +183,19 @@ int BOVCollection::_parseHeader(std::ifstream &header)
         // Optional tokens.  If their values are invalid, SetErrMsg, and return -1.
         //
         rc = _findToken(ORIGIN_TOKEN, line, _tmpBrickOrigin);
-        if (rc == (int)parseCodes::ERROR)
+        if (rc == (int)parseCodes::PARSE_ERROR)
             return _invalidValueError(ORIGIN_TOKEN);
         else if (rc == (int)parseCodes::FOUND)
             continue;
 
         rc = _findToken(BRICK_SIZE_TOKEN, line, _tmpBrickSize);
-        if (rc == (int)parseCodes::ERROR)
+        if (rc == (int)parseCodes::PARSE_ERROR)
             return _invalidValueError(BRICK_SIZE_TOKEN);
         else if (rc == (int)parseCodes::FOUND)
             continue;
 
         rc = _findToken(OFFSET_TOKEN, line, _tmpByteOffset);
-        if (rc == (int)parseCodes::ERROR)
+        if (rc == (int)parseCodes::PARSE_ERROR)
             return _invalidValueError(OFFSET_TOKEN);
         else if (rc == (int)parseCodes::FOUND)
             continue;
@@ -436,9 +436,9 @@ template<typename T> int BOVCollection::_findToken(const std::string &token, std
 
         if (verbose) { std::cout << std::setw(20) << token << " " << value << std::endl; }
 
-        if (ss.fail()) { return (int)parseCodes::ERROR; }
+        if (ss.fail()) { return (int)parseCodes::PARSE_ERROR; }
         // If there is more than one value, throw error
-        if (ss.eof() == false) return (int)parseCodes::ERROR;
+        if (ss.eof() == false) return (int)parseCodes::PARSE_ERROR;
 
         return (int)parseCodes::FOUND;
     }
@@ -469,13 +469,13 @@ template<typename T> int BOVCollection::_findToken(const std::string &token, std
 
         for (int i = 0; i < value.size(); i++) {
             lineStream >> lineValue;
-            if (lineStream.fail()) return (int)parseCodes::ERROR;
+            if (lineStream.fail()) return (int)parseCodes::PARSE_ERROR;
 
             value[i] = lineValue;
         }
 
         // If there are more than 3 values, throw error
-        if (!lineStream.eof()) return (int)parseCodes::ERROR;
+        if (!lineStream.eof()) return (int)parseCodes::PARSE_ERROR;
 
         if (verbose) {
             std::cout << std::setw(20) << token << " ";

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -540,8 +540,8 @@ template<class T> int BOVCollection::ReadRegion(std::string varname, size_t ts, 
                 return -1;
             }
 
-            rc = fread(readBuffer, formatSize, count, fp);
-            if (rc != count) {
+            size_t fread_rc = fread(readBuffer, formatSize, count, fp);
+            if (fread_rc != count) {
                 if (ferror(fp) != 0) {
                     MyBase::SetErrMsg("Error reading input file: %M");
                 } else {

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -278,12 +278,6 @@ int BOVCollection::_validateParsedValues()
         return _invalidFileError();
     }
 
-    // If we can read another byte in the file, the file is too big
-    if (fread(readBuffer.get(), formatSize, 1, fp) != 0) {
-        fclose(fp);
-        return _fileTooBigError();
-    }
-
     fclose(fp);
 
     return 0;
@@ -297,12 +291,6 @@ void BOVCollection::_populateDataFileMap()
     std::sort(_times.begin(), _times.end());
 
     _dataFileMap[_variable][_time] = _dataFile;
-}
-
-int BOVCollection::_fileTooBigError() const
-{
-    SetErrMsg((_dataFile + " contains more data than specified in BOV header.").c_str());
-    return -1;
 }
 
 int BOVCollection::_invalidFileSizeError(size_t numElements) const

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -259,7 +259,7 @@ int BOVCollection::_validateParsedValues()
         _byteOffsetAssigned = true;
     }
 
-    if (_variable.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_-") != std::string::npos) return _invalidVarNameError();
+    if (_variable.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-") != std::string::npos) return _invalidVarNameError();
 
     return 0;
 }

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -95,9 +95,6 @@ int BOVCollection::Initialize(const std::vector<std::string> &paths)
         size_t found = _currentFilePath.find_last_of("/\\");
         _currentFilePath = _currentFilePath.substr(0,found);
 
-        _timeAssigned = false;
-        _variableAssigned = false;
-
         header.open(paths[i]);
         if (header.is_open()) {
             rc = _parseHeader(header);
@@ -155,21 +152,13 @@ int BOVCollection::_parseHeader(std::ifstream &header)
         rc = _findToken(TIME_TOKEN, line, time);
         if (rc == (int)parseCodes::ERROR)
             return _failureToReadError(TIME_TOKEN);
-        else if (rc == (int)parseCodes::FOUND) {
-            if (_timeAssigned == true) return _multipleTimestepError();
-            _time = time;
-            _timeAssigned = true;
-        }
+        else if (rc == (int)parseCodes::FOUND) _time = time;
 
         std::string variable;
         rc = _findToken(VARIABLE_TOKEN, line, variable);
         if (rc == (int)parseCodes::ERROR)
             return _invalidValueError(VARIABLE_TOKEN);
-        else if (rc == (int)parseCodes::FOUND) {
-            if (_variableAssigned == true) return _multipleVariablesError();
-            _variable = variable;
-            _variableAssigned = true;
-        }
+        else if (rc == (int)parseCodes::FOUND) _variable = variable;
 
         rc = _findToken(GRID_SIZE_TOKEN, line, _tmpGridSize);
         if (rc == (int)parseCodes::ERROR) return _failureToReadError(GRID_SIZE_TOKEN);
@@ -387,8 +376,9 @@ template<> int BOVCollection::_findToken<DC::XType>(const std::string &token, st
         }
     }
 
-    if (line[line.length() - 1] == ' ')    // If last char is a space, pop it
+    while (line[line.length() - 1] == ' ')    // If last char is a space, pop it
         line.pop_back();
+    
 
     size_t pos = line.find(token);
     if (pos != std::string::npos) {    // We found the token
@@ -420,7 +410,7 @@ template<typename T> int BOVCollection::_findToken(const std::string &token, std
         }
     }
 
-    if (line[line.length() - 1] == ' ')    // If last char is a space, pop it
+    while (line[line.length() - 1] == ' ')    // If last char is a space, pop it
         line.pop_back();
 
     size_t pos = line.find(token);
@@ -463,7 +453,7 @@ template<typename T> int BOVCollection::_findToken(const std::string &token, std
         }
     }
             
-    if (line[line.length() - 1] == ' ')    // If last char is a space, pop it
+    while (line[line.length() - 1] == ' ')    // If last char is a space, pop it
         line.pop_back();
 
     size_t pos = line.find(token);

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -261,7 +261,7 @@ int BOVCollection::_validateParsedValues()
     if (!Wasp::FileUtils::IsPathAbsolute(_dataFile)) { _dataFile = _currentFilePath + "//" + _dataFile; }
 
     // Validate whether we can open the data file
-    FILE* fp = fopen(_dataFile.c_str(), "rb");
+    FILE *fp = fopen(_dataFile.c_str(), "rb");
     if (fp == nullptr) return _invalidFileError();
 
     // Validate the data file's size

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -200,15 +200,15 @@ int BOVCollection::_validateParsedValues()
     // from the header file's containing directory.
     char actualPath[PATH_MAX+1];
     char* success = realpath(_dataFile.c_str(), actualPath);
-    if (success == nullptr)
+    if (success == nullptr) {
         // At this point we can't find the absolute path, so it might be a relative path.
         // Try prepending the directory of the .bov file to the data file
         _dataFile = _currentFilePath + "//" + _dataFile;
         success = realpath(_dataFile.c_str(), actualPath);
         if (success == nullptr)
             return _invalidFileError(DATA_FILE_TOKEN, _dataFile);
-    else
-        _dataFile = std::string(actualPath);
+    }
+    else _dataFile = std::string(actualPath);
 
     // Validate grid dimensions
     if (_tmpGridSize[0] < 1 || _tmpGridSize[1] < 1 || _tmpGridSize[2] < 1)

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -261,7 +261,7 @@ int BOVCollection::_validateParsedValues()
     if (!Wasp::FileUtils::IsPathAbsolute(_dataFile)) { _dataFile = _currentFilePath + "//" + _dataFile; }
 
     // Validate whether we can open the data file
-    fp = fopen(_dataFile.c_str(), "rb");
+    FILE* fp = fopen(_dataFile.c_str(), "rb");
     if (fp == nullptr) return _invalidFileError();
 
     // Validate the data file's size

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -85,9 +85,7 @@ int BOVCollection::Initialize(const std::vector<std::string> &paths)
 
         // Save the path to the BOV header so we can add it
         // to data files given with a relative path
-        _currentFilePath = paths[i];
-        size_t found = _currentFilePath.find_last_of("/\\");
-        _currentFilePath = _currentFilePath.substr(0, found);
+        _currentFilePath = Wasp::FileUtils::Dirname(paths[i]);
 
         header.open(paths[i]);
         if (header.is_open()) {
@@ -251,7 +249,10 @@ int BOVCollection::_validateParsedValues()
     }
 
     // If _dataFile is not an absolute path, prepend with the BOV header's path
-    if (!Wasp::FileUtils::IsPathAbsolute(_dataFile)) { _dataFile = _currentFilePath + "//" + _dataFile; }
+    if (!Wasp::FileUtils::IsPathAbsolute(_dataFile)) { 
+        auto paths = {_currentFilePath, _dataFile};
+        _dataFile = Wasp::FileUtils::JoinPaths(paths); 
+    }
 
     // Validate whether we can open the data file
     FILE *fp = fopen(_dataFile.c_str(), "rb");

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -10,7 +10,7 @@
 #include "vapor/VAssert.h"
 #include "vapor/utils.h"
 #include "vapor/FileUtils.h"
-#include <stdio.h>
+#include <cstdio>
 #include <climits>
 #include <cmath>
 
@@ -259,12 +259,7 @@ int BOVCollection::_validateParsedValues()
         _byteOffsetAssigned = true;
     }
 
-    // Validate whether we can open the data file
-    FILE *fp = fopen(_dataFile.c_str(), "rb");
-    if (fp == nullptr) return _invalidFileError();
-    fclose(fp);
-
-    if (_variable.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890") != std::string::npos) return _invalidVarNameError();
+    if (_variable.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_-") != std::string::npos) return _invalidVarNameError();
 
     return 0;
 }
@@ -539,7 +534,7 @@ template<class T> int BOVCollection::ReadRegion(std::string varname, size_t ts, 
             size_t yOffset = _gridSize[0] * j;
             size_t offset = formatSize * (xOffset + yOffset + zOffset) + _byteOffset;
 
-            size_t rc = fseek(fp, offset, SEEK_SET);
+            int rc = fseek(fp, offset, SEEK_SET);
             if (rc != 0) {
                 MyBase::SetErrMsg("Unable to seek on file: %M");
                 return -1;

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -11,14 +11,7 @@
 #include "vapor/utils.h"
 #include "vapor/FileUtils.h"
 #include <stdio.h>
-
-#ifdef WIN32
-    #include <Windows.h>
-    #define _USE_MATH_DEFINES
-    #pragma warning(disable : 4251 4100)
-#else
-    #include <climits>
-#endif
+#include <climits>
 #include <cmath>
 
 #include <vapor/BOVCollection.h>

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -108,8 +108,8 @@ int BOVCollection::Initialize(const std::vector<std::string> &paths)
 
             // If _dataFile is not an absolute path, prepend with the BOV header's path
             if (!Wasp::FileUtils::IsPathAbsolute(_dataFile)) {
-                auto paths = {_currentFilePath, _dataFile};
-                _dataFile = Wasp::FileUtils::JoinPaths(paths);
+                auto dirAndPath = {_currentFilePath, _dataFile};
+                _dataFile = Wasp::FileUtils::JoinPaths(dirAndPath);
             }
 
             rc = _validateParsedValues();

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -270,14 +270,6 @@ int BOVCollection::_validateParsedValues()
     fp = fopen(_dataFile.c_str(), "rb");
     if (fp == nullptr) return _invalidFileError();
 
-    // Validate that we can seek the data file.
-    // If we seek to the end of the file, there's no data to read, so report error
-    int rc = fseek(fp, _byteOffset, SEEK_SET);
-    if (rc != 0 || feof(fp)) {
-        fclose(fp);
-        return _byteOffsetError();
-    }
-
     // Validate the data file's size
     int    formatSize = _sizeOfFormat(_dataFormat);
     size_t count = _gridSize[0] * _gridSize[1] * _gridSize[2];
@@ -316,12 +308,6 @@ void BOVCollection::_populateDataFileMap()
 int BOVCollection::_fileTooBigError() const
 {
     SetErrMsg((_dataFile + " contains more data than specified in BOV header.").c_str());
-    return -1;
-}
-
-int BOVCollection::_byteOffsetError() const
-{
-    SetErrMsg(("Seeking by " + to_string(_byteOffset) + " bytes results in error: " + strerror(errno)).c_str());
     return -1;
 }
 

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -339,11 +339,12 @@ template<typename T> int BOVCollection::_findToken(const std::string &token, std
     for (size_t i = 0; i < line.length(); i++) {
         if (line[i] == '#') {
             line.erase(line.begin() + i, line.end());
-            if (line[line.length() - 1] == ' ')    // If last char is a space, pop it
-                line.pop_back();
             break;
         }
     }
+
+    if (line[line.length() - 1] == ' ')    // If last char is a space, pop it
+        line.pop_back();
 
     size_t pos = line.find(token);
     if (pos != std::string::npos) {    // We found the token

--- a/lib/vdc/DCBOV.cpp
+++ b/lib/vdc/DCBOV.cpp
@@ -36,6 +36,7 @@ DCBOV::~DCBOV()
 
 int DCBOV::initialize(const vector<string> &paths, const std::vector<string> &options)
 {
+    if (_bovCollection != nullptr) delete _bovCollection;
     _bovCollection = new BOVCollection();
     int rc = _bovCollection->Initialize(paths);
     if (rc < 0) {


### PR DESCRIPTION
Fixes #2798 and fixes #2797 - bug6.bov and bug5.bov
Fixed by trimming white space after values are read, at lines [386](https://github.com/NCAR/VAPOR/blob/a4f4924ad15112a439c27429b1911faa96b1f904/lib/vdc/BOVCollection.cpp#L386), [420](https://github.com/NCAR/VAPOR/blob/a4f4924ad15112a439c27429b1911faa96b1f904/lib/vdc/BOVCollection.cpp#L420), and [463](https://github.com/NCAR/VAPOR/blob/a4f4924ad15112a439c27429b1911faa96b1f904/lib/vdc/BOVCollection.cpp#L463) in the _findToken template functions.

Fixes #2792 and #2790- bug4.bov and bug2.bov
Fixed [by enforcing the DATA_ENDIAN value](https://github.com/NCAR/VAPOR/blob/a4f4924ad15112a439c27429b1911faa96b1f904/lib/vdc/BOVCollection.cpp#L250) to be either BIG or LITTLE, and adding [a sanity check](https://github.com/NCAR/VAPOR/blob/a4f4924ad15112a439c27429b1911faa96b1f904/lib/vdc/BOVCollection.cpp#L267) that compares the grid size * data format size, to the size of the binary file being loaded.

@shaomeng The sanity check is in place, but I believe your bug report has the correctly sized data file for the header description.  128x512x256x8(double) = 134,217,728 bytes, which is the size of /glade/p/cisl/vast/vapor/Bugs/BOV_Bugs/Bx.bot.

#2791 Is not a bug - bug3.bov
This regards #2799, where the maximum timestep of DataStatus is not honored.  FYI, the last values reported in a BOV file are registered as "true values".  If you define TIME twice, the second one will overwrite the first one.  **This will be documented.** 

Fixes #2788 - bug1.bov
Fixed by [correcting the count](https://github.com/NCAR/VAPOR/blob/a4f4924ad15112a439c27429b1911faa96b1f904/lib/vdc/BOVCollection.cpp#L583) of bytes passed into _swapBytes()

Fixes #2789 and #2784 - Relative file paths
Fixed by prepending the BOV header file path to the data file path [when realpath() could not be evaluated](https://github.com/NCAR/VAPOR/blob/a4f4924ad15112a439c27429b1911faa96b1f904/lib/vdc/BOVCollection.cpp#L200) for the data file.