### PR TITLE
ArbitrarilyOrientedRegularGrid: Allow for origin to be specified outside of Grid extents

### DIFF
--- a/apps/vaporgui/PSliceOriginSelector.cpp
+++ b/apps/vaporgui/PSliceOriginSelector.cpp
@@ -1,5 +1,5 @@
 #include "PSliceOriginSelector.h"
-#include "PSliderEdit.h"
+#include "PSliderEditHLI.h"
 #include "PLabel.h"
 #include <vapor/SliceParams.h>
 #include <assert.h>
@@ -8,9 +8,9 @@ using namespace VAPoR;
 
 PSliceOriginSelector::PSliceOriginSelector() : PSection("Slice Origin")
 {
-    _xSlider = new PDoubleSliderEdit(RenderParams::XSlicePlaneOriginTag, "X");
-    _ySlider = new PDoubleSliderEdit(RenderParams::YSlicePlaneOriginTag, "Y");
-    _zSlider = new PDoubleSliderEdit(RenderParams::ZSlicePlaneOriginTag, "Z");
+    _xSlider = new PDoubleSliderEditHLI<RenderParams>("X", &RenderParams::GetXSlicePlaneOrigin, &RenderParams::SetXSlicePlaneOrigin);
+    _ySlider = new PDoubleSliderEditHLI<RenderParams>("Y", &RenderParams::GetYSlicePlaneOrigin, &RenderParams::SetYSlicePlaneOrigin);
+    _zSlider = new PDoubleSliderEditHLI<RenderParams>("Z", &RenderParams::GetZSlicePlaneOrigin, &RenderParams::SetZSlicePlaneOrigin);
 
     _xSlider->EnableDynamicUpdate();
     _ySlider->EnableDynamicUpdate();

--- a/include/vapor/ArbitrarilyOrientedRegularGrid.h
+++ b/include/vapor/ArbitrarilyOrientedRegularGrid.h
@@ -71,6 +71,8 @@ private:
     glm::tvec3<double, glm::highp> _normal, _origin, _axis1, _axis2, _rotation;
     float* _myBlks;
 
+    void _makeEmptyGrid();
+
     void _populateData(
         const VAPoR::Grid *grid,
         const planeDescription& description

--- a/include/vapor/RenderParams.h
+++ b/include/vapor/RenderParams.h
@@ -393,6 +393,27 @@ public:
     //! Return whether a renderer can be oriented - IE, can this renderer be rotated about an origin point?
     virtual bool GetOrientable() const;
 
+    //! Return the renderer's origin value on the X axis for creating ArbitrarilyOrientedRegularGrids.
+    double GetXSlicePlaneOrigin() const;
+
+    //! Return the renderer's origin value on the Y axis for creating ArbitrarilyOrientedRegularGrids.
+    double GetYSlicePlaneOrigin() const;
+
+    //! Return the renderer's origin value on the Z axis for creating ArbitrarilyOrientedRegularGrids.
+    double GetZSlicePlaneOrigin() const;
+
+    //! Set the renderer's origin value on the X axis for creating ArbitrarilyOrientedRegularGrids.
+    //! \param[in] Value to use for the plane origin on the X axis.
+    void SetXSlicePlaneOrigin(double xOrigin);
+
+    //! Set the renderer's origin value on the Y axis for creating ArbitrarilyOrientedRegularGrids.
+    //! \param[in] Value to use for the plane origin on the Y axis.
+    void SetYSlicePlaneOrigin(double yOrigin);
+
+    //! Set the renderer's origin value on the Z axis for creating ArbitrarilyOrientedRegularGrids.
+    //! \param[in] Value to use for the plane origin on the Z axis.
+    void SetZSlicePlaneOrigin(double zOrigin);
+
 protected:
     DataMgr *_dataMgr;
     int      _maxDim;

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <cstring>
 #include <string>
+#include <float.h>
 #include "vapor/VAssert.h"
 #include <vapor/RenderParams.h>
 #include <vapor/DataMgr.h>
@@ -859,3 +860,37 @@ vector<string> RenParamsContainer::GetNames() const
 }
 
 bool RenderParams::GetOrientable() const { return false; }
+
+void RenderParams::SetXSlicePlaneOrigin(double xOrigin) {
+    SetValueDouble(XSlicePlaneOriginTag, "Set origin of plane on X axis", xOrigin);
+}
+
+void RenderParams::SetYSlicePlaneOrigin(double yOrigin) {
+    SetValueDouble(YSlicePlaneOriginTag, "Set origin of plane on Y axis", yOrigin);
+}
+
+void RenderParams::SetZSlicePlaneOrigin(double zOrigin) {
+    SetValueDouble(ZSlicePlaneOriginTag, "Set origin of plane on Z axis", zOrigin);
+}
+
+double RenderParams::GetXSlicePlaneOrigin() const {
+    VAPoR::CoordType min, max;
+    GetBox()->GetExtents(min,max);
+    double defaultVal = (min[0]+max[0])/2.;
+    return GetValueDouble(XSlicePlaneOriginTag, defaultVal);
+}
+
+double RenderParams::GetYSlicePlaneOrigin() const {
+    VAPoR::CoordType min, max;
+    GetBox()->GetExtents(min,max);
+    double defaultVal = (min[1]+max[1])/2.;
+    return GetValueDouble(YSlicePlaneOriginTag, defaultVal);
+}
+
+double RenderParams::GetZSlicePlaneOrigin() const {
+    VAPoR::CoordType min, max;
+    GetBox()->GetExtents(min,max);
+    double defaultVal = (min[2]+max[2])/2.;
+    return GetValueDouble(ZSlicePlaneOriginTag, defaultVal);
+}
+

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -23,7 +23,6 @@
 #include <string>
 #include <cstring>
 #include <string>
-#include <float.h>
 #include "vapor/VAssert.h"
 #include <vapor/RenderParams.h>
 #include <vapor/DataMgr.h>

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -860,36 +860,32 @@ vector<string> RenParamsContainer::GetNames() const
 
 bool RenderParams::GetOrientable() const { return false; }
 
-void RenderParams::SetXSlicePlaneOrigin(double xOrigin) {
-    SetValueDouble(XSlicePlaneOriginTag, "Set origin of plane on X axis", xOrigin);
-}
+void RenderParams::SetXSlicePlaneOrigin(double xOrigin) { SetValueDouble(XSlicePlaneOriginTag, "Set origin of plane on X axis", xOrigin); }
 
-void RenderParams::SetYSlicePlaneOrigin(double yOrigin) {
-    SetValueDouble(YSlicePlaneOriginTag, "Set origin of plane on Y axis", yOrigin);
-}
+void RenderParams::SetYSlicePlaneOrigin(double yOrigin) { SetValueDouble(YSlicePlaneOriginTag, "Set origin of plane on Y axis", yOrigin); }
 
-void RenderParams::SetZSlicePlaneOrigin(double zOrigin) {
-    SetValueDouble(ZSlicePlaneOriginTag, "Set origin of plane on Z axis", zOrigin);
-}
+void RenderParams::SetZSlicePlaneOrigin(double zOrigin) { SetValueDouble(ZSlicePlaneOriginTag, "Set origin of plane on Z axis", zOrigin); }
 
-double RenderParams::GetXSlicePlaneOrigin() const {
+double RenderParams::GetXSlicePlaneOrigin() const
+{
     VAPoR::CoordType min, max;
-    GetBox()->GetExtents(min,max);
-    double defaultVal = (min[0]+max[0])/2.;
+    GetBox()->GetExtents(min, max);
+    double defaultVal = (min[0] + max[0]) / 2.;
     return GetValueDouble(XSlicePlaneOriginTag, defaultVal);
 }
 
-double RenderParams::GetYSlicePlaneOrigin() const {
+double RenderParams::GetYSlicePlaneOrigin() const
+{
     VAPoR::CoordType min, max;
-    GetBox()->GetExtents(min,max);
-    double defaultVal = (min[1]+max[1])/2.;
+    GetBox()->GetExtents(min, max);
+    double defaultVal = (min[1] + max[1]) / 2.;
     return GetValueDouble(YSlicePlaneOriginTag, defaultVal);
 }
 
-double RenderParams::GetZSlicePlaneOrigin() const {
+double RenderParams::GetZSlicePlaneOrigin() const
+{
     VAPoR::CoordType min, max;
-    GetBox()->GetExtents(min,max);
-    double defaultVal = (min[2]+max[2])/2.;
+    GetBox()->GetExtents(min, max);
+    double defaultVal = (min[2] + max[2]) / 2.;
     return GetValueDouble(ZSlicePlaneOriginTag, defaultVal);
 }
-

--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -129,9 +129,9 @@ void SliceRenderer::_resetCache()
     _cacheParams.yRotation = p->GetValueDouble(RenderParams::YSlicePlaneRotationTag, 0);
     _cacheParams.zRotation = p->GetValueDouble(RenderParams::ZSlicePlaneRotationTag, 0);
 
-    _cacheParams.xOrigin = p->GetValueDouble(RenderParams::XSlicePlaneOriginTag, 0);
-    _cacheParams.yOrigin = p->GetValueDouble(RenderParams::YSlicePlaneOriginTag, 0);
-    _cacheParams.zOrigin = p->GetValueDouble(RenderParams::ZSlicePlaneOriginTag, 0);
+    _cacheParams.xOrigin = p->GetXSlicePlaneOrigin();
+    _cacheParams.yOrigin = p->GetYSlicePlaneOrigin();
+    _cacheParams.zOrigin = p->GetZSlicePlaneOrigin();
 
     _cacheParams.textureSampleRate = p->GetValueDouble(RenderParams::SampleRateTag, 200);
 
@@ -302,9 +302,9 @@ bool SliceRenderer::_isDataCacheDirty() const
     if (_cacheParams.yRotation != p->GetValueDouble(RenderParams::YSlicePlaneRotationTag, 0)) return true;
     if (_cacheParams.zRotation != p->GetValueDouble(RenderParams::ZSlicePlaneRotationTag, 0)) return true;
 
-    if (_cacheParams.xOrigin != p->GetValueDouble(RenderParams::XSlicePlaneOriginTag, 0)) return true;
-    if (_cacheParams.yOrigin != p->GetValueDouble(RenderParams::YSlicePlaneOriginTag, 0)) return true;
-    if (_cacheParams.zOrigin != p->GetValueDouble(RenderParams::ZSlicePlaneOriginTag, 0)) return true;
+    if (_cacheParams.xOrigin != p->GetXSlicePlaneOrigin()) return true;
+    if (_cacheParams.yOrigin != p->GetYSlicePlaneOrigin()) return true;
+    if (_cacheParams.zOrigin != p->GetZSlicePlaneOrigin()) return true;
 
     if (_cacheParams.textureSampleRate != p->GetValueDouble(RenderParams::SampleRateTag, 200)) return true;
 


### PR DESCRIPTION
This allows us to specify origins outside of a given Grid for creating slices.

This also adds Setters and Getters to the origin values in RenderParams.  These are needed to provide default values to the origin to support pre-3.6 session files.