### PR TITLE
Fixed #2985 - Vapor crashes on 2D NetCDF data 

### DIFF
--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -289,12 +289,12 @@ Grid::ConstNodeIteratorSG::ConstNodeIteratorSG(const Grid *g, bool begin) : Cons
     _index = {0, 0, 0};
     _lastIndex = {0, 0, 0};
 
-    if (!begin) {
-        if (_nDims < 1)
-            _lastIndex[0] = 1;    // edge case for 0D grids
-        else
-            _lastIndex[_nDims - 1] = _dims[_nDims - 1];
+	if (_nDims < 1)
+		_lastIndex[0] = 1;    // edge case for 0D grids
+	else
+		_lastIndex[_nDims - 1] = _dims[_nDims - 1];
 
+    if (!begin) {
         _index = _lastIndex;
     }
 }
@@ -387,12 +387,12 @@ Grid::ConstCellIteratorSG::ConstCellIteratorSG(const Grid *g, bool begin) : Cons
     _index = {0, 0, 0};
     _lastIndex = _index;
 
-    if (!begin) {
-        if (_nDims < 1)
-            _lastIndex[0] = 1;    // edge case for 0D grids
-        else
-            _lastIndex[_nDims - 1] = _dims[_nDims - 1];
+	if (_nDims < 1)
+		_lastIndex[0] = 1;    // edge case for 0D grids
+	else
+		_lastIndex[_nDims - 1] = _dims[_nDims - 1];
 
+    if (!begin) {
         _index = _lastIndex;
     }
 }

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -289,14 +289,12 @@ Grid::ConstNodeIteratorSG::ConstNodeIteratorSG(const Grid *g, bool begin) : Cons
     _index = {0, 0, 0};
     _lastIndex = {0, 0, 0};
 
-	if (_nDims < 1)
-		_lastIndex[0] = 1;    // edge case for 0D grids
-	else
-		_lastIndex[_nDims - 1] = _dims[_nDims - 1];
+    if (_nDims < 1)
+        _lastIndex[0] = 1;    // edge case for 0D grids
+    else
+        _lastIndex[_nDims - 1] = _dims[_nDims - 1];
 
-    if (!begin) {
-        _index = _lastIndex;
-    }
+    if (!begin) { _index = _lastIndex; }
 }
 
 Grid::ConstNodeIteratorSG::ConstNodeIteratorSG(const ConstNodeIteratorSG &rhs) : ConstNodeIteratorAbstract()
@@ -387,14 +385,12 @@ Grid::ConstCellIteratorSG::ConstCellIteratorSG(const Grid *g, bool begin) : Cons
     _index = {0, 0, 0};
     _lastIndex = _index;
 
-	if (_nDims < 1)
-		_lastIndex[0] = 1;    // edge case for 0D grids
-	else
-		_lastIndex[_nDims - 1] = _dims[_nDims - 1];
+    if (_nDims < 1)
+        _lastIndex[0] = 1;    // edge case for 0D grids
+    else
+        _lastIndex[_nDims - 1] = _dims[_nDims - 1];
 
-    if (!begin) {
-        _index = _lastIndex;
-    }
+    if (!begin) { _index = _lastIndex; }
 }
 
 Grid::ConstCellIteratorSG::ConstCellIteratorSG(const ConstCellIteratorSG &rhs) : ConstCellIteratorAbstract()

--- a/lib/vdc/GridHelper.cpp
+++ b/lib/vdc/GridHelper.cpp
@@ -139,8 +139,9 @@ RegularGrid *GridHelper::_make_grid_regular(const DimsType &dims, const vector<f
 
 ) const
 {
-    CoordType minu, maxu;
-    for (int i = 0; i < dims.size(); i++) {
+    CoordType minu = {0.0, 0.0, 0.0};
+    CoordType maxu = {0.0, 0.0, 0.0};
+    for (int i = 0; i < Grid::GetNumDimensions(dims); i++) {
         VAssert(dims[i] > 0);
         float *coords = blkvec[i + 1];
         minu[i] = (coords[0]);

--- a/test_apps/smokeTests/gridTools.cpp
+++ b/test_apps/smokeTests/gridTools.cpp
@@ -215,10 +215,9 @@ bool TestConstNodeIterator(const Grid *g, size_t &count, size_t &expectedCount, 
 
     if (withCoordBounds) {
         CoordType minu, maxu;
-        g->GetUserExtents (minu, maxu);
+        g->GetUserExtents(minu, maxu);
         itr = g->ConstNodeBegin(minu, maxu);
-    }
-    else {
+    } else {
         itr = g->ConstNodeBegin();
     }
 

--- a/test_apps/smokeTests/gridTools.cpp
+++ b/test_apps/smokeTests/gridTools.cpp
@@ -202,7 +202,7 @@ bool CompareIndexToCoords(VAPoR::Grid *grid,
     return rc;
 }
 
-bool TestConstNodeIterator(const Grid *g, size_t &count, size_t &expectedCount, size_t &disagreements, double &time)
+bool TestConstNodeIterator(const Grid *g, size_t &count, size_t &expectedCount, size_t &disagreements, double &time, bool withCoordBounds)
 {
     bool rc = true;
     count = 0;
@@ -213,7 +213,14 @@ bool TestConstNodeIterator(const Grid *g, size_t &count, size_t &expectedCount, 
     Grid::ConstNodeIterator itr;
     Grid::ConstNodeIterator enditr = g->ConstNodeEnd();
 
-    itr = g->ConstNodeBegin();
+    if (withCoordBounds) {
+        CoordType minu, maxu;
+        g->GetUserExtents (minu, maxu);
+        itr = g->ConstNodeBegin(minu, maxu);
+    }
+    else {
+        itr = g->ConstNodeBegin();
+    }
 
     auto dims = g->GetDimensions();
     for (auto dim : dims) expectedCount *= dim;
@@ -413,9 +420,13 @@ bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, f
 
     PrintGridIteratorResults(type, "ConstCoordIterator", count, expectedCount, disagreements, time, silenceTime);
 
-    if (TestConstNodeIterator(grid, count, expectedCount, disagreements, time) == false) { rc = false; }
+    if (TestConstNodeIterator(grid, count, expectedCount, disagreements, time, false) == false) { rc = false; }
 
     PrintGridIteratorResults(type, "ConstNodeIterator", count, expectedCount, disagreements, time, silenceTime);
+
+    if (TestConstNodeIterator(grid, count, expectedCount, disagreements, time, true) == false) { rc = false; }
+
+    PrintGridIteratorResults(type, "ConstNodeIterator with bounds", count, expectedCount, disagreements, time, silenceTime);
 
     return rc;
 }


### PR DESCRIPTION
Fixed #2985 

This was a regression that was introduced by migration from using std::vector to std::array to represent coordinates and dimensions in the Grid* classes.

Also add unit test to gridTools.cpp for

`ConstNodeIterator ConstNodeBegin(const CoordType &minu, const CoordType &maxu)`