### PR TITLE
Fix: testDataMgr doesn't compute grid extents correctly

### DIFF
--- a/test_apps/smokeTests/dataMgrTools.cpp
+++ b/test_apps/smokeTests/dataMgrTools.cpp
@@ -105,10 +105,8 @@ void TestVariables(VAPoR::DataMgr &dataMgr, bool silenceTime)
             dataMgr.GetVariableExtents(0, varName, -1, -1, minExt, maxExt);
 
             // Reduce extents to test
-            for (int i = 0; i < minExt.size(); i++) {
-                minExt[i] = minExt[i] + minExt[i] / 32.0;
+            for (int i = 0; i < minExt.size(); i++)
                 maxExt[i] = minExt[i] + maxExt[i] / 32.0;
-            }
 
             VAPoR::Grid *grid = dataMgr.GetVariable(0, varName, -1, -1, minExt, maxExt);
             if (!grid) {

--- a/test_apps/smokeTests/dataMgrTools.cpp
+++ b/test_apps/smokeTests/dataMgrTools.cpp
@@ -105,8 +105,7 @@ void TestVariables(VAPoR::DataMgr &dataMgr, bool silenceTime)
             dataMgr.GetVariableExtents(0, varName, -1, -1, minExt, maxExt);
 
             // Reduce extents to test
-            for (int i = 0; i < minExt.size(); i++)
-                maxExt[i] = minExt[i] + maxExt[i] / 32.0;
+            for (int i = 0; i < minExt.size(); i++) maxExt[i] = minExt[i] + maxExt[i] / 32.0;
 
             VAPoR::Grid *grid = dataMgr.GetVariable(0, varName, -1, -1, minExt, maxExt);
             if (!grid) {

--- a/test_apps/smokeTests/dataMgrTools.cpp
+++ b/test_apps/smokeTests/dataMgrTools.cpp
@@ -107,7 +107,7 @@ void TestVariables(VAPoR::DataMgr &dataMgr, bool silenceTime)
             // Reduce extents to test
             for (int i = 0; i < minExt.size(); i++) {
                 minExt[i] = minExt[i] + minExt[i] / 32.0;
-                maxExt[i] = maxExt[i] + maxExt[i] / 32.0;
+                maxExt[i] = minExt[i] + maxExt[i] / 32.0;
             }
 
             VAPoR::Grid *grid = dataMgr.GetVariable(0, varName, -1, -1, minExt, maxExt);
@@ -115,9 +115,9 @@ void TestVariables(VAPoR::DataMgr &dataMgr, bool silenceTime)
                 cerr << "Failed to read variable " << varName << endl;
                 exit(1);
             }
-            double       rms;
-            size_t       numMissingValues;
-            size_t       disagreements;
+            double rms;
+            size_t numMissingValues;
+            size_t disagreements;
             CompareIndexToCoords(grid, rms, numMissingValues, disagreements);
             cout << "Grid test for " << d << "D variable " << varName << ":" << endl;
             cout << "    # Dimensions:       " << dataMgr.GetNumDimensions(varName) << endl;

--- a/test_apps/smokeTests/dataMgrTools.cpp
+++ b/test_apps/smokeTests/dataMgrTools.cpp
@@ -110,7 +110,6 @@ void TestVariables(VAPoR::DataMgr &dataMgr, bool silenceTime)
                 double width = (maxExt[i] - minExt[i]) / 32.0;
                 minExt[i] = center - (width / 2.0);
                 maxExt[i] = center + (width / 2.0);
-                //maxExt[i] = minExt[i] + maxExt[i] / 32.0;
             }
 
             VAPoR::Grid *grid = dataMgr.GetVariable(0, varName, -1, -1, minExt, maxExt);

--- a/test_apps/smokeTests/dataMgrTools.cpp
+++ b/test_apps/smokeTests/dataMgrTools.cpp
@@ -106,8 +106,8 @@ void TestVariables(VAPoR::DataMgr &dataMgr, bool silenceTime)
 
             // Reduce extents to test
             for (int i = 0; i < minExt.size(); i++) {
-                minExt[i] /= 32.0;
-                maxExt[i] /= 32.0;
+                minExt[i] = minExt[i] + minExt[i] / 32.0;
+                maxExt[i] = maxExt[i] + maxExt[i] / 32.0;
             }
 
             VAPoR::Grid *grid = dataMgr.GetVariable(0, varName, -1, -1, minExt, maxExt);

--- a/test_apps/smokeTests/dataMgrTools.cpp
+++ b/test_apps/smokeTests/dataMgrTools.cpp
@@ -104,8 +104,14 @@ void TestVariables(VAPoR::DataMgr &dataMgr, bool silenceTime)
             VAPoR::CoordType minExt, maxExt;
             dataMgr.GetVariableExtents(0, varName, -1, -1, minExt, maxExt);
 
-            // Reduce extents to test
-            for (int i = 0; i < minExt.size(); i++) maxExt[i] = minExt[i] + maxExt[i] / 32.0;
+            // Reduce extents to test, while maintaining the same origin
+            for (int i = 0; i < minExt.size(); i++) {
+                double center = (maxExt[i] + minExt[i]) / 2.0;
+                double width = (maxExt[i] - minExt[i]) / 32.0;
+                minExt[i] = center - (width / 2.0);
+                maxExt[i] = center + (width / 2.0);
+                //maxExt[i] = minExt[i] + maxExt[i] / 32.0;
+            }
 
             VAPoR::Grid *grid = dataMgr.GetVariable(0, varName, -1, -1, minExt, maxExt);
             if (!grid) {

--- a/test_apps/smokeTests/dataMgrTools.cpp
+++ b/test_apps/smokeTests/dataMgrTools.cpp
@@ -104,7 +104,7 @@ void TestVariables(VAPoR::DataMgr &dataMgr, bool silenceTime)
             VAPoR::CoordType minExt, maxExt;
             dataMgr.GetVariableExtents(0, varName, -1, -1, minExt, maxExt);
 
-            // Reduce extents to test, while maintaining the same origin
+            // Reduce extents about the center of the volume to speed tests
             for (int i = 0; i < minExt.size(); i++) {
                 double center = (maxExt[i] + minExt[i]) / 2.0;
                 double width = (maxExt[i] - minExt[i]) / 32.0;


### PR DESCRIPTION
Fixes #2944 by reducing the maximum extents after offsetting them by the minimum value.  Removes the reduction to the minimum extents which are not needed.

I'm not sure why clang-format is modifying lines 115 through 117.

@clyne Since this fixes an issue that doesn't present itself on main, this PR is targeting your ROMS PR fix, #2943.