### PR TITLE
Deleting a renderer with a visualizer manipulator open causes crash #2937

### DIFF
--- a/apps/vaporgui/VizWin.cpp
+++ b/apps/vaporgui/VizWin.cpp
@@ -661,7 +661,7 @@ void VizWin::_renderHelper(bool fast)
 
     if (_getCurrentMouseMode() == MouseModeParams::GetRegionModeName()) {
         updateManip();
-        if (_getRenderParams()->GetOrientable()) { _updateOriginGlyph(); }
+        if (_getRenderParams() && _getRenderParams()->GetOrientable()) { _updateOriginGlyph(); }
     } else if (vParams->GetProjectionType() == ViewpointParams::MapOrthographic) {
 #ifndef WIN32
         _glManager->PixelCoordinateSystemPush();


### PR DESCRIPTION
Fix #2937