### PR TITLE
Constrain BOV reader to support 3D grids, and add a check for brick size

### DIFF
--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -16,7 +16,7 @@ namespace VAPoR {
 
 class BOVCollection;
 
-// Example BOV header file, bovA1.bov
+// Example BOV header file, bovA1.bov.
 //
 // # TIME is a floating point value specifying the timestep being read in DATA_FILE
 // TIME: 1.1
@@ -24,7 +24,7 @@ class BOVCollection;
 // # DATA_FILE points to a binary data file.  It can be a full file path, or a path relative to the BOV header.
 // DATA_FILE: bovA1.bin
 //
-// # The data size corresponds to NX,NY,NZ in the above example code.  It must contain three values
+// # The data size corresponds to NX,NY,NZ in the above example code.  It must contain three values that are greather than 1.
 // DATA_SIZE: 10 10 10
 //
 // # Allowable values for DATA_FORMAT are: INT,FLOAT,DOUBLE

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -216,7 +216,7 @@ int BOVCollection::_parseHeader(std::ifstream &header)
 int BOVCollection::_validateParsedValues()
 {
     // Validate grid dimensions
-    if (_tmpGridSize[0] < 1 || _tmpGridSize[1] < 1 || _tmpGridSize[2] < 1)
+    if (_tmpGridSize[0] < 2 || _tmpGridSize[1] < 2 || _tmpGridSize[2] < 2)
         return _invalidDimensionError(GRID_SIZE_TOKEN);
     else if (_tmpGridSize != _gridSize && _gridSizeAssigned == true)
         return _inconsistentValueError(GRID_SIZE_TOKEN);
@@ -247,6 +247,9 @@ int BOVCollection::_validateParsedValues()
     if (_tmpBrickSize != _brickSize && _brickSizeAssigned == true)
         return _inconsistentValueError(BRICK_SIZE_TOKEN);
     else {
+        for (auto i = 0; i < _tmpBrickSize.size(); i++) {
+            if (_tmpBrickSize[i] < 0) return _invalidValueError(BRICK_SIZE_TOKEN);
+        }
         _brickSize = _tmpBrickSize;
         _brickSizeAssigned = true;
     }


### PR DESCRIPTION
This constrains the BOV reader to 3D data.  I've added an enhancement to support 2D data [here](https://github.com/NCAR/VAPOR/issues/2833).

This also adds a guard to check that the BRICK_SIZE token is >0.