### PR TITLE
MPAS data sets may not have edge variables

### DIFF
--- a/lib/vdc/DCMPAS.cpp
+++ b/lib/vdc/DCMPAS.cpp
@@ -36,7 +36,7 @@ const string maxEdgesDimName = "maxEdges";
 const string maxEdges2DimName = "maxEdges2";
 const string vertexDegreeDimName = "vertexDegree";
 
-const vector<string> requiredDimNames = {timeDimName, nCellsDimName, nVerticesDimName, nEdgesDimName, maxEdgesDimName, maxEdges2DimName, vertexDegreeDimName};
+const vector<string> requiredDimNames = {timeDimName, nCellsDimName, nVerticesDimName, nEdgesDimName, vertexDegreeDimName};
 
 const vector<string> optionalVertDimNames = {nVertLevelsDimName};
 


### PR DESCRIPTION
MPAS data sets may not have edge variables, in which case the `maxEdges` and `maxEdges2` dimension names may not be present. 

This PR removes the requirement that these dimension names are present in an MPAS file.