### PR TITLE
Issue2858 - Add option to silence time reports in smokeTests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - run:
           name: Smoke test
           command: |
-            python3 /root/project/test_apps/smokeTests/smokeTests.py --testDataRoot=/smokeTestData/smokeTestData --binaryRoot=/root/project/build/bin --resultsDir=/root/project/test_apps/smokeTests/testResults
+            python3 /root/project/test_apps/smokeTests/smokeTests.py -testDataRoot=/smokeTestData/smokeTestData -binaryRoot=/root/project/build/bin -resultsDir=/root/project/test_apps/smokeTests/testResults
 
       - store_artifacts:
           path: /root/project/test_apps/smokeTests/testResults

--- a/test_apps/smokeTests/dataMgrTools.cpp
+++ b/test_apps/smokeTests/dataMgrTools.cpp
@@ -93,7 +93,7 @@ void PrintVariables(const VAPoR::DataMgr &dataMgr, bool verbose, bool testVars)
     }
 }
 
-void TestVariables(VAPoR::DataMgr &dataMgr)
+void TestVariables(VAPoR::DataMgr &dataMgr, bool silenceTime)
 {
     vector<string> vars;
     for (int d = 1; d < 4; d++) {
@@ -129,12 +129,12 @@ void TestVariables(VAPoR::DataMgr &dataMgr)
             cout << "    Dimension Lengths:  " << s << endl;
             cout << "    Topology Dimension: " << dataMgr.GetVarTopologyDim(varName) << endl;
             cout << endl;
-            PrintStats(rms, numMissingValues, disagreements, 0.0);
+            PrintStats(rms, numMissingValues, disagreements, 0.0, silenceTime);
         }
     }
 }
 
