### PR TITLE
Issue 2708 - Smoke tests failing on 1D and 2D grids

### DIFF
--- a/include/vapor/QuadTreeRectangle.hpp
+++ b/include/vapor/QuadTreeRectangle.hpp
@@ -162,7 +162,7 @@ public:
         if (!_nodes[_rootidx].intersects(rectangle)) return (false);
 
         float ar = rectangle.hAspectRatio();
-        if (! (std::isfinite(ar))) return(false);
+        if (!(std::isfinite(ar))) return (false);
 
         if (ar <= maxAspectRatio && ar >= (1.0 / maxAspectRatio)) {
             return (node_t::insert(_nodes, _rootidx, rectangle, payload, _maxDepth));

--- a/include/vapor/QuadTreeRectangle.hpp
+++ b/include/vapor/QuadTreeRectangle.hpp
@@ -162,6 +162,8 @@ public:
         if (!_nodes[_rootidx].intersects(rectangle)) return (false);
 
         float ar = rectangle.hAspectRatio();
+        if (! (std::isfinite(ar))) return(false);
+
         if (ar <= maxAspectRatio && ar >= (1.0 / maxAspectRatio)) {
             return (node_t::insert(_nodes, _rootidx, rectangle, payload, _maxDepth));
         } else if (ar >= maxAspectRatio) {


### PR DESCRIPTION
fixed #2708 

Wasn't checking for divide by zero