### PR TITLE
Issue2826: BOV support for 2D grids, and add validation for negative grid/brick sizes

### DIFF
--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -19,7 +19,7 @@ public:
     std::string                GetTimeDimension() const;
     std::vector<float>         GetUserTimes() const;
     float                      GetUserTime(size_t ts) const { return GetUserTimes()[ts]; };
-    std::array<size_t, 3>      GetDataSize() const;
+    std::array<int, 3>         GetDataSize() const;
     std::array<std::string, 3> GetSpatialDimensions() const;
     DC::XType                  GetDataFormat() const;
     std::array<double, 3>      GetBrickOrigin() const;
@@ -34,7 +34,7 @@ private:
     std::vector<float>       _times;
     std::string              _dataFile;
     std::vector<std::string> _dataFiles;
-    std::array<size_t, 3>    _gridSize;
+    std::array<int, 3>       _gridSize;
     DC::XType                _dataFormat;
     std::string              _variable;
     std::vector<std::string> _variables;
@@ -52,7 +52,7 @@ private:
     // Placeholder variables to store values read from BOV descriptor files.
     // These values must be consistent among BOV files, and are validated before
     // assigning to "actual" values such as _gridSize, declaired above.
-    std::array<size_t, 3> _tmpGridSize;
+    std::array<int, 3>    _tmpGridSize;
     DC::XType             _tmpDataFormat;
     std::array<double, 3> _tmpBrickOrigin;
     std::array<double, 3> _tmpBrickSize;
@@ -115,7 +115,7 @@ private:
     static const size_t                _defaultByteOffset;
     static const std::array<double, 3> _defaultOrigin;
     static const std::array<double, 3> _defaultBrickSize;
-    static const std::array<size_t, 3> _defaultGridSize;
+    static const std::array<int, 3>    _defaultGridSize;
 
     // These defaults are currently unimplemented in the BOV reader logic
     static const std::string           _defaultEndian;

--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -74,6 +74,7 @@ class BOVCollection;
 //! If duplicate values exist for whatever reason, all entries must be valid (except for DATA_FILE, which gets validated after parsing)
 //! Scientific notation is supported for floating point values like BRICK_ORIGIN and BRICK_SIZE.
 //! Scientific notation is not supported for integer values like DATA_SIZE.
+//! DATA_SIZE must contain three values greater than 1.
 //! Wild card characters are not currently supported in the DATA_FILE token.
 //! Each .bov file can only refer to a single data file.
 //! VARIABLE must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-)

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -36,7 +36,7 @@ const std::string BOVCollection::DATA_COMPONENTS_TOKEN = "DATA_COMPONENTS";
 
 const std::array<double, 3> BOVCollection::_defaultOrigin = {0., 0., 0.};
 const std::array<double, 3> BOVCollection::_defaultBrickSize = {1., 1., 1.};
-const std::array<size_t, 3> BOVCollection::_defaultGridSize = {0, 0, 0};
+const std::array<int, 3>    BOVCollection::_defaultGridSize = {0, 0, 0};
 const DC::XType             BOVCollection::_defaultFormat = DC::XType::INVALID;
 const std::string           BOVCollection::_defaultFile = "";
 const std::string           BOVCollection::_defaultVar = "brickVar";
@@ -247,6 +247,9 @@ int BOVCollection::_validateParsedValues()
     if (_tmpBrickSize != _brickSize && _brickSizeAssigned == true)
         return _inconsistentValueError(BRICK_SIZE_TOKEN);
     else {
+        for (size_t i = 0; i < _tmpBrickSize.size(); i++) {
+            if (_tmpBrickSize[i] < 0) return _invalidValueError(BRICK_SIZE_TOKEN);
+        }
         _brickSize = _tmpBrickSize;
         _brickSizeAssigned = true;
     }
@@ -341,7 +344,7 @@ std::string BOVCollection::GetTimeDimension() const { return _timeDimension; }
 
 std::vector<float> BOVCollection::GetUserTimes() const { return _times; }
 
-std::array<size_t, 3> BOVCollection::GetDataSize() const { return _gridSize; }
+std::array<int, 3> BOVCollection::GetDataSize() const { return _gridSize; }
 
 DC::XType BOVCollection::GetDataFormat() const { return _dataFormat; }
 

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -36,7 +36,7 @@ const std::string BOVCollection::DATA_COMPONENTS_TOKEN = "DATA_COMPONENTS";
 
 const std::array<double, 3> BOVCollection::_defaultOrigin = {0., 0., 0.};
 const std::array<double, 3> BOVCollection::_defaultBrickSize = {1., 1., 1.};
