### PR TITLE
BOV: Multiple timesteps for a single variable

### DIFF
--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -51,16 +51,16 @@ class BOVCollection;
 //! following VisIt document: https://github.com/NCAR/VAPOR/files/6341067/GettingDataIntoVisIt2.0.0.pdf
 //!
 //! The following BOV tags are mandatory for Vapor to ingest data:
-//! - DATA_FILE
-//! - DATA_SIZE
-//! - DATA_FORMAT
+//! - DATA_FILE    (type: string)
+//! - DATA_SIZE    (type: three integer values that are >1)
+//! - DATA_FORMAT  (type: string of either INT, FLOAT, or DOUBLE)
 //!
 //! The following BOV tags are optional:
-//! - BRICK_ORIGIN (default: 0., 0., 0.)
-//! - BRICK_SIZE   (default: 1., 1., 1.)
-//! - TIME         (default: 0.)
-//! - VARIABLE     (default: "brickVar")
-//! - BYTE_OFFSET  (default: 0)
+//! - BRICK_ORIGIN (type: three floating point values,   default: 0., 0., 0.)
+//! - BRICK_SIZE   (type: three floating point values,   default: 1., 1., 1.)
+//! - TIME         (type: one floating point value,      default: 0.)
+//! - VARIABLE     (type: one alphanumeric string value, default: "brickVar")
+//! - BYTE_OFFSET  (type: one integer value,             default: 0)
 //!
 //! The following BOV tags are currently unsupported.  They can be included in a BOV header,
 //! but they will be unused.

--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -70,6 +70,7 @@ class BOVCollection;
 //! - DATA_BRICKLETS
 //! - DATA_COMPONENTS
 //!
+//! If multiple files specify a single TIME value for a single variable, the first-read file will be used for that variable at that timestep.
 //! If duplicate key/value pairs exist in a BOV header, the value closest to the bottom of the file will be used.
 //! If duplicate values exist for whatever reason, all entries must be valid (except for DATA_FILE, which gets validated after parsing)
 //! Scientific notation is supported for floating point values like BRICK_ORIGIN and BRICK_SIZE.


### PR DESCRIPTION
Fixes #2821 by adding documentation to DCBOV.h.  

The documentation regards how duplicate timestep/variable definitions are handled among imported BOV files.

> //! If multiple files specify a single TIME value for a single variable, the first-read file will be used for that variable at that timestep.