### PR TITLE
Fix broken Windows build

### DIFF
--- a/include/vapor/AnimationParams.h
+++ b/include/vapor/AnimationParams.h
@@ -34,7 +34,7 @@
 //! When this class is local, it controls the time-steps in one visualizer.
 //! The global (shared) AnimationParams controls the animation in any number of visualizers.
 
-class AnimationParams : public VAPoR::ParamsBase {
+class PARAMS_API AnimationParams : public VAPoR::ParamsBase {
 public:
     AnimationParams(ParamsBase::StateSave *ssave);
 

--- a/include/vapor/BookmarkParams.h
+++ b/include/vapor/BookmarkParams.h
@@ -18,7 +18,7 @@
 
 class MouseModeParams;
 
-class BookmarkParams : public VAPoR::ParamsBase {
+class PARAMS_API BookmarkParams : public VAPoR::ParamsBase {
 public:
     BookmarkParams(VAPoR::ParamsBase::StateSave *ssave);
     BookmarkParams(VAPoR::ParamsBase::StateSave *ssave, VAPoR::XmlNode *node);

--- a/include/vapor/ConvexHull.h
+++ b/include/vapor/ConvexHull.h
@@ -28,4 +28,4 @@ double orientation(glm::vec2 p, glm::vec2 q, glm::vec2 r);
 int compare(const void *vp1, const void *vp2);
 
 // Prints convex hull of a set of n points.
-std::stack<glm::vec2> convexHull(glm::vec2 points[], int n);
+std::stack<glm::vec2> convexHull(std::shared_ptr<glm::vec2[]> points, int n);

--- a/include/vapor/ConvexHull.h
+++ b/include/vapor/ConvexHull.h
@@ -28,4 +28,4 @@ double orientation(glm::vec2 p, glm::vec2 q, glm::vec2 r);
 int compare(const void *vp1, const void *vp2);
 
 // Prints convex hull of a set of n points.
-std::stack<glm::vec2> convexHull(std::shared_ptr<glm::vec2[]> points, int n);
+std::stack<glm::vec2> convexHull(glm::vec2* points, int n);

--- a/include/vapor/ConvexHull.h
+++ b/include/vapor/ConvexHull.h
@@ -28,4 +28,4 @@ double orientation(glm::vec2 p, glm::vec2 q, glm::vec2 r);
 int compare(const void *vp1, const void *vp2);
 
 // Prints convex hull of a set of n points.
-std::stack<glm::vec2> convexHull(glm::vec2* points, int n);
+std::stack<glm::vec2> convexHull(glm::vec2 *points, int n);

--- a/include/vapor/GUIStateParams.h
+++ b/include/vapor/GUIStateParams.h
@@ -24,7 +24,7 @@
 class MouseModeParams;
 class BookmarkParams;
 
-class GUIStateParams : public VAPoR::ParamsBase {
+class PARAMS_API GUIStateParams : public VAPoR::ParamsBase {
 public:
     GUIStateParams(VAPoR::ParamsBase::StateSave *ssave);
 

--- a/include/vapor/MouseModeParams.h
+++ b/include/vapor/MouseModeParams.h
@@ -32,7 +32,7 @@
 //! \version 3.0
 //! \date    April 2014
 //!
-class MouseModeParams : public VAPoR::ParamsBase {
+class PARAMS_API MouseModeParams : public VAPoR::ParamsBase {
 public:
     struct MouseMode {
         string             name;

--- a/include/vapor/NavigationUtils.h
+++ b/include/vapor/NavigationUtils.h
@@ -13,7 +13,7 @@ class ViewpointParams;
 //! \brief This class is just migrated legacy code to de-spaghetti other legacy code.
 //! (It is not written by me)
 
-class NavigationUtils : public Wasp::MyBase {
+class RENDER_API NavigationUtils : public Wasp::MyBase {
 public:
     static void SetHomeViewpoint(ControlExec *ce);
     static void UseHomeViewpoint(ControlExec *ce);

--- a/include/vapor/TrackBall.h
+++ b/include/vapor/TrackBall.h
@@ -56,7 +56,7 @@
 /* The Trackball package gives that nice 3D rotation interface.
  * A TrackBall class is needed for each rotated scene.
  */
-class Trackball {
+class RENDER_API Trackball {
 public:
     Trackball();
     Trackball(float scale[3]);

--- a/lib/render/ConvexHull.cpp
+++ b/lib/render/ConvexHull.cpp
@@ -71,7 +71,7 @@ int compare(const void *vp1, const void *vp2)
 //} // end anonymouse namespace
 
 // Prints convex hull of a set of n points.
-std::stack<glm::vec2> convexHull(glm::vec2 points[], int n)
+std::stack<glm::vec2> convexHull(std::shared_ptr<glm::vec2[]> points, int n)
 {
     // Find the bottommost point
     double ymin = points[0].y;

--- a/lib/render/ConvexHull.cpp
+++ b/lib/render/ConvexHull.cpp
@@ -71,8 +71,7 @@ int compare(const void *vp1, const void *vp2)
 //} // end anonymouse namespace
 
 // Prints convex hull of a set of n points.
-//std::stack<glm::vec2> convexHull(std::shared_ptr<glm::vec2[]> points, int n)
-std::stack<glm::vec2> convexHull(glm::vec2* points, int n)
+std::stack<glm::vec2> convexHull(glm::vec2 *points, int n)
 {
     // Find the bottommost point
     double ymin = points[0].y;

--- a/lib/render/ConvexHull.cpp
+++ b/lib/render/ConvexHull.cpp
@@ -71,7 +71,8 @@ int compare(const void *vp1, const void *vp2)
 //} // end anonymouse namespace
 
 // Prints convex hull of a set of n points.
-std::stack<glm::vec2> convexHull(std::shared_ptr<glm::vec2[]> points, int n)
+//std::stack<glm::vec2> convexHull(std::shared_ptr<glm::vec2[]> points, int n)
+std::stack<glm::vec2> convexHull(glm::vec2* points, int n)
 {
     // Find the bottommost point
     double ymin = points[0].y;

--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -293,14 +293,15 @@ void SliceRenderer::_findIntercepts(glm::vec3 &_origin, glm::vec3 &_normal, std:
 
 stack<glm::vec2> SliceRenderer::_2DConvexHull(std::vector<_vertexIn2dAnd3d> &vertices) const
 {
+    VAssert(vertices.size() > 0);
+
     // We now have a set of vertices along the Box's XYZ intercepts.  The edges of these vertices define where
     // the user should see data.  To find the connectivity/edges of these vertices, we will first project them into a 2D
     // coordinate system using our basis function, and then perform Convex Hull on those 2D coordinates.
 
     // Project our 3D points onto the 2D plane using our basis function (_normal, _axis1, and _axis2)
-    //std::shared_ptr<glm::vec2[]> unorderedTwoDPoints(new glm::vec2[vertices.size()]);
-	glm::vec2* unorderedTwoDPoints = new glm::vec2[vertices.size()];
-    int       count = 0;
+    glm::vec2 *unorderedTwoDPoints = new glm::vec2[vertices.size()];
+    int        count = 0;
     for (auto &vertex : vertices) {
         double x = glm::dot(_axis1, vertex.threeD - _origin);    // Find 3D point's projected X coordinate
         double y = glm::dot(_axis2, vertex.threeD - _origin);    // Find 3D point's projected Y coordinate
@@ -313,10 +314,11 @@ stack<glm::vec2> SliceRenderer::_2DConvexHull(std::vector<_vertexIn2dAnd3d> &ver
     // Perform convex hull on our list of 2D points,
     // which defines the outer edges of our polygon
     stack<glm::vec2> orderedTwoDPoints = convexHull(unorderedTwoDPoints, sizeof(unorderedTwoDPoints) / sizeof(unorderedTwoDPoints[0]));
-	if (unorderedTwoDPoints != nullptr) {
-		delete[] unorderedTwoDPoints;
-		unorderedTwoDPoints = nullptr;
-	}
+
+    if (unorderedTwoDPoints != nullptr) {
+        delete[] unorderedTwoDPoints;
+        unorderedTwoDPoints = nullptr;
+    }
 
     return orderedTwoDPoints;
 }

--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -298,7 +298,8 @@ stack<glm::vec2> SliceRenderer::_2DConvexHull(std::vector<_vertexIn2dAnd3d> &ver
     // coordinate system using our basis function, and then perform Convex Hull on those 2D coordinates.
 
     // Project our 3D points onto the 2D plane using our basis function (_normal, _axis1, and _axis2)
-    std::shared_ptr<glm::vec2[]> unorderedTwoDPoints(new glm::vec2[vertices.size()]);
+    //std::shared_ptr<glm::vec2[]> unorderedTwoDPoints(new glm::vec2[vertices.size()]);
+	glm::vec2* unorderedTwoDPoints = new glm::vec2[vertices.size()];
     int       count = 0;
     for (auto &vertex : vertices) {
         double x = glm::dot(_axis1, vertex.threeD - _origin);    // Find 3D point's projected X coordinate
@@ -312,6 +313,11 @@ stack<glm::vec2> SliceRenderer::_2DConvexHull(std::vector<_vertexIn2dAnd3d> &ver
     // Perform convex hull on our list of 2D points,
     // which defines the outer edges of our polygon
     stack<glm::vec2> orderedTwoDPoints = convexHull(unorderedTwoDPoints, sizeof(unorderedTwoDPoints) / sizeof(unorderedTwoDPoints[0]));
+	if (unorderedTwoDPoints != nullptr) {
+		delete[] unorderedTwoDPoints;
+		unorderedTwoDPoints = nullptr;
+	}
+
     return orderedTwoDPoints;
 }
 

--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -298,7 +298,7 @@ stack<glm::vec2> SliceRenderer::_2DConvexHull(std::vector<_vertexIn2dAnd3d> &ver
     // coordinate system using our basis function, and then perform Convex Hull on those 2D coordinates.
 
     // Project our 3D points onto the 2D plane using our basis function (_normal, _axis1, and _axis2)
-    glm::vec2 unorderedTwoDPoints[vertices.size()];
+    std::shared_ptr<glm::vec2[]> unorderedTwoDPoints(new glm::vec2[vertices.size()]);
     int       count = 0;
     for (auto &vertex : vertices) {
         double x = glm::dot(_axis1, vertex.threeD - _origin);    // Find 3D point's projected X coordinate


### PR DESCRIPTION
Several classes were missing the RENDER_API or PARAMS_API macro for Windows.

Additionally, the SliceRenderer was allocating a dynamically sized array, which is a no-go for MSVC.  For some reason it wasn't a problem with GCC or Clang.

Note: I tried using a std::shared_ptr for the array in the SliceRenderer, but it was requiring c++17 features not available with our versions gcc/clang.  I've defaulted to using a raw pointer instead.