### PR TITLE
Issue2821: Tighter constraints on TIME token, and relevant documentation

### DIFF
--- a/include/vapor/BOVCollection.h
+++ b/include/vapor/BOVCollection.h
@@ -73,7 +73,7 @@ private:
     std::string                _timeDimension;
 
     int  _parseHeader(std::ifstream &header);
-    void _populateDataFileMap();
+    int  _populateDataFileMap();
 
     template<typename T> int _findToken(const std::string &token, std::string &line, T &value, bool verbose = false);
     template<typename T> int _findToken(const std::string &token, std::string &line, std::array<T, 3> &value, bool verbose = false);

--- a/include/vapor/DCBOV.h
+++ b/include/vapor/DCBOV.h
@@ -51,16 +51,16 @@ class BOVCollection;
 //! following VisIt document: https://github.com/NCAR/VAPOR/files/6341067/GettingDataIntoVisIt2.0.0.pdf
 //!
 //! The following BOV tags are mandatory for Vapor to ingest data:
-//! - DATA_FILE
-//! - DATA_SIZE
-//! - DATA_FORMAT
+//! - DATA_FILE    (type: string)
+//! - DATA_SIZE    (type: three integer values that are >1)
+//! - DATA_FORMAT  (type: string of either INT, FLOAT, or DOUBLE)
+//! - TIME         (type: one floating point value.  May not be equal to FLT_MIN)
 //!
 //! The following BOV tags are optional:
-//! - BRICK_ORIGIN (default: 0., 0., 0.)
-//! - BRICK_SIZE   (default: 1., 1., 1.)
-//! - TIME         (default: 0.)
-//! - VARIABLE     (default: "brickVar")
-//! - BYTE_OFFSET  (default: 0)
+//! - BRICK_ORIGIN (type: three floating point values,   default: 0., 0., 0.)
+//! - BRICK_SIZE   (type: three floating point values,   default: 1., 1., 1.)
+//! - VARIABLE     (type: one alphanumeric string value, default: "brickVar")
+//! - BYTE_OFFSET  (type: one integer value,             default: 0)
 //!
 //! The following BOV tags are currently unsupported.  They can be included in a BOV header,
 //! but they will be unused.
@@ -70,12 +70,12 @@ class BOVCollection;
 //! - DATA_BRICKLETS
 //! - DATA_COMPONENTS
 //!
+//! Each .bov file can only refer to a single data file for a single variable, at a single timestep.
 //! If duplicate key/value pairs exist in a BOV header, the value closest to the bottom of the file will be used.
 //! If duplicate values exist for whatever reason, all entries must be valid (except for DATA_FILE, which gets validated after parsing)
 //! Scientific notation is supported for floating point values like BRICK_ORIGIN and BRICK_SIZE.
 //! Scientific notation is not supported for integer values like DATA_SIZE.
 //! Wild card characters are not currently supported in the DATA_FILE token.
-//! Each .bov file can only refer to a single data file.
 //! VARIABLE must be alphanumeric (abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-)
 //!
 //! \author Scott Pearse

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -128,7 +128,7 @@ int BOVCollection::Initialize(const std::vector<std::string> &paths)
 
             rc = _populateDataFileMap();
             if (rc < 0) {
-                SetErrMsg("Duplicate time entries found in BOV files.  Each file must uniquely describe one variable, at one timestep.");
+                SetErrMsg("Problem indexing data files.");
                 return -1;
             }
         } else {
@@ -273,7 +273,10 @@ int BOVCollection::_validateParsedValues()
 
 int BOVCollection::_populateDataFileMap()
 {
-    if (_dataFileMap[_variable].count(_time)) return -1;    // Duplicate time entries were found for this variable
+    if (_dataFileMap[_variable].count(_time)) {
+        SetErrMsg("Duplicate time entries found in BOV files.  Each file must uniquely describe one variable, at one timestep.");
+        return -1;
+    }
 
     _variables.push_back(_variable);
 

--- a/lib/vdc/BOVCollection.cpp
+++ b/lib/vdc/BOVCollection.cpp
@@ -41,7 +41,7 @@ const std::array<size_t, 3> BOVCollection::_defaultGridSize = {0, 0, 0};
 const DC::XType             BOVCollection::_defaultFormat = DC::XType::INVALID;
 const std::string           BOVCollection::_defaultFile = "";
 const std::string           BOVCollection::_defaultVar = "brickVar";
-const double                BOVCollection::_defaultTime = FLT_MIN;//0.;
+const double                BOVCollection::_defaultTime = FLT_MIN;
 const size_t                BOVCollection::_defaultByteOffset = 0;
 
 // Currently unused in ReadRegion() logic
@@ -124,6 +124,7 @@ int BOVCollection::Initialize(const std::vector<std::string> &paths)
             if (_dataFile == _defaultFile) { return _missingValueError(DATA_FILE_TOKEN); }
             if (_dataFormat == _defaultFormat) { return _missingValueError(FORMAT_TOKEN); }
             if (_gridSize == _defaultGridSize) { return _missingValueError(GRID_SIZE_TOKEN); }
+            if (_time == _defaultTime) { return _missingValueError(TIME_TOKEN); }
 
             rc = _populateDataFileMap();
             if (rc < 0) {
@@ -230,9 +231,6 @@ int BOVCollection::_validateParsedValues()
         _gridSizeAssigned = true;
     }
 
-    // Validate time value
-    if (_time == _defaultTime)
-        return _invalidValueError(TIME_TOKEN);
 
     // Validate data format
     if (_tmpDataFormat == DC::INVALID)
@@ -275,10 +273,11 @@ int BOVCollection::_validateParsedValues()
 
 int BOVCollection::_populateDataFileMap()
 {
+    if (_dataFileMap[_variable].count(_time)) return -1;    // Duplicate time entries were found for this variable
+
     _variables.push_back(_variable);
 
     if (std::find(_times.begin(), _times.end(), _time) == _times.end()) _times.push_back(_time);
-    else return -1; // Duplicate time entries were found for this variable
 
     std::sort(_times.begin(), _times.end());
 


### PR DESCRIPTION
Fixes #2821 by making the TIME token mandatory in each file, and throwing an error when duplicate files refer to a single variable at the same timestep.

Also adds documentation on how this requirement for TIME, and adds info on default values for the optional tokens in BOV files.