-const std::array<int, 3>    BOVCollection::_defaultGridSize = {0, 0, 0};
+const std::array<size_t, 3> BOVCollection::_defaultGridSize = {0, 0, 0};
 const DC::XType             BOVCollection::_defaultFormat = DC::XType::INVALID;
 const std::string           BOVCollection::_defaultFile = "";
 const std::string           BOVCollection::_defaultVar = "brickVar";
@@ -76,7 +76,9 @@ BOVCollection::BOVCollection()
     _dataFiles.clear();
     _times.clear();
     _gridSize = _defaultGridSize;
-    _tmpGridSize = _defaultGridSize;
+    _tmpGridSize[0] = (int)_defaultGridSize[0];
+    _tmpGridSize[1] = (int)_defaultGridSize[1];
+    _tmpGridSize[2] = (int)_defaultGridSize[2];
     _brickOrigin = _defaultOrigin;
     _tmpBrickOrigin = _defaultOrigin;
     _brickSize = _defaultBrickSize;
@@ -218,10 +220,12 @@ int BOVCollection::_validateParsedValues()
     // Validate grid dimensions
     if (_tmpGridSize[0] < 1 || _tmpGridSize[1] < 1 || _tmpGridSize[2] < 1)
         return _invalidDimensionError(GRID_SIZE_TOKEN);
-    else if (_tmpGridSize != _gridSize && _gridSizeAssigned == true)
+    else if ((_tmpGridSize[0] != _gridSize[0] || _tmpGridSize[1] != _gridSize[1] || _tmpGridSize[2] != _gridSize[2]) && _gridSizeAssigned == true)
         return _inconsistentValueError(GRID_SIZE_TOKEN);
     else {
-        _gridSize = _tmpGridSize;
+        _gridSize[0] = (size_t)_tmpGridSize[0];
+        _gridSize[1] = (size_t)_tmpGridSize[1];
+        _gridSize[2] = (size_t)_tmpGridSize[2];
         _gridSizeAssigned = true;
     }
 
@@ -344,7 +348,7 @@ std::string BOVCollection::GetTimeDimension() const { return _timeDimension; }
 
 std::vector<float> BOVCollection::GetUserTimes() const { return _times; }
 