-int TestDataMgr(const std::string &fileType, size_t memsize, size_t nthreads, const std::vector<std::string> &files, const std::vector<std::string> &options)
+int TestDataMgr(const std::string &fileType, size_t memsize, size_t nthreads, const std::vector<std::string> &files, const std::vector<std::string> &options, bool silenceTime)
 {
     VAPoR::DataMgr dataMgr(fileType, memsize, nthreads);
     int            rc = dataMgr.Initialize(files, options);
@@ -146,7 +146,7 @@ int TestDataMgr(const std::string &fileType, size_t memsize, size_t nthreads, co
     PrintDimensions(dataMgr);
     PrintMeshes(dataMgr);
     PrintVariables(dataMgr);
-    TestVariables(dataMgr);
+    TestVariables(dataMgr, silenceTime);
     PrintCoordVariables(dataMgr);
     PrintTimeCoordinates(dataMgr);
 

--- a/test_apps/smokeTests/dataMgrTools.h
+++ b/test_apps/smokeTests/dataMgrTools.h
@@ -18,4 +18,4 @@ void PrintCompressionInfo(const VAPoR::DataMgr &dataMgr, const std::string &varn
 
 void TestVariables(VAPoR::DataMgr &dataMgr);
 
-int TestDataMgr(const std::string &fileType, size_t memsize, size_t nthreads, const std::vector<std::string> &files, const std::vector<std::string> &options);
+int TestDataMgr(const std::string &fileType, size_t memsize, size_t nthreads, const std::vector<std::string> &files, const std::vector<std::string> &options, bool silenceTime);

--- a/test_apps/smokeTests/gridTools.cpp
+++ b/test_apps/smokeTests/gridTools.cpp
@@ -302,16 +302,17 @@ bool TestConstCoordItr(const Grid *g, size_t &count, size_t &expectedCount, size
     return rc;
 }
 
-void PrintStats(double rms, size_t numMissingValues, size_t disagreements, double time)
+void PrintStats(double rms, size_t numMissingValues, size_t disagreements, double time, bool silenceTime)
 {
     cout << "    RMS error:                                           " << rms << endl;
     cout << "    Missing value count:                                 " << numMissingValues << endl;
     cout << "    GetValueAtIndex() vs GetValue() disagreement count:  " << disagreements << endl;
-    cout << "    Time:                                                " << time << endl;
+    if ( !silenceTime )
+        cout << "    Time:                                                " << time << endl;
     cout << endl;
 }
 
-bool RunTest(Grid *grid)
+bool RunTest(Grid *grid, bool silenceTime)
 {
     bool   rc = true;
     double rms;
@@ -329,7 +330,7 @@ bool RunTest(Grid *grid)
 
     double time = Wasp::GetTime() - t0;
 
-    PrintStats(rms, numMissingValues, disagreements, time);
+    PrintStats(rms, numMissingValues, disagreements, time, silenceTime);
 
     if (rc == false) {
         cout << "*** Error reported in " << grid->GetType() << " grid ***" << endl << endl;
@@ -340,7 +341,7 @@ bool RunTest(Grid *grid)
     return rc;
 }
 
-bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, float maxVal)
+bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, float maxVal, bool silenceTime)
 {
     auto   dims = grid->GetDimensions();
     size_t nDims = grid->GetNumDimensions();
@@ -357,10 +358,10 @@ bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, f
         MakeConstantField(grid, maxVal);
 
         grid->SetInterpolationOrder(linear);
-        if (RunTest(grid) == false) { rc = false; }
+        if (RunTest(grid, silenceTime) == false) { rc = false; }
 
         grid->SetInterpolationOrder(nearestNeighbor);
-        if (RunTest(grid) == false) { rc = false; }
+        if (RunTest(grid, silenceTime) == false) { rc = false; }
     }
 
     if (std::find(tests.begin(), tests.end(), "Ramp") != tests.end()) {
@@ -368,20 +369,21 @@ bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, f
         MakeRamp(grid, minVal, maxVal);
 
         grid->SetInterpolationOrder(linear);
-        if (RunTest(grid) == false) { rc = false; }
+        if (RunTest(grid, silenceTime) == false) { rc = false; }
 
         grid->SetInterpolationOrder(nearestNeighbor);
-        if (RunTest(grid) == false) { rc = false; }
+        if (RunTest(grid, silenceTime) == false) { rc = false; }
     }
 
     if (std::find(tests.begin(), tests.end(), "RampOnAxis") != tests.end()) {
         cout << type << " " << x << "x" << y << "x" << z << " Ramp up on Z axis:" << endl;
         MakeRampOnAxis(grid, minVal, maxVal, Z);
         grid->SetInterpolationOrder(linear);
-        if (RunTest(grid) == false) { rc = false; }
+        if (RunTest(grid, silenceTime) == false) { rc = false; }
 
         grid->SetInterpolationOrder(nearestNeighbor);
-        if (RunTest(grid) == false) { rc = false; }
+        if (RunTest(grid, silenceTime) == false) { rc = false; }
+
     }
 
     if (std::find(tests.begin(), tests.end(), "Triangle") != tests.end()) {
@@ -389,11 +391,11 @@ bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, f
         MakeTriangle(grid, minVal, maxVal);
 
         grid->SetInterpolationOrder(linear);
-        if (RunTest(grid) == false) { rc = false; }
-        RunTest(grid);
+        if (RunTest(grid, silenceTime) == false) { rc = false; }
+        RunTest(grid, silenceTime);
 
         grid->SetInterpolationOrder(nearestNeighbor);
-        if (RunTest(grid) == false) { rc = false; }
+        if (RunTest(grid, silenceTime) == false) { rc = false; }
     }
 
     // Iterator tests
@@ -405,32 +407,32 @@ bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, f
 
     if (TestIterator(grid, count, expectedCount, disagreements, time) == false) { rc = false; }
 
-    PrintGridIteratorResults(type, "Iterator", count, expectedCount, disagreements, time);
+    PrintGridIteratorResults(type, "Iterator", count, expectedCount, disagreements, time, silenceTime);
 
     if (TestConstCoordItr(grid, count, expectedCount, disagreements, time) == false) { rc = false; }
 
-    PrintGridIteratorResults(type, "ConstCoordIterator", count, expectedCount, disagreements, time);
+    PrintGridIteratorResults(type, "ConstCoordIterator", count, expectedCount, disagreements, time, silenceTime);
 
     if (TestConstNodeIterator(grid, count, expectedCount, disagreements, time) == false) { rc = false; }
 
-    PrintGridIteratorResults(type, "ConstNodeIterator", count, expectedCount, disagreements, time);
+    PrintGridIteratorResults(type, "ConstNodeIterator", count, expectedCount, disagreements, time, silenceTime);
 
     return rc;
 }
 
-void PrintGridIteratorResults(std::string &gridType, std::string itrType, size_t count, size_t expectedCount, size_t disagreements, double time)
+void PrintGridIteratorResults(std::string &gridType, std::string itrType, size_t count, size_t expectedCount, size_t disagreements, double time, bool silenceTime)
 {
     std::string passFail = " --- PASS";
     if (count != expectedCount || disagreements > 0) { passFail = " --- FAIL"; }
 
     cout << gridType << " Grid::" << itrType << passFail << endl;
     cout << "  Count:                " << count << endl;
-    ;
     cout << "  Expected Count:       " << expectedCount << endl;
-    ;
     cout << "  Value Disagreements:  " << disagreements << endl;
-    ;
-    cout << "  Time:                 " << time << endl;
+
+    if (!silenceTime)
+        cout << "  Time:                 " << time << endl;
+
     cout << endl;
 }
 

--- a/test_apps/smokeTests/gridTools.cpp
+++ b/test_apps/smokeTests/gridTools.cpp
@@ -217,7 +217,7 @@ bool TestConstNodeIterator(const Grid *g, size_t &count, size_t &expectedCount, 
     for (auto dim : dims) expectedCount *= dim;
 
     for (; itr != enditr; ++itr) {
-        DimsType            ijk3 = {0, 0, 0};
+        DimsType ijk3 = {0, 0, 0};
         Wasp::VectorizeCoords(count, dims.data(), ijk3.data(), dims.size());
 
         double itrData = g->GetValueAtIndex(*itr);
@@ -284,7 +284,7 @@ bool TestConstCoordItr(const Grid *g, size_t &count, size_t &expectedCount, size
     for (; itr != enditr; ++itr) {
         DimsType ijk;
         Wasp::VectorizeCoords(count, dims.data(), ijk.data(), dims.size());
-        CoordType           coords;
+        CoordType coords;
 
         bool disagree = false;
         g->GetUserCoordinates(ijk, coords);
@@ -307,8 +307,7 @@ void PrintStats(double rms, size_t numMissingValues, size_t disagreements, doubl
     cout << "    RMS error:                                           " << rms << endl;
     cout << "    Missing value count:                                 " << numMissingValues << endl;
     cout << "    GetValueAtIndex() vs GetValue() disagreement count:  " << disagreements << endl;
-    if ( !silenceTime )
-        cout << "    Time:                                                " << time << endl;
+    if (!silenceTime) cout << "    Time:                                                " << time << endl;
     cout << endl;
 }
 
@@ -383,7 +382,6 @@ bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, f
 
         grid->SetInterpolationOrder(nearestNeighbor);
         if (RunTest(grid, silenceTime) == false) { rc = false; }
-
     }
 
     if (std::find(tests.begin(), tests.end(), "Triangle") != tests.end()) {
@@ -430,8 +428,7 @@ void PrintGridIteratorResults(std::string &gridType, std::string itrType, size_t
     cout << "  Expected Count:       " << expectedCount << endl;
     cout << "  Value Disagreements:  " << disagreements << endl;
 
-    if (!silenceTime)
-        cout << "  Time:                 " << time << endl;
+    if (!silenceTime) cout << "  Time:                 " << time << endl;
 
     cout << endl;
 }

--- a/test_apps/smokeTests/gridTools.h
+++ b/test_apps/smokeTests/gridTools.h
@@ -33,13 +33,13 @@ bool TestIterator(VAPoR::Grid *g, size_t &count, size_t &expectedCount, size_t &
 // Returns the expected node count for Grid::ConstCoordIterator
 bool TestConstCoordItr(const VAPoR::Grid *g, size_t &count, size_t &expectedCount, size_t &disagreements, double &time);
 
-void PrintGridIteratorResults(std::string &gridType, std::string itrType, size_t count, size_t expectedCount, size_t disagreements, double time);
+void PrintGridIteratorResults(std::string &gridType, std::string itrType, size_t count, size_t expectedCount, size_t disagreements, double time, bool silenceTime);
 
-void PrintStats(double rms, size_t numMissingValues, size_t disagreements, double time);
+void PrintStats(double rms, size_t numMissingValues, size_t disagreements, double time, bool silenceTime);
 
-bool RunTest(VAPoR::Grid *grid);
+bool RunTest(VAPoR::Grid *grid, bool silenceTime);
 
-bool RunTests(VAPoR::Grid *grid, const std::vector<std::string> &tests, float minVal, float maxVal);
+bool RunTests(VAPoR::Grid *grid, const std::vector<std::string> &tests, float minVal, float maxVal, bool silenceTime);
 
 VAPoR::StretchedGrid *MakeStretchedGrid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const std::vector<double> &minu, const std::vector<double> &maxu);
 

--- a/test_apps/smokeTests/smokeTests.py
+++ b/test_apps/smokeTests/smokeTests.py
@@ -13,19 +13,8 @@ import argparse
 parser = argparse.ArgumentParser(
     "A test driver for the DataMgr and Grid classes"
 )
-'''parser.add_argument( 
-    '--makeBaseline', 
-    nargs=1,
-    type=str,
-    default=False, 
-    required=False,
-    metavar='false',
-    help='Boolean that makes these test results the baseline on which future'
-    + ' tests will be compared.  If no baseline file exists, this will automatically '
-    + ' be set to true.'
-)'''
 parser.add_argument( 
-    '--makeBaseline', 
+    '-makeBaseline', 
     default=False,
     dest='makeBaseline',
     action='store_true',
@@ -34,7 +23,7 @@ parser.add_argument(
     + ' be set to true.'
 )
 parser.add_argument( 
-    '--testDataRoot', 
+    '-testDataRoot', 
     nargs=1,
     type=str,
     default="/Users/pearse/Data/smokeTestData", 
@@ -43,7 +32,7 @@ parser.add_argument(
     help='Directory where DataMgr test data is stored.'
 )
 parser.add_argument( 
-    '--binaryRoot', 
+    '-binaryRoot', 
     nargs=1,
     type=str,
     default="/Users/pearse/VAPOR/build/bin", 
@@ -52,7 +41,7 @@ parser.add_argument(
     help='Directory where binary test programs (testGrid, testDataMgr) are stored.'
 )
 parser.add_argument( 
-    '--resultsDir', 
+    '-resultsDir', 
     nargs=1,
     type=str,
     default="/Users/pearse/VAPOR/test_apps/smokeTests/testResults", 
@@ -60,16 +49,8 @@ parser.add_argument(
     metavar='/path/to/write/results/to',
     help='Directory where test results are stored.'
 )
-'''parser.add_argument( 
-    '--silenceTime', 
-    nargs=1,
-    type=bool,
-    default=False, 
-    required=False,
-    help='Boolean (0, 1, true, or false) that sliences the elapsed time from the printed results.'
-)'''
 parser.add_argument( 
-    '--silenceTime',
+    '-silenceTime',
     default=False,
     dest='silenceTime',
     action='store_true',
@@ -188,10 +169,6 @@ def testDataMgr( dataMgrType, dataMgr, makeBaseline=False ):
     return outputFileName
 
 def testDataMgrs( makeBaseline ):
-    #if ( makeBaseline ):
-    #    diff = open( dataMgrResultsFile, "w" )
-    #else:
-    #    diff = open( dataMgrResultsFile, "a" )
     diff = open( dataMgrResultsFile, "w" )
     
     mismatches = 0
@@ -238,7 +215,6 @@ def main():
 
     rc = 0
 
-    #if ( args.makeBaseline == False and makeBaseline == True ): 
     if ( makeBaseline == True ): 
         print( "    Warning: Some or all baseline files for running DataMgr tests were missing.  "
                "    These files are needed as comparisons for the results of the current series "

--- a/test_apps/smokeTests/testDataMgr.cpp
+++ b/test_apps/smokeTests/testDataMgr.cpp
@@ -113,8 +113,6 @@ int main(int argc, char **argv)
     std::vector<string> options;
     InitializeOptions(argc, argv, op, files, options);
 
-    //std::cout << "                   SILENCE " << opt.silenceTime<< std::endl;
-
     for (int i = 0; i < files.size(); i++) {
         std::string fileName = files[i];
         fileName = fileName.substr(fileName.find_last_of("\\/") + 1);

--- a/test_apps/smokeTests/testDataMgr.cpp
+++ b/test_apps/smokeTests/testDataMgr.cpp
@@ -53,6 +53,7 @@ struct {
     std::string             fileType;
     int                     memsize;
     int                     nthreads;
+    OptionParser::Boolean_T silenceTime;
     OptionParser::Boolean_T nogeoxform;
     OptionParser::Boolean_T novertxform;
 } opt;
@@ -62,6 +63,7 @@ OptionParser::OptDescRec_T set_opts[] = {{"fileType", 1, "vdc", "data set type (
                                          {"nthreads", 1, "0",
                                           "Specify number of execution threads "
                                           "0 => use number of cores"},
+                                         {"silenceTime", 0, "", "Do not print elapsed time for tests"},
                                          {"nogeoxform", 0, "", "Do not apply geographic transform (projection to PCS"},
                                          {"novertxform", 0, "", "Do not apply to convert pressure, etc. to meters"},
                                          {nullptr}};
@@ -69,6 +71,7 @@ OptionParser::OptDescRec_T set_opts[] = {{"fileType", 1, "vdc", "data set type (
 OptionParser::Option_T get_options[] = {{"fileType", Wasp::CvtToCPPStr, &opt.fileType, sizeof(opt.fileType)},
                                         {"memsize", Wasp::CvtToInt, &opt.memsize, sizeof(opt.memsize)},
                                         {"nthreads", Wasp::CvtToInt, &opt.nthreads, sizeof(opt.nthreads)},
+                                        {"silenceTime", Wasp::CvtToBoolean, &opt.silenceTime, sizeof(opt.silenceTime)},
                                         {"nogeoxform", Wasp::CvtToBoolean, &opt.nogeoxform, sizeof(opt.nogeoxform)},
                                         {"novertxform", Wasp::CvtToBoolean, &opt.novertxform, sizeof(opt.novertxform)},
                                         {nullptr}};
@@ -110,15 +113,17 @@ int main(int argc, char **argv)
     std::vector<string> options;
     InitializeOptions(argc, argv, op, files, options);
 
+    //std::cout << "                   SILENCE " << opt.silenceTime<< std::endl;
+
     for (int i = 0; i < files.size(); i++) {
         std::string fileName = files[i];
         fileName = fileName.substr(fileName.find_last_of("\\/") + 1);
         cout << fileName << endl;
     }
 
-    int rc = TestDataMgr(opt.fileType, opt.memsize, opt.nthreads, files, options);
+    int rc = TestDataMgr(opt.fileType, opt.memsize, opt.nthreads, files, options, opt.silenceTime);
 
-    cout << "Elapsed time: " << Wasp::GetTime() - t0 << endl;
+    if (!opt.silenceTime) cout << "Elapsed time: " << Wasp::GetTime() - t0 << endl;
 
     return rc;
 }

--- a/test_apps/smokeTests/testGrid.cpp
+++ b/test_apps/smokeTests/testGrid.cpp
@@ -175,13 +175,6 @@ int main(int argc, char **argv)
     OptionParser op;
     InitializeOptions(argc, argv, op);
 
-    //for (int i=0; i<argc; i++) 
-    //    std::cout << argv[i] << std::endl;
-    //std::cout << "                              HELP         " << opt.help << std::endl;
-    //std::cout << "                              SILENCE TIME " << opt.silenceTime << std::endl;
-
-    //exit(0);
-
     std::cout << std::fixed << std::showpoint;
     std::cout << std::setprecision(4);
 

--- a/test_apps/smokeTests/testGrid.cpp
+++ b/test_apps/smokeTests/testGrid.cpp
@@ -101,6 +101,7 @@ struct opt_t {
     std::vector<float>       extents;
     double                   minValue;
     double                   maxValue;
+    OptionParser::Boolean_T  silenceTime;
     OptionParser::Boolean_T  help;
 } opt;
 
@@ -118,6 +119,7 @@ OptionParser::OptDescRec_T set_opts[] = {{"grids", 1, "Regular:Stretched:Layered
                                           "(X0:Y0:Z0:X1:Y1:Z1)"},
                                          {"minValue", 1, "0", "The minimum data value to be assigned to cells in synthetic grids"},
                                          {"maxValue", 1, "1", "The maximum data value to be assigned to cells in synthetic grids"},
+                                         {"silenceTime", 0, "", "Do not print elapsed time for tests"},
                                          {"help", 0, "", "Print this message and exit"},
                                          {nullptr}};
 
@@ -128,6 +130,7 @@ OptionParser::Option_T get_options[] = {{"grids", Wasp::CvtToStrVec, &opt.grids,
                                         {"extents", Wasp::CvtToFloatVec, &opt.extents, sizeof(opt.extents)},
                                         {"minValue", Wasp::CvtToDouble, &opt.minValue, sizeof(opt.minValue)},
                                         {"maxValue", Wasp::CvtToDouble, &opt.maxValue, sizeof(opt.maxValue)},
+                                        {"silenceTime", Wasp::CvtToBoolean, &opt.silenceTime, sizeof(opt.silenceTime)},
                                         {"help", Wasp::CvtToBoolean, &opt.help, sizeof(opt.help)},
                                         {nullptr}};
 
@@ -172,6 +175,13 @@ int main(int argc, char **argv)
     OptionParser op;
     InitializeOptions(argc, argv, op);
 
+    //for (int i=0; i<argc; i++) 
+    //    std::cout << argv[i] << std::endl;
+    //std::cout << "                              HELP         " << opt.help << std::endl;
+    //std::cout << "                              SILENCE TIME " << opt.silenceTime << std::endl;
+
+    //exit(0);
+
     std::cout << std::fixed << std::showpoint;
     std::cout << std::setprecision(4);
 
@@ -203,8 +213,8 @@ int main(int argc, char **argv)
         std::vector<float *> rgBlks = AllocateBlocks(opt.bs, opt.dims);
         RegularGrid *        regularGrid = new RegularGrid(opt.dims, opt.bs, rgBlks, minu, maxu);
         double               t1 = Wasp::GetTime() - t0;
-        cout << "RegularGrid() time: " << t1 << endl;
-        regularRC = RunTests(regularGrid, opt.arrangements, opt.minValue, opt.maxValue);
+        if (!opt.silenceTime) cout << "RegularGrid() time: " << t1 << endl;
+        regularRC = RunTests(regularGrid, opt.arrangements, opt.minValue, opt.maxValue, opt.silenceTime);
         delete regularGrid;
     }
 
@@ -213,8 +223,8 @@ int main(int argc, char **argv)
         double         t0 = Wasp::GetTime();
         StretchedGrid *stretchedGrid = MakeStretchedGrid(opt.dims, opt.bs, minu, maxu);
         double         t1 = Wasp::GetTime() - t0;
-        cout << "MakeStretchedGrid() time: " << t1 << endl;
-        stretchedRC = RunTests(stretchedGrid, opt.arrangements, opt.minValue, opt.maxValue);
+        if (!opt.silenceTime) cout << "MakeStretchedGrid() time: " << t1 << endl;
+        stretchedRC = RunTests(stretchedGrid, opt.arrangements, opt.minValue, opt.maxValue, opt.silenceTime);
         delete stretchedGrid;
     }
 
@@ -223,8 +233,8 @@ int main(int argc, char **argv)
         double       t0 = Wasp::GetTime();
         LayeredGrid *layeredGrid = MakeLayeredGrid(opt.dims, opt.bs, minu, maxu);
         double       t1 = Wasp::GetTime() - t0;
-        cout << "MakeLayeredGrid() time: " << t1 << endl;
-        layeredRC = RunTests(layeredGrid, opt.arrangements, opt.minValue, opt.maxValue);
+        if (!opt.silenceTime) cout << "MakeLayeredGrid() time: " << t1 << endl;
+        layeredRC = RunTests(layeredGrid, opt.arrangements, opt.minValue, opt.maxValue, opt.silenceTime);
         delete layeredGrid;
     }
 
@@ -234,8 +244,8 @@ int main(int argc, char **argv)
         CurvilinearGrid *curvilinearGrid;
         curvilinearGrid = MakeCurvilinearTerrainGrid(opt.bs, minu, maxu, opt.dims);
         double t1 = Wasp::GetTime() - t0;
-        cout << "MakeCurvilinearTerrainGrid() time: " << t1 << endl;
-        curvilinearRC = RunTests(curvilinearGrid, opt.arrangements, opt.minValue, opt.maxValue);
+        if (!opt.silenceTime) cout << "MakeCurvilinearTerrainGrid() time: " << t1 << endl;
+        curvilinearRC = RunTests(curvilinearGrid, opt.arrangements, opt.minValue, opt.maxValue, opt.silenceTime);
         delete curvilinearGrid;
     }
 
@@ -244,8 +254,8 @@ int main(int argc, char **argv)
         double              t0 = Wasp::GetTime();
         UnstructuredGrid2D *g = MakeUnstructuredGrid2D(opt.dims, opt.bs, minu, maxu);
         double              t1 = Wasp::GetTime() - t0;
-        cout << "MakeUnstructuredGrid2D() time: " << t1 << endl;
-        unstructured2DRC = RunTests(g, opt.arrangements, opt.minValue, opt.maxValue);
+        if (!opt.silenceTime) cout << "MakeUnstructuredGrid2D() time: " << t1 << endl;
+        unstructured2DRC = RunTests(g, opt.arrangements, opt.minValue, opt.maxValue, opt.silenceTime);
         delete g;
     }
 
@@ -271,7 +281,7 @@ int main(int argc, char **argv)
     }
 
     double t1 = Wasp::GetTime();
-    cout << "Elapsed time: " << t1 - t0 << endl;
+    if (!opt.silenceTime) cout << "Elapsed time: " << t1 - t0 << endl;
 
     DeleteHeap();
 


### PR DESCRIPTION
Fixes #2858 by adding the "-silenceTime" option, which silences all timing reports in our smoke tests.