### PR TITLE
Fix smoke tests in #2871

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - run:
           name: Smoke test
           command: |
-            python3 /root/project/test_apps/smokeTests/smokeTests.py -testDataRoot=/smokeTestData/smokeTestData -binaryRoot=/root/project/build/bin -resultsDir=/root/project/test_apps/smokeTests/testResults
+            python3 /root/project/test_apps/smokeTests/smokeTests.py -testDataRoot=/smokeTestData/smokeTestData -binaryRoot=/root/project/build/test_binaries -resultsDir=/root/project/test_apps/smokeTests/testResults
 
       - store_artifacts:
           path: /root/project/test_apps/smokeTests/testResults


### PR DESCRIPTION
Redirect smoke test launcher to new the test directory, test_binaries.