-std::array<int, 3> BOVCollection::GetDataSize() const { return _gridSize; }
+std::array<size_t, 3> BOVCollection::GetDataSize() const { return _gridSize; }
 
 DC::XType BOVCollection::GetDataFormat() const { return _dataFormat; }
 

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -218,7 +218,7 @@ int BOVCollection::_parseHeader(std::ifstream &header)
 int BOVCollection::_validateParsedValues()
 {
     // Validate grid dimensions
-    if (_tmpGridSize[0] < 1 || _tmpGridSize[1] < 1 || _tmpGridSize[2] < 1)
+    if (_tmpGridSize[0] < 2 || _tmpGridSize[1] < 2 || _tmpGridSize[2] < 2)
         return _invalidDimensionError(GRID_SIZE_TOKEN);
     else if ((_tmpGridSize[0] != _gridSize[0] || _tmpGridSize[1] != _gridSize[1] || _tmpGridSize[2] != _gridSize[2]) && _gridSizeAssigned == true)
         return _inconsistentValueError(GRID_SIZE_TOKEN);
@@ -252,7 +252,7 @@ int BOVCollection::_validateParsedValues()
         return _inconsistentValueError(BRICK_SIZE_TOKEN);
     else {
         for (size_t i = 0; i < _tmpBrickSize.size(); i++) {
-            if (_tmpBrickSize[i] < 0) return _invalidValueError(BRICK_SIZE_TOKEN);
+            if (_tmpBrickSize[i] < 0.) return _invalidValueError(BRICK_SIZE_TOKEN);
         }
         _brickSize = _tmpBrickSize;
         _brickSizeAssigned = true;

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -556,13 +556,13 @@ template<class T> int BOVCollection::ReadRegion(std::string varname, size_t ts, 
 
             if (_dataFormat == DC::XType::INT32) {
                 int *castBuffer = (int *)readBuffer;
-                for (int i = 0; i < count; i++) { *region++ = (typename std::remove_pointer<T>::type)castBuffer[i]; }
+                for (size_t i = 0; i < count; i++) { *region++ = (typename std::remove_pointer<T>::type)castBuffer[i]; }
             } else if (_dataFormat == DC::XType::FLOAT) {
                 float *castBuffer = (float *)readBuffer;
-                for (int i = 0; i < count; i++) { *region++ = (typename std::remove_pointer<T>::type)castBuffer[i]; }
+                for (size_t i = 0; i < count; i++) { *region++ = (typename std::remove_pointer<T>::type)castBuffer[i]; }
             } else if (_dataFormat == DC::XType::DOUBLE) {
                 double *castBuffer = (double *)readBuffer;
-                for (int i = 0; i < count; i++) { *region++ = (typename std::remove_pointer<T>::type)castBuffer[i]; }
+                for (size_t i = 0; i < count; i++) { *region++ = (typename std::remove_pointer<T>::type)castBuffer[i]; }
             }
         }
     }

--- a/lib/vdc/DCBOV.cpp
+++ b/lib/vdc/DCBOV.cpp
@@ -288,7 +288,6 @@ template<class T> void DCBOV::_generateCoordinates(int dim, const vector<size_t>
 
     double denom = (dataSize[dim] - 1);
     double increment = denom == 0 ? 0 : brickSize[dim] / denom;
-    // double increment = brickSize[dim] / (dataSize[dim] - 1);
     double start = origin[dim] + min[0] * increment;
     size_t steps = max[0] - min[0];
 

--- a/lib/vdc/DCBOV.cpp
+++ b/lib/vdc/DCBOV.cpp
@@ -66,7 +66,7 @@ void DCBOV::_InitDimensions()
 {
     _dimsMap.clear();
     std::array<std::string, 3> dimnames = _bovCollection->GetSpatialDimensions();
-    std::array<int, 3>         dimlens = _bovCollection->GetDataSize();
+    std::array<size_t, 3>      dimlens = _bovCollection->GetDataSize();
 
     for (int i = 0; i < dimnames.size(); i++) {
         Dimension dim(dimnames[i], dimlens[i]);
@@ -282,7 +282,7 @@ int DCBOV::_isCoordinateVariable(std::string varname) const
 
 template<class T> void DCBOV::_generateCoordinates(int dim, const vector<size_t> &min, const vector<size_t> &max, T *region) const
 {
-    std::array<int, 3>    dataSize = _bovCollection->GetDataSize();
+    std::array<size_t, 3> dataSize = _bovCollection->GetDataSize();
     std::array<double, 3> origin = _bovCollection->GetBrickOrigin();
     std::array<double, 3> brickSize = _bovCollection->GetBrickSize();
 

--- a/lib/vdc/DCBOV.cpp
+++ b/lib/vdc/DCBOV.cpp
@@ -287,7 +287,7 @@ template<class T> void DCBOV::_generateCoordinates(int dim, const vector<size_t>
     std::array<double, 3> brickSize = _bovCollection->GetBrickSize();
 
     double denom = (dataSize[dim] - 1);
-    double increment = denom == 0 ? 0 : brickSize[dim] / denom;
+    double increment = denom == 0. ? 0. : brickSize[dim] / denom;
     double start = origin[dim] + min[0] * increment;
     size_t steps = max[0] - min[0];
 

--- a/lib/vdc/DCBOV.cpp
+++ b/lib/vdc/DCBOV.cpp
@@ -66,7 +66,7 @@ void DCBOV::_InitDimensions()
 {
     _dimsMap.clear();
     std::array<std::string, 3> dimnames = _bovCollection->GetSpatialDimensions();
-    std::array<size_t, 3>      dimlens = _bovCollection->GetDataSize();
+    std::array<int, 3>         dimlens = _bovCollection->GetDataSize();
 
     for (int i = 0; i < dimnames.size(); i++) {
         Dimension dim(dimnames[i], dimlens[i]);
@@ -282,11 +282,13 @@ int DCBOV::_isCoordinateVariable(std::string varname) const
 
 template<class T> void DCBOV::_generateCoordinates(int dim, const vector<size_t> &min, const vector<size_t> &max, T *region) const
 {
-    std::array<size_t, 3> dataSize = _bovCollection->GetDataSize();
+    std::array<int, 3>    dataSize = _bovCollection->GetDataSize();
     std::array<double, 3> origin = _bovCollection->GetBrickOrigin();
     std::array<double, 3> brickSize = _bovCollection->GetBrickSize();
 
-    double increment = brickSize[dim] / (dataSize[dim] - 1);
+    double denom = (dataSize[dim] - 1);
+    double increment = denom == 0 ? 0 : brickSize[dim] / denom;
+    // double increment = brickSize[dim] / (dataSize[dim] - 1);
     double start = origin[dim] + min[0] * increment;
     size_t steps = max[0] - min[0];
 


### PR DESCRIPTION
Fixes #2826 with 2D grids at DCBOV.cpp:290.

This also adds validation for negative values passed to DATA_SIZE and BRICK_SIZE.  

Note - this required changing the types for those values from size_t to int.  This is because stringstream is used for converting the user's string values to numeric values.  Unfortunately, stringstream does not fail or report an error when converting negative values to size_t.  Therefore, I had to convert to int, and check for negative values during validation.  I don't think this is a problem since grid sizes shouldn't hit INT_MAX any time soon.