### PR TITLE
Merge contour3d with main

### DIFF
--- a/apps/vaporgui/ContourEventRouter.cpp
+++ b/apps/vaporgui/ContourEventRouter.cpp
@@ -42,7 +42,6 @@ ContourEventRouter::ContourEventRouter(QWidget *parent, ControlExec *ce) : Rende
     }));
     
     AddGeometrySubtab(new PGroup({
-        new PGeometrySubtab,
         (new PShowIf(""))->DimensionEquals(3)->Then(new PGroup({
             (new PSection("Slice Orientation", {
                 new PEnumDropdown(RenderParams::SlicePlaneOrientationModeTag, {"Rotation", "Normal"}, {(int)RenderParams::SlicePlaneOrientationMode::Rotation, (int)RenderParams::SlicePlaneOrientationMode::Normal}, "Orientation Mode"),
@@ -59,6 +58,7 @@ ContourEventRouter::ContourEventRouter(QWidget *parent, ControlExec *ce) : Rende
             }))->SetTooltip("The plane normal of the slice. The offset will move the slice along this normal as well."),
             (new PSliceOriginSelector)->SetTooltip("The slice plane will pass through this point. The plane can be offset from this point along the plane normal determined by the orientation."),
             (new PSliceOffsetSelector)->SetTooltip("Offset the plane from its origin along its normal (set by the orientation)."),
+        new PGeometrySubtab,
         })),
     }));
     

--- a/apps/vaporgui/PSliceOriginSelector.cpp
+++ b/apps/vaporgui/PSliceOriginSelector.cpp
@@ -1,5 +1,5 @@
 #include "PSliceOriginSelector.h"
-#include "PSliderEdit.h"
+#include "PSliderEditHLI.h"
 #include "PLabel.h"
 #include <vapor/SliceParams.h>
 #include <assert.h>
@@ -8,9 +8,9 @@ using namespace VAPoR;
 
 PSliceOriginSelector::PSliceOriginSelector() : PSection("Slice Origin")
 {
-    _xSlider = new PDoubleSliderEdit(RenderParams::XSlicePlaneOriginTag, "X");
-    _ySlider = new PDoubleSliderEdit(RenderParams::YSlicePlaneOriginTag, "Y");
-    _zSlider = new PDoubleSliderEdit(RenderParams::ZSlicePlaneOriginTag, "Z");
+    _xSlider = new PDoubleSliderEditHLI<RenderParams>("X", &RenderParams::GetXSlicePlaneOrigin, &RenderParams::SetXSlicePlaneOrigin);
+    _ySlider = new PDoubleSliderEditHLI<RenderParams>("Y", &RenderParams::GetYSlicePlaneOrigin, &RenderParams::SetYSlicePlaneOrigin);
+    _zSlider = new PDoubleSliderEditHLI<RenderParams>("Z", &RenderParams::GetZSlicePlaneOrigin, &RenderParams::SetZSlicePlaneOrigin);
 
     _xSlider->EnableDynamicUpdate();
     _ySlider->EnableDynamicUpdate();

--- a/include/vapor/ArbitrarilyOrientedRegularGrid.h
+++ b/include/vapor/ArbitrarilyOrientedRegularGrid.h
@@ -74,6 +74,8 @@ private:
     glm::tvec3<double, glm::highp> _normal, _origin, _axis1, _axis2;
     float* _myBlks;
 
+    void _makeEmptyGrid();
+
     void _populateData(
         const VAPoR::Grid *grid,
         const planeDescription& description

--- a/include/vapor/DataMgr.h
+++ b/include/vapor/DataMgr.h
@@ -484,6 +484,10 @@ public:
     //!
     size_t GetVarTopologyDim(string varname) const;
 
+    //! \copydoc DC:GetVarGeometryDim()
+    //!
+    size_t GetVarGeometryDim(string varname) const;
+
     //! Clear the memory cache
     //!
     //! This method clears the internal memory cache of all entries
@@ -584,7 +588,7 @@ public:
 
         void Insert(const DimsType &bcoord, const CoordType &min, const CoordType &max);
 
-        bool Intersect(const CoordType &min, const CoordType &max, DimsType &bmin, DimsType &bmax) const;
+        bool Intersect(const CoordType &min, const CoordType &max, DimsType &bmin, DimsType &bmax, int nCoords = 3) const;
 
         friend std::ostream &operator<<(std::ostream &o, const BlkExts &b);
 

--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -101,10 +101,10 @@ public:
 
     //! Return the useful number of dimensions of grid connectivity array
     //!
-    //! \param[out] dims The number of values of \p dims parameter provided to
+    //! \param[out] dims The number of non-unit components of \p dims parameter provided to
     //! the constructor.
     //!
-    size_t GetNumDimensions() const { return _nDims; }
+    size_t GetNumDimensions() const { return GetNumDimensions(_dims); }
 
     //! Return the number of non-unit dimensions
     //!
@@ -139,10 +139,10 @@ public:
     //
     virtual size_t GetGeometryDim() const = 0;
 
-    virtual const DimsType &           GetNodeDimensions() const = 0;
-    virtual const size_t               GetNumNodeDimensions() const = 0;
-    virtual const DimsType &           GetCellDimensions() const = 0;
-    virtual const size_t               GetNumCellDimensions() const = 0;
+    virtual const DimsType &GetNodeDimensions() const = 0;
+    virtual const size_t    GetNumNodeDimensions() const = 0;
+    virtual const DimsType &GetCellDimensions() const = 0;
+    virtual const size_t    GetNumCellDimensions() const = 0;
 
     //! Return the ijk dimensions of grid in blocks
     //!
@@ -982,7 +982,6 @@ public:
 
     protected:
         DimsType _dims;
-        size_t   _nDims;
         DimsType _index;
         DimsType _lastIndex;
     };
@@ -1057,7 +1056,6 @@ public:
 
     protected:
         DimsType _dims;
-        size_t   _nDims;
         DimsType _index;
         DimsType _lastIndex;
     };
@@ -1146,14 +1144,13 @@ public:
         ForwardIterator<T> &operator=(ForwardIterator<T> rhs);
         ForwardIterator<T> &operator=(ForwardIterator<T> &rhs) = delete;
 
-        bool operator==(const ForwardIterator<T> &rhs) const { return (_indexL == rhs._indexL); }
-        bool operator!=(const ForwardIterator<T> &rhs) { return (_indexL != rhs._indexL); }
+        bool operator==(const ForwardIterator<T> &rhs) const { return (_index == rhs._index); }
+        bool operator!=(const ForwardIterator<T> &rhs) { return (_index != rhs._index); }
 
         const ConstCoordItr &GetCoordItr() { return (_coordItr); }
 
         friend void swap(Grid::ForwardIterator<T> &a, Grid::ForwardIterator<T> &b)
         {
-            std::swap(a._ndims, b._ndims);
             std::swap(a._blks, b._blks);
             std::swap(a._dims3d, b._dims3d);
             std::swap(a._bdims3d, b._bdims3d);
@@ -1161,25 +1158,22 @@ public:
             std::swap(a._blocksize, b._blocksize);
             std::swap(a._coordItr, b._coordItr);
             std::swap(a._index, b._index);
-            std::swap(a._indexL, b._indexL);
-            std::swap(a._end_indexL, b._end_indexL);
+            std::swap(a._lastIndex, b._lastIndex);
             std::swap(a._xb, b._xb);
             std::swap(a._itr, b._itr);
             std::swap(a._pred, b._pred);
         }
 
     private:
-        size_t               _ndims;
         std::vector<float *> _blks;
         DimsType             _dims3d;
         DimsType             _bdims3d;
         DimsType             _bs3d;
         size_t               _blocksize;
         ConstCoordItr        _coordItr;
-        DimsType             _index;         // current index into grid
-        size_t               _indexL;        // current index into grid
-        size_t               _end_indexL;    // Last valid index
-        size_t               _xb;            // x index within a block
+        DimsType             _index;        // current index into grid
+        DimsType             _lastIndex;    // Last valid index
+        size_t               _xb;           // x index within a block
         float *              _itr;
         InsideBox            _pred;
     };
@@ -1270,8 +1264,7 @@ protected:
     }
 
 private:
-    DimsType             _dims;    // dimensions of grid arrays
-    size_t               _nDims;
+    DimsType             _dims;                   // dimensions of grid arrays
     DimsType             _bs = {{1, 1, 1}};       // dimensions of each block
     DimsType             _bdims = {{1, 1, 1}};    // dimensions (specified in blocks) of ROI
     std::vector<size_t>  _bsDeprecated;           // legacy API
@@ -1289,8 +1282,6 @@ private:
     mutable CoordType    _maxuCache = {{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()}};
 
     void _grid(const DimsType &dims, const DimsType &bs, const std::vector<float *> &blks, size_t topology_dimension);
-
-    virtual void _getUserCoordinatesHelper(const std::vector<double> &coords, double &x, double &y, double &z) const;
 };
 
 template void Grid::CopyToArr3<size_t>(const std::vector<size_t> &src, std::array<size_t, 3> &dst);

--- a/include/vapor/RegularGrid.h
+++ b/include/vapor/RegularGrid.h
@@ -99,7 +99,6 @@ public:
     private:
         DimsType  _index;
         DimsType  _dims;
-        size_t    _nDims;
         CoordType _minu;
         CoordType _delta;
         CoordType _coords;
@@ -122,10 +121,10 @@ protected:
 private:
     void _regularGrid(const CoordType &minu, const CoordType &maxu);
 
-    CoordType           _minu = {{0.0, 0.0, 0.0}};
-    CoordType           _maxu = {{0.0, 0.0, 0.0}};
-    size_t              _geometryDim;
-    CoordType           _delta;    // increment between grid points in user coords
+    CoordType _minu = {{0.0, 0.0, 0.0}};
+    CoordType _maxu = {{0.0, 0.0, 0.0}};
+    size_t    _geometryDim;
+    CoordType _delta;    // increment between grid points in user coords
 };
 };    // namespace VAPoR
 #endif

--- a/include/vapor/RenderParams.h
+++ b/include/vapor/RenderParams.h
@@ -393,9 +393,36 @@ public:
     //! Return whether a renderer can be oriented - IE, can this renderer be rotated about an origin point?
     virtual bool GetOrientable() const;
 
+    //! Return the renderer's 3 axis rotation for creating ArbitrarilyOrientedRegularGrids.
     vector<double> GetSlicePlaneRotation() const;
+
+    //! Return the renderer's 3 axis origin for creating ArbitrarilyOrientedRegularGrids.
     vector<double> GetSlicePlaneOrigin() const;
+
+    //! Return the renderer's 3 axis normal for creating ArbitrarilyOrientedRegularGrids.
     vector<double> GetSlicePlaneNormal() const;
+
+    //! Return the renderer's origin value on the X axis for creating ArbitrarilyOrientedRegularGrids.
+    double GetXSlicePlaneOrigin() const;
+
+    //! Return the renderer's origin value on the Y axis for creating ArbitrarilyOrientedRegularGrids.
+    double GetYSlicePlaneOrigin() const;
+
+    //! Return the renderer's origin value on the Z axis for creating ArbitrarilyOrientedRegularGrids.
+    double GetZSlicePlaneOrigin() const;
+
+    //! Set the renderer's origin value on the X axis for creating ArbitrarilyOrientedRegularGrids.
+    //! \param[in] Value to use for the plane origin on the X axis.
+    void SetXSlicePlaneOrigin(double xOrigin);
+
+    //! Set the renderer's origin value on the Y axis for creating ArbitrarilyOrientedRegularGrids.
+    //! \param[in] Value to use for the plane origin on the Y axis.
+    void SetYSlicePlaneOrigin(double yOrigin);
+
+    //! Set the renderer's origin value on the Z axis for creating ArbitrarilyOrientedRegularGrids.
+    //! \param[in] Value to use for the plane origin on the Z axis.
+    void SetZSlicePlaneOrigin(double zOrigin);
+
 
 protected:
     DataMgr *_dataMgr;

--- a/lib/flow/Advection.cpp
+++ b/lib/flow/Advection.cpp
@@ -602,8 +602,11 @@ void Advection::RemoveParticleProperty(const std::string &varToRemove)
 
 void Advection::ResetParticleValues()
 {
-    for (auto &stream : _streams)
-        for (auto &part : stream) part.value = 0.0f;
+    for (auto &stream : _streams) {
+        std::for_each(stream.begin(), stream.end(), [](Particle &p) {
+            if (!p.IsSpecial()) p.value = 0.0f;
+        });
+    }
 }
 
 void Advection::SetXPeriodicity(bool isPeri, float min, float max)

--- a/lib/flow/Particle.cpp
+++ b/lib/flow/Particle.cpp
@@ -56,6 +56,9 @@ void Particle::SetSpecial(bool isSpecial)
         time = 0.0f;
         value = 0.0f;
     }
+    location.x = 0.0f;
+    location.y = 0.0f;
+    location.z = 0.0f;
 }
 
 bool Particle::IsSpecial() const { return (std::isnan(time) && std::isnan(value)); }

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -907,3 +907,33 @@ vector<double> RenderParams::GetSlicePlaneNormal() const
 
     return v;
 }
+
+void RenderParams::SetXSlicePlaneOrigin(double xOrigin) { SetValueDouble(XSlicePlaneOriginTag, "Set origin of plane on X axis", xOrigin); }
+
+void RenderParams::SetYSlicePlaneOrigin(double yOrigin) { SetValueDouble(YSlicePlaneOriginTag, "Set origin of plane on Y axis", yOrigin); }
+
+void RenderParams::SetZSlicePlaneOrigin(double zOrigin) { SetValueDouble(ZSlicePlaneOriginTag, "Set origin of plane on Z axis", zOrigin); }
+
+double RenderParams::GetXSlicePlaneOrigin() const
+{
+    VAPoR::CoordType min, max;
+    GetBox()->GetExtents(min, max);
+    double defaultVal = (min[0] + max[0]) / 2.;
+    return GetValueDouble(XSlicePlaneOriginTag, defaultVal);
+}
+
+double RenderParams::GetYSlicePlaneOrigin() const
+{
+    VAPoR::CoordType min, max;
+    GetBox()->GetExtents(min, max);
+    double defaultVal = (min[1] + max[1]) / 2.;
+    return GetValueDouble(YSlicePlaneOriginTag, defaultVal);
+}
+
+double RenderParams::GetZSlicePlaneOrigin() const
+{
+    VAPoR::CoordType min, max;
+    GetBox()->GetExtents(min, max);
+    double defaultVal = (min[2] + max[2]) / 2.;
+    return GetValueDouble(ZSlicePlaneOriginTag, defaultVal);
+}

--- a/lib/render/FlowRenderer.cpp
+++ b/lib/render/FlowRenderer.cpp
@@ -310,7 +310,7 @@ int FlowRenderer::_paintGL(bool fast)
             vector<double> integrationVolumeMin, integrationVolumeMax;
             params->GetIntegrationBox()->GetExtents(integrationVolumeMin, integrationVolumeMax);
             float distScale = params->GetValueDouble(params->_integrationScalarTag, 1.f);
-            _advection.CalculateParticleIntegratedValues(&_colorField, true, distScale, integrationVolumeMin, integrationVolumeMax);
+            rv = _advection.CalculateParticleIntegratedValues(&_colorField, true, distScale, integrationVolumeMin, integrationVolumeMax);
             _printNonZero(rv, __FILE__, __func__, __LINE__);
             if (_2ndAdvection)    // bi-directional advection
                 rv = _2ndAdvection->CalculateParticleIntegratedValues(&_colorField, true, distScale, integrationVolumeMin, integrationVolumeMax);

--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -129,9 +129,9 @@ void SliceRenderer::_resetCache()
     _cacheParams.yRotation = p->GetValueDouble(RenderParams::YSlicePlaneRotationTag, 0);
     _cacheParams.zRotation = p->GetValueDouble(RenderParams::ZSlicePlaneRotationTag, 0);
 
-    _cacheParams.xOrigin = p->GetValueDouble(RenderParams::XSlicePlaneOriginTag, 0);
-    _cacheParams.yOrigin = p->GetValueDouble(RenderParams::YSlicePlaneOriginTag, 0);
-    _cacheParams.zOrigin = p->GetValueDouble(RenderParams::ZSlicePlaneOriginTag, 0);
+    _cacheParams.xOrigin = p->GetXSlicePlaneOrigin();
+    _cacheParams.yOrigin = p->GetYSlicePlaneOrigin();
+    _cacheParams.zOrigin = p->GetZSlicePlaneOrigin();
 
     _cacheParams.textureSampleRate = p->GetValueDouble(RenderParams::SampleRateTag, 200);
 
@@ -303,9 +303,9 @@ bool SliceRenderer::_isDataCacheDirty() const
     if (_cacheParams.yRotation != p->GetValueDouble(RenderParams::YSlicePlaneRotationTag, 0)) return true;
     if (_cacheParams.zRotation != p->GetValueDouble(RenderParams::ZSlicePlaneRotationTag, 0)) return true;
 
-    if (_cacheParams.xOrigin != p->GetValueDouble(RenderParams::XSlicePlaneOriginTag, 0)) return true;
-    if (_cacheParams.yOrigin != p->GetValueDouble(RenderParams::YSlicePlaneOriginTag, 0)) return true;
-    if (_cacheParams.zOrigin != p->GetValueDouble(RenderParams::ZSlicePlaneOriginTag, 0)) return true;
+    if (_cacheParams.xOrigin != p->GetXSlicePlaneOrigin()) return true;
+    if (_cacheParams.yOrigin != p->GetYSlicePlaneOrigin()) return true;
+    if (_cacheParams.zOrigin != p->GetZSlicePlaneOrigin()) return true;
 
     if (_cacheParams.textureSampleRate != p->GetValueDouble(RenderParams::SampleRateTag, 200)) return true;
 

--- a/lib/vdc/ArbitrarilyOrientedRegularGrid.cpp
+++ b/lib/vdc/ArbitrarilyOrientedRegularGrid.cpp
@@ -37,16 +37,7 @@ ArbitrarilyOrientedRegularGrid::ArbitrarilyOrientedRegularGrid(
     CoordType gridMin, gridMax;
     grid3d->GetUserExtents(gridMin, gridMax);
 
-    // .vs3 files before Vapor3.6 will try to initialize Slices with origin values set to 0, which
-    // can sometimes lie outside of the domain.  If this happens, we need to configure a new origin
-    // within the 3D grid's bounds.
-    for (int i=0; i<3; i++) {
-        _origin[i] = (pd.origin[i] <= gridMin[i] && pd.origin[i] >= gridMax[i]) ? pd.origin[i] : (gridMax[i]-gridMin[i])/2 + gridMin[i];
-        if (pd.origin[i] <= gridMax[i] && pd.origin[i] >= gridMin[i]) 
-            _origin[i] = pd.origin[i];
-        else 
-            _origin[i] = (gridMax[i]-gridMin[i])/2 + gridMin[i];
-    }
+    _origin = {pd.origin[0], pd.origin[1], pd.origin[2]};
 
     // Rotate the plane via quaternion method
     _rotate();
@@ -54,6 +45,12 @@ ArbitrarilyOrientedRegularGrid::ArbitrarilyOrientedRegularGrid(
     // Find the vertices where our plane intercepts the edges of the Box
     std::vector<glm::tvec3<double, glm::highp>> vertices;
     _findIntercepts(gridMin, gridMax, vertices);
+
+    // If there are no vertices to define our quad, make a grid of empty values
+    if (!vertices.size()) {
+        _makeEmptyGrid();
+        return;
+    }
 
     // Find the minimum-area-rectangle that encloses the vertices that are along the edges
     // of the Box.  Define this rectangle in 3D space, and in a newly projecteed 2D space.
@@ -68,6 +65,20 @@ ArbitrarilyOrientedRegularGrid::ArbitrarilyOrientedRegularGrid(
 ArbitrarilyOrientedRegularGrid::~ArbitrarilyOrientedRegularGrid() {
     if (_myBlks != nullptr)
         delete [] _myBlks;
+}
+
+void ArbitrarilyOrientedRegularGrid::_makeEmptyGrid() {
+    _rectangle2D.clear();
+    _rectangle2D.resize(4);
+    _rectangle2D[0] = glm::vec2(0., 0.);
+    _rectangle2D[1] = glm::vec2(0., 0.);
+    _rectangle2D[2] = glm::vec2(0., 0.);
+    _rectangle2D[3] = glm::vec2(0., 0.);
+
+    size_t numSamples = _sideSize*_sideSize;
+    for (size_t i = 0; i < numSamples; i++) {
+        _myBlks[i] = GetMissingValue();
+    }
 }
 
 // Huges-Moller algorithm to get an orthogonal vector

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -46,7 +46,6 @@ CurvilinearGrid::CurvilinearGrid(const DimsType &dims, const DimsType &bs, const
                                  std::shared_ptr<const QuadTreeRectangleP> qtr)
 : StructuredGrid(dims, bs, blks)
 {
-
     // Only support 2D X & Y coordinates currently. I.e. only support
     // "layered" curvilinear grids
     //
@@ -275,7 +274,6 @@ CurvilinearGrid::ConstCoordItrCG::ConstCoordItrCG(const CurvilinearGrid *cg, boo
 {
     _cg = cg;
     auto dims = _cg->GetDimensions();
-    auto ndims = _cg->GetNumDimensions();
     _index = {0, 0, 0};
     _coords = {0.0, 0.0, 0.0};
     _terrainFollowing = _cg->_terrainFollowing;
@@ -288,22 +286,17 @@ CurvilinearGrid::ConstCoordItrCG::ConstCoordItrCG(const CurvilinearGrid *cg, boo
         _yCoordItr = _cg->_yrg.cend();
         if (_terrainFollowing) { _zCoordItr = _cg->_zrg.cend(); }
 
-        if (ndims < 1)
-            _index[0] = 1;    // edge case for 0D grids
-        else
-            _index[ndims - 1] = dims[ndims - 1];
+        _index = {0, 0, dims[dims.size() - 1]};
 
         return;
     }
     _coords[0] = *_xCoordItr;
     _coords[1] = *_yCoordItr;
 
-    if (ndims == 3) {
-        if (_terrainFollowing) {
-            _coords[2] = *_zCoordItr;
-        } else {
-            _coords[2] = _cg->_zcoords[0];
-        }
+    if (_terrainFollowing) {
+        _coords[2] = *_zCoordItr;
+    } else {
+        if (_cg->_zcoords.size()) _coords[2] = _cg->_zcoords[0];
     }
 }
 
@@ -341,8 +334,6 @@ void CurvilinearGrid::ConstCoordItrCG::next()
         return;
     }
 
-    if (_cg->GetNumDimensions() <= 1) return;
-
     _index[0] = 0;
     _index[1]++;
 
@@ -352,8 +343,6 @@ void CurvilinearGrid::ConstCoordItrCG::next()
         if (_terrainFollowing) { _coords[2] = *_zCoordItr; }
         return;
     }
-
-    if (_cg->GetNumDimensions() == 2) return;
 
     _index[1] = 0;
     _index[2]++;
@@ -370,36 +359,29 @@ void CurvilinearGrid::ConstCoordItrCG::next()
         }
         return;
     }
+
+    _index = {0, 0, dims[dims.size() - 1]};    // last index
 }
 
 void CurvilinearGrid::ConstCoordItrCG::next(const long &offset)
 {
-
     auto dims = _cg->GetDimensions();
     auto ndims = _cg->GetNumDimensions();
 
     if (!ndims) return;
 
-    DimsType maxIndex = {0, 0, 0};
-
-    for (int i = 0; i < ndims; i++) {
-        VAssert(dims[i] > 0);
-        maxIndex[i] = dims[i] - 1;
-    }
-
-    long maxIndexL = Wasp::LinearizeCoords(maxIndex.data(), dims.data(), ndims);
-    long newIndexL = Wasp::LinearizeCoords(_index.data(), dims.data(), ndims) + offset;
+    long maxIndexL = Wasp::VProduct(dims.data(), dims.size()) - 1;
+    long newIndexL = Wasp::LinearizeCoords(_index.data(), dims.data(), dims.size()) + offset;
     if (newIndexL < 0) { newIndexL = 0; }
     if (newIndexL > maxIndexL) {
-        _index = {0, 0, 0};
-        _index[ndims - 1] = dims[ndims - 1];
+        _index = {0, 0, dims[dims.size() - 1]};
         return;
     }
 
     size_t index2DL = _index[1] * dims[0] + _index[0];
 
     _index = {0, 0, 0};
-    Wasp::VectorizeCoords(newIndexL, dims.data(), _index.data(), ndims);
+    Wasp::VectorizeCoords(newIndexL, dims.data(), _index.data(), dims.size());
 
     VAssert(_index[1] * dims[0] + _index[0] >= index2DL);
     size_t offset2D = (_index[1] * dims[0] + _index[0]) - index2DL;
@@ -409,8 +391,6 @@ void CurvilinearGrid::ConstCoordItrCG::next(const long &offset)
 
     _coords[0] = *_xCoordItr;
     _coords[1] = *_yCoordItr;
-
-    if (ndims == 2) return;
 
     if (_terrainFollowing) {
         _zCoordItr += offset;
@@ -735,8 +715,8 @@ bool CurvilinearGrid::_insideGrid(double x, double y, double z, size_t &i, size_
 
 std::shared_ptr<QuadTreeRectangleP> CurvilinearGrid::_makeQuadTreeRectangle() const
 {
-    const DimsType &      dims = GetCellDimensions();
-    size_t                reserve_size = dims[0] * dims[1];
+    const DimsType &dims = GetCellDimensions();
+    size_t          reserve_size = dims[0] * dims[1];
 
     CoordType minu, maxu;
     GetUserExtents(minu, maxu);

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -1743,6 +1743,23 @@ size_t DataMgr::GetVarTopologyDim(string varname) const
     return (mesh.GetTopologyDim());
 }
 
+size_t DataMgr::GetVarGeometryDim(string varname) const
+{
+    VAssert(_dc);
+
+    DC::DataVar var;
+    bool        status = GetDataVarInfo(varname, var);
+    if (!status) return (0);
+
+    string mname = var.GetMeshName();
+
+    DC::Mesh mesh;
+    status = GetMesh(mname, mesh);
+    if (!status) return (0);
+
+    return (mesh.GetGeometryDim());
+}
+
 template<typename T> T *DataMgr::_get_region_from_cache(size_t ts, string varname, int level, int lod, const DimsType &bmin, const DimsType &bmax, bool lock)
 {
     list<region_t>::iterator itr;
@@ -2350,7 +2367,7 @@ void DataMgr::BlkExts::Insert(const DimsType &bcoord, const CoordType &min, cons
     _maxs[offset] = max;
 }
 
-bool DataMgr::BlkExts::Intersect(const CoordType &min, const CoordType &max, DimsType &bmin, DimsType &bmax) const
+bool DataMgr::BlkExts::Intersect(const CoordType &min, const CoordType &max, DimsType &bmin, DimsType &bmax, int nCoords) const
 {
     bmin = _bmax;
     bmax = _bmin;
@@ -2362,7 +2379,7 @@ bool DataMgr::BlkExts::Intersect(const CoordType &min, const CoordType &max, Dim
     //
     for (size_t offset = 0; offset < _mins.size(); offset++) {
         bool overlap = true;
-        for (int j = 0; j < min.size(); j++) {
+        for (int j = 0; j < nCoords; j++) {
             if (_maxs[offset][j] < min[j] || _mins[offset][j] > max[j]) {
                 overlap = false;
                 break;
@@ -2379,7 +2396,7 @@ bool DataMgr::BlkExts::Intersect(const CoordType &min, const CoordType &max, Dim
             DimsType coord;
             Wasp::VectorizeCoords(offset, _bmin.data(), _bmax.data(), coord.data(), coord.size());
 
-            for (int i = 0; i < coord.size(); i++) {
+            for (int i = 0; i < nCoords; i++) {
                 if (coord[i] < bmin[i]) bmin[i] = coord[i];
                 if (coord[i] > bmax[i]) bmax[i] = coord[i];
             }
@@ -2762,10 +2779,12 @@ int DataMgr::_find_bounding_grid(size_t ts, string varname, int level, int lod, 
 
     const BlkExts &blkexts = itr->second;
 
+
+
     // Find block coordinates of region that contains the bounding volume
     //
     DimsType bmin, bmax;
-    ok = blkexts.Intersect(min, max, bmin, bmax);
+    ok = blkexts.Intersect(min, max, bmin, bmax, GetVarGeometryDim(varname));
     if (!ok) { return (1); }
 
     // Finally, map from block to voxel coordinates

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -21,11 +21,7 @@
 using namespace std;
 using namespace VAPoR;
 
-Grid::Grid()
-{
-    _dims = {1, 1, 1};
-    _nDims = 0;
-}
+Grid::Grid() { _dims = {1, 1, 1}; }
 
 void Grid::_grid(const DimsType &dims, const DimsType &bs, const std::vector<float *> &blks, size_t topology_dimension)
 {
@@ -42,7 +38,6 @@ void Grid::_grid(const DimsType &dims, const DimsType &bs, const std::vector<flo
             blks.size() == std::accumulate(_bdims.begin(), _bdims.end(), 1, std::multiplies<size_t>()));
 
     _dims = dims;
-    _nDims = GetNumDimensions(dims);
     _periodic = vector<bool>(topology_dimension, false);
     _topologyDimension = topology_dimension;
     _missingValue = INFINITY;
@@ -179,23 +174,9 @@ void Grid::GetRange(const DimsType &min, const DimsType &max, float range[2]) co
 
     range[0] = range[1] = mv;
 
-    size_t jmin = 0;
-    size_t jmax = 0;
-    if (GetNumDimensions() > 1) {
-        jmin = cMin[1];
-        jmax = cMax[1];
-    }
-
-    size_t kmin = 0;
-    size_t kmax = 0;
-    if (GetNumDimensions() > 2) {
-        kmin = cMin[2];
-        kmax = cMax[2];
-    }
-
     bool first = true;
-    for (size_t k = kmin; k <= kmax; k++) {
-        for (size_t j = jmin; j <= jmax; j++) {
+    for (size_t k = cMin[2]; k <= cMax[2]; k++) {
+        for (size_t j = cMin[1]; j <= cMax[1]; j++) {
             for (size_t i = cMin[0]; i <= cMax[0]; i++) {
                 float v = AccessIJK(i, j, k);
                 if (first && v != mv) {
@@ -236,12 +217,6 @@ float Grid::GetValue(const CoordType &coords) const
     }
 }
 
-void Grid::_getUserCoordinatesHelper(const vector<double> &coords, double &x, double &y, double &z) const
-{
-    if (GetNumDimensions() >= 1) { x = coords[0]; }
-    if (GetNumDimensions() >= 2) { y = coords[1]; }
-    if (GetNumDimensions() >= 3) { z = coords[2]; }
-}
 
 void Grid::GetUserCoordinates(size_t i, double &x, double &y, double &z) const
 {
@@ -249,7 +224,9 @@ void Grid::GetUserCoordinates(size_t i, double &x, double &y, double &z) const
     vector<size_t> indices = {i};
     vector<double> coords;
     GetUserCoordinates(indices, coords);
-    _getUserCoordinatesHelper(coords, x, y, z);
+    x = coords[0];
+    y = coords[1];
+    z = coords[2];
 }
 
 void Grid::GetUserCoordinates(size_t i, size_t j, double &x, double &y, double &z) const
@@ -258,7 +235,9 @@ void Grid::GetUserCoordinates(size_t i, size_t j, double &x, double &y, double &
     vector<size_t> indices = {i, j};
     vector<double> coords;
     GetUserCoordinates(indices, coords);
-    _getUserCoordinatesHelper(coords, x, y, z);
+    x = coords[0];
+    y = coords[1];
+    z = coords[2];
 }
 
 void Grid::GetUserCoordinates(size_t i, size_t j, size_t k, double &x, double &y, double &z) const
@@ -267,7 +246,9 @@ void Grid::GetUserCoordinates(size_t i, size_t j, size_t k, double &x, double &y
     vector<size_t> indices = {i, j, k};
     vector<double> coords;
     GetUserCoordinates(indices, coords);
-    _getUserCoordinatesHelper(coords, x, y, z);
+    x = coords[0];
+    y = coords[1];
+    z = coords[2];
 }
 
 void Grid::SetInterpolationOrder(int order)
@@ -285,14 +266,8 @@ void Grid::SetInterpolationOrder(int order)
 Grid::ConstNodeIteratorSG::ConstNodeIteratorSG(const Grid *g, bool begin) : ConstNodeIteratorAbstract()
 {
     _dims = g->GetNodeDimensions();
-    _nDims = g->GetNumNodeDimensions();
     _index = {0, 0, 0};
-    _lastIndex = {0, 0, 0};
-
-    if (_nDims < 1)
-        _lastIndex[0] = 1;    // edge case for 0D grids
-    else
-        _lastIndex[_nDims - 1] = _dims[_nDims - 1];
+    _lastIndex = {0, 0, _dims[_dims.size() - 1]};
 
     if (!begin) { _index = _lastIndex; }
 }
@@ -300,7 +275,6 @@ Grid::ConstNodeIteratorSG::ConstNodeIteratorSG(const Grid *g, bool begin) : Cons
 Grid::ConstNodeIteratorSG::ConstNodeIteratorSG(const ConstNodeIteratorSG &rhs) : ConstNodeIteratorAbstract()
 {
     _dims = rhs._dims;
-    _nDims = rhs._nDims;
     _index = rhs._index;
     _lastIndex = rhs._lastIndex;
 }
@@ -308,7 +282,6 @@ Grid::ConstNodeIteratorSG::ConstNodeIteratorSG(const ConstNodeIteratorSG &rhs) :
 Grid::ConstNodeIteratorSG::ConstNodeIteratorSG() : ConstNodeIteratorAbstract()
 {
     _dims = {1, 1, 1};
-    _nDims = 0;
     _index = {0, 0, 0};
     _lastIndex = {0, 0, 0};
 }
@@ -316,16 +289,17 @@ Grid::ConstNodeIteratorSG::ConstNodeIteratorSG() : ConstNodeIteratorAbstract()
 void Grid::ConstNodeIteratorSG::next()
 {
     _index[0]++;
-    if (_index[0] < _dims[0] || _nDims <= 1) { return; }
+    if (_index[0] < _dims[0]) { return; }
 
     _index[0] = 0;
     _index[1]++;
-    if (_index[1] < _dims[1] || _nDims == 2) { return; }
+    if (_index[1] < _dims[1]) { return; }
 
     _index[1] = 0;
     _index[2]++;
-    if (_index[2] < _dims[2] || _nDims == 3) { return; }
-    VAssert(0 && "Invalid state");
+    if (_index[2] < _dims[2]) { return; }
+
+    _index[2] = _dims[2];    // last index;
 }
 
 void Grid::ConstNodeIteratorSG::next(const long &offset)
@@ -381,14 +355,8 @@ void Grid::ConstNodeIteratorBoxSG::next(const long &offset)
 Grid::ConstCellIteratorSG::ConstCellIteratorSG(const Grid *g, bool begin) : ConstCellIteratorAbstract()
 {
     _dims = g->GetCellDimensions();
-    _nDims = g->GetNumCellDimensions();
     _index = {0, 0, 0};
-    _lastIndex = _index;
-
-    if (_nDims < 1)
-        _lastIndex[0] = 1;    // edge case for 0D grids
-    else
-        _lastIndex[_nDims - 1] = _dims[_nDims - 1];
+    _lastIndex = {0, 0, _dims[_dims.size() - 1]};
 
     if (!begin) { _index = _lastIndex; }
 }
@@ -396,7 +364,6 @@ Grid::ConstCellIteratorSG::ConstCellIteratorSG(const Grid *g, bool begin) : Cons
 Grid::ConstCellIteratorSG::ConstCellIteratorSG(const ConstCellIteratorSG &rhs) : ConstCellIteratorAbstract()
 {
     _dims = rhs._dims;
-    _nDims = rhs._nDims;
     _index = rhs._index;
     _lastIndex = rhs._lastIndex;
 }
@@ -404,7 +371,6 @@ Grid::ConstCellIteratorSG::ConstCellIteratorSG(const ConstCellIteratorSG &rhs) :
 Grid::ConstCellIteratorSG::ConstCellIteratorSG() : ConstCellIteratorAbstract()
 {
     _dims = {1, 1, 1};
-    _nDims = 0;
     _index = {0, 0, 0};
     _lastIndex = {0, 0, 0};
 }
@@ -412,16 +378,17 @@ Grid::ConstCellIteratorSG::ConstCellIteratorSG() : ConstCellIteratorAbstract()
 void Grid::ConstCellIteratorSG::next()
 {
     _index[0]++;
-    if (_index[0] < (_dims[0]) || _nDims <= 1) { return; }
+    if (_index[0] < (_dims[0])) { return; }
 
     _index[0] = 0;
     _index[1]++;
-    if (_index[1] < (_dims[1]) || _nDims == 2) { return; }
+    if (_index[1] < (_dims[1])) { return; }
 
     _index[1] = 0;
     _index[2]++;
-    if (_index[2] < (_dims[2]) || _nDims == 3) { return; }
-    VAssert(0 && "Invalid state");
+    if (_index[2] < (_dims[2])) { return; }
+
+    _index[2] = _dims[2];    // last index;
 }
 
 void Grid::ConstCellIteratorSG::next(const long &offset)
@@ -527,28 +494,21 @@ void Grid::ConstCellIteratorBoxSG::next(const long &offset)
 
 template<class T> Grid::ForwardIterator<T>::ForwardIterator(T *rg, bool begin, const CoordType &minu, const CoordType &maxu) : _pred(minu, maxu)
 {
-    _ndims = rg->GetNumDimensions();
-
     _blks = rg->GetBlks();
 
     _dims3d = rg->GetDimensions();
+    _bdims3d = {1, 1, 1};
+    _bs3d = {1, 1, 1};
     CopyToArr3(rg->GetDimensionInBlks(), _bdims3d);
     CopyToArr3(rg->GetBlockSize(), _bs3d);
-    for (int i = _ndims; i < 3; i++) {
-        _dims3d[i] = 1;
-        _bdims3d[i] = 1;
-        _bs3d[i] = 1;
-    }
+
     _blocksize = Wasp::VProduct(_bs3d.data(), _bs3d.size());
 
     _index = {0, 0, 0};
-    _indexL = 0;
+    _lastIndex = {0, 0, _dims3d[_dims3d.size() - 1]};
 
-    _end_indexL = 0;
-
-    _end_indexL = Wasp::VProduct(_dims3d.data(), _dims3d.size());
     if (!begin || !_blks.size()) {
-        _indexL = _end_indexL;
+        _index = _lastIndex;
         return;
     }
 
@@ -561,7 +521,6 @@ template<class T> Grid::ForwardIterator<T>::ForwardIterator(T *rg, bool begin, c
 
 template<class T> Grid::ForwardIterator<T>::ForwardIterator(ForwardIterator<T> &&rhs)
 {
-    _ndims = rhs._ndims;
     _blks = rhs._blks;
     _dims3d = rhs._dims3d;
     _bdims3d = rhs._bdims3d;
@@ -569,8 +528,6 @@ template<class T> Grid::ForwardIterator<T>::ForwardIterator(ForwardIterator<T> &
     _blocksize = rhs._blocksize;
     _coordItr = std::move(rhs._coordItr);
     _index = rhs._index;
-    _indexL = rhs._indexL;
-    _end_indexL = rhs._end_indexL;
     _xb = rhs._xb;
     _itr = rhs._itr;
     rhs._itr = nullptr;
@@ -579,19 +536,14 @@ template<class T> Grid::ForwardIterator<T>::ForwardIterator(ForwardIterator<T> &
 
 template<class T> Grid::ForwardIterator<T>::ForwardIterator()
 {
-    _ndims = 0;
     _blks.clear();
     _dims3d = {1, 1, 1};
     _bdims3d = {1, 1, 1};
     _bs3d = {1, 1, 1};
     _blocksize = 1;
-    //_coordItr = xx;
     _index = {0, 0, 0};
-    _indexL = 0;
-    _end_indexL = 0;
     _xb = 0;
     _itr = nullptr;
-    //_pred = xx;
 }
 
 template<class T> Grid::ForwardIterator<T> &Grid::ForwardIterator<T>::operator=(ForwardIterator<T> rhs)
@@ -614,7 +566,6 @@ template<class T> Grid::ForwardIterator<T> &Grid::ForwardIterator<T>::operator++
         _xb++;
         _itr++;
         _index[0]++;
-        _indexL++;
         if (_pred.Enabled()) ++_coordItr;
 
         if (_xb < _bs3d[0] && _index[0] < _dims3d[0]) {
@@ -625,22 +576,16 @@ template<class T> Grid::ForwardIterator<T> &Grid::ForwardIterator<T>::operator++
 
         _xb = 0;
         if (_index[0] >= _dims3d[0]) {
-            if (_indexL == _end_indexL) {
-                return (*this);    // last element
-            }
             _index[0] = _xb = 0;
             _index[1]++;
         }
 
         if (_index[1] >= _dims3d[1]) {
-            if (_indexL == _end_indexL) {
-                return (*this);    // last element
-            }
             _index[1] = 0;
             _index[2]++;
         }
 
-        if (_indexL == _end_indexL) {
+        if (_index == _lastIndex) {
             return (*this);    // last element
         }
 
@@ -654,7 +599,7 @@ template<class T> Grid::ForwardIterator<T> &Grid::ForwardIterator<T>::operator++
         float *blk = _blks[zb * _bdims3d[0] * _bdims3d[1] + yb * _bdims3d[0] + xb];
         _itr = &blk[z * _bs3d[0] * _bs3d[1] + y * _bs3d[0] + x];
 
-    } while (_indexL != _end_indexL && !_pred(*_coordItr));
+    } while (_index != _lastIndex && !_pred(*_coordItr));
 
     return (*this);
 }
@@ -672,16 +617,18 @@ template<class T> Grid::ForwardIterator<T> &Grid::ForwardIterator<T>::operator+=
 
     if (!_blks.size()) return (*this);
 
-    _indexL = Wasp::LinearizeCoords(_index.data(), _dims3d.data(), _ndims) + offset;
+    long maxIndexL = Wasp::VProduct(_dims3d.data(), _dims3d.size()) - 1;
+    long indexL = Wasp::LinearizeCoords(_index.data(), _dims3d.data(), _index.size()) + offset;
 
     // Check for overflow
     //
-    if (_indexL >= _end_indexL) {
-        _indexL = _end_indexL;
+    if (indexL < 0) { indexL = 0; }
+    if (indexL > maxIndexL) {
+        _index = _lastIndex;
         return (*this);
     }
 
-    Wasp::VectorizeCoords(_indexL, _dims3d.data(), _index.data(), _ndims);
+    Wasp::VectorizeCoords(indexL, _dims3d.data(), _index.data(), _index.size());
     if (_pred.Enabled()) _coordItr += offset;
 
     size_t x = _index[0] % _bs3d[0];

--- a/lib/vdc/RegularGrid.cpp
+++ b/lib/vdc/RegularGrid.cpp
@@ -140,14 +140,12 @@ float RegularGrid::GetValueLinear(const CoordType &coords) const
 
     if (_delta[0] != 0.0) { i = (size_t)floor((cCoords[0] - _minu[0]) / _delta[0]); }
     if (_delta[1] != 0.0) { j = (size_t)floor((cCoords[1] - _minu[1]) / _delta[1]); }
-
-    if (GetGeometryDim() == 3 && _delta[2] != 0.0) { k = (size_t)floor((cCoords[2] - _minu[2]) / _delta[2]); }
+    if (_delta[2] != 0.0) { k = (size_t)floor((cCoords[2] - _minu[2]) / _delta[2]); }
 
     auto dims = GetDimensions();
     VAssert(i < dims[0]);
     VAssert(j < dims[1]);
-
-    if (GetNumDimensions() == 3) { VAssert(k < dims[2]); }
+    VAssert(k < dims[2]);
 
     double iwgt = 0.0;
     double jwgt = 0.0;
@@ -155,8 +153,7 @@ float RegularGrid::GetValueLinear(const CoordType &coords) const
 
     if (_delta[0] != 0.0) { iwgt = ((cCoords[0] - _minu[0]) - (i * _delta[0])) / _delta[0]; }
     if (_delta[1] != 0.0) { jwgt = ((cCoords[1] - _minu[1]) - (j * _delta[1])) / _delta[1]; }
-
-    if (GetGeometryDim() == 3 && _delta[2] != 0.0) { kwgt = ((cCoords[2] - _minu[2]) - (k * _delta[2])) / _delta[2]; }
+    if (_delta[2] != 0.0) { kwgt = ((cCoords[2] - _minu[2]) - (k * _delta[2])) / _delta[2]; }
 
     float  missingValue = GetMissingValue();
     double p0, p1, p2, p3, p4, p5, p6, p7;
@@ -239,7 +236,7 @@ void RegularGrid::GetUserCoordinates(const DimsType &indices, CoordType &coords)
 
     auto dims = GetDimensions();
 
-    for (int i = 0; i < GetNumDimensions(); i++) {
+    for (int i = 0; i < dims.size(); i++) {
         size_t index = cIndices[i];
         VAssert(dims[i] > 0);
 
@@ -295,26 +292,19 @@ bool RegularGrid::InsideGrid(const CoordType &coords) const
 RegularGrid::ConstCoordItrRG::ConstCoordItrRG(const RegularGrid *rg, bool begin) : ConstCoordItrAbstract()
 {
     _dims = rg->GetDimensions();
-    _nDims = rg->GetNumDimensions();
     _delta = rg->_delta;
     _minu = rg->_minu;
     _coords = rg->_minu;
     _index = {0, 0, 0};
 
 
-    if (!begin) {
-        if (_nDims < 1)
-            _index[0] = 1;    // edge case for 0D grids
-        else
-            _index[_nDims - 1] = _dims[_nDims - 1];
-    }
+    if (!begin) { _index = {0, 0, _dims[_dims.size() - 1]}; }
 }
 
 RegularGrid::ConstCoordItrRG::ConstCoordItrRG(const ConstCoordItrRG &rhs) : ConstCoordItrAbstract()
 {
     _index = rhs._index;
     _dims = rhs._dims;
-    _nDims = rhs._nDims;
     _minu = rhs._minu;
     _delta = rhs._delta;
     _coords = rhs._coords;
@@ -335,8 +325,6 @@ void RegularGrid::ConstCoordItrRG::next()
     _coords[0] += _delta[0];
     if (_index[0] < _dims[0]) { return; }
 
-    if (_nDims <= 1) { return; }
-
     _index[0] = 0;
     _coords[0] = _minu[0];
     _index[1]++;
@@ -344,28 +332,23 @@ void RegularGrid::ConstCoordItrRG::next()
 
     if (_index[1] < _dims[1]) { return; }
 
-    if (_nDims == 2) { return; }
-
     _index[1] = 0;
     _coords[1] = _minu[1];
     _index[2]++;
     _coords[2] += _delta[2];
+
+    if (_index[2] < _dims[2]) { return; }
+
+    _index[2] = _dims[2];    // last index;
 }
 
 void RegularGrid::ConstCoordItrRG::next(const long &offset)
 {
-    if (!_nDims) return;
-
-    static DimsType maxIndex = {0, 0, 0};
-    ;
-    for (int i = 0; i < _nDims; i++) maxIndex[i] = _dims[i] - 1;
-
-    long maxIndexL = Wasp::LinearizeCoords(maxIndex.data(), _dims.data(), _dims.size());
+    long maxIndexL = Wasp::VProduct(_dims.data(), _dims.size()) - 1;
     long newIndexL = Wasp::LinearizeCoords(_index.data(), _dims.data(), _dims.size()) + offset;
     if (newIndexL < 0) { newIndexL = 0; }
     if (newIndexL > maxIndexL) {
-        _index = {0, 0, 0};
-        _index[_nDims - 1] = _dims[_nDims - 1];
+        _index = {0, 0, _dims[_dims.size() - 1]};
         return;
     }
 

--- a/lib/vdc/StretchedGrid.cpp
+++ b/lib/vdc/StretchedGrid.cpp
@@ -160,19 +160,13 @@ StretchedGrid::ConstCoordItrSG::ConstCoordItrSG(const StretchedGrid *sg, bool be
     _sg = sg;
     _index = {0, 0, 0};
     _coords = {0.0, 0.0, 0.0};
-    size_t          ndims = sg->GetNumDimensions();
     const DimsType &dims = sg->GetDimensions();
 
-    if (!begin) {
-        if (ndims < 1)
-            _index[0] = 1;    // edge case for 0D grids
-        else
-            _index[ndims - 1] = dims[ndims - 1];
-    }
+    if (!begin) { _index = {0, 0, dims[dims.size() - 1]}; }
 
-    if (_sg->GetGeometryDim() >= 1) _coords[0] = _sg->_xcoords[0];
-    if (_sg->GetGeometryDim() >= 2) _coords[1] = _sg->_ycoords[0];
-    if (_sg->GetGeometryDim() >= 3) _coords[2] = _sg->_zcoords[0];
+    if (_sg->_xcoords.size()) _coords[0] = _sg->_xcoords[0];
+    if (_sg->_ycoords.size()) _coords[1] = _sg->_ycoords[0];
+    if (_sg->_zcoords.size()) _coords[2] = _sg->_zcoords[0];
 }
 
 StretchedGrid::ConstCoordItrSG::ConstCoordItrSG(const ConstCoordItrSG &rhs) : ConstCoordItrAbstract()
@@ -192,7 +186,6 @@ StretchedGrid::ConstCoordItrSG::ConstCoordItrSG() : ConstCoordItrAbstract()
 void StretchedGrid::ConstCoordItrSG::next()
 {
     auto dims = _sg->GetDimensions();
-    auto ndims = _sg->GetNumDimensions();
 
     _index[0]++;
 
@@ -201,8 +194,6 @@ void StretchedGrid::ConstCoordItrSG::next()
         _coords[1] = _sg->_ycoords[_index[1]];
         return;
     }
-
-    if (ndims <= 1) return;
 
     _index[0] = 0;
     _index[1]++;
@@ -213,8 +204,6 @@ void StretchedGrid::ConstCoordItrSG::next()
         return;
     }
 
-    if (ndims == 2) return;
-
     _index[1] = 0;
     _index[2]++;
     if (_index[2] < dims[2]) {
@@ -223,37 +212,27 @@ void StretchedGrid::ConstCoordItrSG::next()
         _coords[2] = _sg->_zcoords[_index[2]];
         return;
     }
+
+    _index[2] = dims[2];    // last index;
 }
 
 void StretchedGrid::ConstCoordItrSG::next(const long &offset)
 {
     auto dims = _sg->GetDimensions();
-    auto ndims = _sg->GetNumDimensions();
 
-    if (!_index.size()) return;
-
-    vector<size_t> maxIndex;
-    maxIndex.reserve(3);
-    ;
-    for (int i = 0; i < ndims; i++) maxIndex.push_back(dims[i] - 1);
-
-    long maxIndexL = Wasp::LinearizeCoords(maxIndex.data(), dims.data(), ndims);
-    long newIndexL = Wasp::LinearizeCoords(_index.data(), dims.data(), ndims) + offset;
+    long maxIndexL = Wasp::VProduct(dims.data(), dims.size()) - 1;
+    long newIndexL = Wasp::LinearizeCoords(_index.data(), dims.data(), dims.size()) + offset;
     if (newIndexL < 0) { newIndexL = 0; }
     if (newIndexL > maxIndexL) {
-        _index = {0, 0, 0};
-        _index[ndims - 1] = dims[ndims - 1];
+        _index = {0, 0, dims[dims.size() - 1]};
         return;
     }
 
     _index = {0, 0, 0};
-    Wasp::VectorizeCoords(newIndexL, dims.data(), _index.data(), ndims);
+    Wasp::VectorizeCoords(newIndexL, dims.data(), _index.data(), dims.size());
 
     _coords[0] = _sg->_xcoords[_index[0]];
     _coords[1] = _sg->_ycoords[_index[1]];
-
-    if (ndims == 2) return;
-
     _coords[2] = _sg->_zcoords[_index[2]];
 }
 
@@ -300,10 +279,9 @@ float StretchedGrid::GetValueLinear(const CoordType &coords) const
     if (!inside) return (GetMissingValue());
 
     auto dims = GetDimensions();
-    auto ndims = GetNumDimensions();
     VAssert(i < dims[0]);
     VAssert(j < dims[1]);
-    if (ndims > 2) VAssert(k < dims[2]);
+    VAssert(k < dims[2]);
 
     float verts0[4];
     verts0[0] = AccessIJK(i, j, k);
@@ -312,8 +290,6 @@ float StretchedGrid::GetValueLinear(const CoordType &coords) const
     verts0[3] = dims[0] > 1 && dims[1] > 1 ? AccessIJK(i + 1, j + 1, k) : 0.0;
 
     float v0 = ((verts0[0] * xwgt[0] + verts0[1] * xwgt[1]) * ywgt[0]) + ((verts0[2] * xwgt[0] + verts0[3] * xwgt[1]) * ywgt[1]);
-
-    if (ndims == 2) return (v0);
 
     if (dims[2] > 1) k++;
 
@@ -344,7 +320,7 @@ void StretchedGrid::GetUserExtentsHelper(CoordType &minext, CoordType &maxext) c
 
     CoordType minv, maxv;
     StretchedGrid::GetBoundingBox(min, max, minv, maxv);
-    for (int i = 0; i < GetNumDimensions(); i++) {
+    for (int i = 0; i < min.size(); i++) {
         minext[i] = minv[i];
         maxext[i] = maxv[i];
     }

--- a/lib/vdc/StructuredGrid.cpp
+++ b/lib/vdc/StructuredGrid.cpp
@@ -52,14 +52,13 @@ bool StructuredGrid::GetCellNodes(const DimsType &cindices, vector<DimsType> &no
     ClampCellIndex(cindices, cCindices);
 
     auto dims = GetDimensions();
-    auto ndims = GetNumDimensions();
 
     // Cells have the same ID's as their first node
     //
     // walk counter-clockwise order
     //
 
-    if (ndims == 2) {
+    if (dims[0] > 1 && dims[1] > 1 && dims[2] < 2) {
         nodes.resize(4);
         nodes[0][0] = cCindices[0];
         nodes[0][1] = cCindices[1];
@@ -77,7 +76,7 @@ bool StructuredGrid::GetCellNodes(const DimsType &cindices, vector<DimsType> &no
         nodes[3][1] = cCindices[1] + 1;
         nodes[3][2] = 0;
 
-    } else if (ndims == 3) {
+    } else if (dims[0] > 1 && dims[1] > 1 && dims[2] > 1) {
         nodes.resize(8);
         nodes[0][0] = cCindices[0];
         nodes[0][1] = cCindices[1];
@@ -115,7 +114,7 @@ bool StructuredGrid::GetCellNodes(const DimsType &cindices, vector<DimsType> &no
     // Handle dims[i] == 1
     //
     for (int j = 0; j < nodes.size(); j++) {
-        for (int i = 0; i < ndims; i++) {
+        for (int i = 0; i < dims.size(); i++) {
             if (nodes[j][i] >= dims[i]) { nodes[j][i] -= 1; }
         }
     }
@@ -134,6 +133,7 @@ bool StructuredGrid::GetCellNeighbors(const DimsType &cindices, std::vector<Dims
     auto ndims = GetNumDimensions();
 
     VAssert((ndims == 2) && "3D cells not yet supported");
+    VAssert(dims[0] > 1 && dims[1] > 1);
 
     // Cells have the same ID's as their first node
     //
@@ -173,6 +173,7 @@ bool StructuredGrid::GetNodeCells(const DimsType &indices, std::vector<DimsType>
     auto ndims = GetNumDimensions();
 
     VAssert((ndims == 2) && "3D cells not yet supported");
+    VAssert(dims[0] > 1 && dims[1] > 1);
 
     // Check if invalid indices
     //
@@ -209,9 +210,13 @@ bool StructuredGrid::GetNodeCells(const DimsType &indices, std::vector<DimsType>
 
 bool StructuredGrid::GetEnclosingRegion(const CoordType &minu, const CoordType &maxu, DimsType &min, DimsType &max) const
 {
+    const DimsType &dims = GetNodeDimensions();
+
     if (!GetIndicesCell(minu, min)) return (false);
     if (!GetIndicesCell(maxu, max)) return (false);
-    for (int i = 0; i < GetNumDimensions(); i++) { max[i] += 1; }
+    for (int i = 0; i < max.size(); i++) {
+        if (max[i] < dims[i] - 1) max[i] += 1;
+    }
 
     // For curvilinear grids it's possible that minu and maxu components
     // are swapped
@@ -220,7 +225,7 @@ bool StructuredGrid::GetEnclosingRegion(const CoordType &minu, const CoordType &
     GetUserCoordinates(min.data(), newMinu.data());
     GetUserCoordinates(max.data(), newMaxu.data());
 
-    for (int i = 0; i < GetNumDimensions(); i++) {
+    for (int i = 0; i < newMinu.size(); i++) {
         if (newMinu > newMaxu) std::swap(min[i], max[i]);
     }
 

--- a/test_apps/smokeTests/gridTools.cpp
+++ b/test_apps/smokeTests/gridTools.cpp
@@ -70,10 +70,9 @@ vector<float *> AllocateBlocks(const vector<size_t> &bs, const vector<size_t> &d
 void MakeTriangle(Grid *grid, float minVal, float maxVal)
 {
     auto   dims = grid->GetDimensions();
-    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = nDims > 1 ? dims[Y] : 1;
-    size_t z = nDims > 2 ? dims[Z] : 1;
+    size_t y = dims[Y];
+    size_t z = dims[Z];
 
     float value = minVal;
     for (size_t k = 0; k < z; k++) {
@@ -89,10 +88,9 @@ void MakeTriangle(Grid *grid, float minVal, float maxVal)
 void MakeConstantField(Grid *grid, float value)
 {
     auto   dims = grid->GetDimensions();
-    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = nDims > 1 ? dims[Y] : 1;
-    size_t z = nDims > 2 ? dims[Z] : 1;
+    size_t y = dims[Y];
+    size_t z = dims[Z];
 
     for (size_t k = 0; k < z; k++) {
         for (size_t j = 0; j < y; j++) {
@@ -104,10 +102,9 @@ void MakeConstantField(Grid *grid, float value)
 void MakeRamp(Grid *grid, float minVal, float maxVal)
 {
     auto   dims = grid->GetDimensions();
-    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = nDims > 1 ? dims[Y] : 1;
-    size_t z = nDims > 2 ? dims[Z] : 1;
+    size_t y = dims[Y];
+    size_t z = dims[Z];
 
     float increment = (maxVal - minVal) / ((x * y * z - 1) == 0 ? 1 : (x * y * z - 1));
 
@@ -125,10 +122,9 @@ void MakeRamp(Grid *grid, float minVal, float maxVal)
 void MakeRampOnAxis(Grid *grid, float minVal, float maxVal, size_t axis = X)
 {
     auto   dims = grid->GetDimensions();
-    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = nDims > 1 ? dims[Y] : 1;
-    size_t z = nDims > 2 ? dims[Z] : 1;
+    size_t y = dims[Y];
+    size_t z = dims[Z];
 
     float xIncrement = axis == X ? (maxVal - minVal) / (dims[X] - 1) : 0;
     float yIncrement = axis == Y ? (maxVal - minVal) / (dims[Y] - 1) : 0;
@@ -164,10 +160,9 @@ bool CompareIndexToCoords(VAPoR::Grid *grid,
     numMissingValues = 0;
 
     auto   dims = grid->GetDimensions();
-    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = nDims > 1 ? dims[Y] : 1;
-    size_t z = nDims > 2 ? dims[Z] : 1;
+    size_t y = dims[Y];
+    size_t z = dims[Z];
 
     double peak = 0.f;
     double sum = 0;
@@ -351,10 +346,9 @@ bool RunTest(Grid *grid, bool silenceTime)
 bool RunTests(Grid *grid, const std::vector<std::string> &tests, float minVal, float maxVal, bool silenceTime)
 {
     auto   dims = grid->GetDimensions();
-    size_t nDims = grid->GetNumDimensions();
     size_t x = dims[X];
-    size_t y = nDims > 1 ? dims[Y] : 1;
-    size_t z = nDims > 2 ? dims[Z] : 1;
+    size_t y = dims[Y];
+    size_t z = dims[Z];
 
     bool        rc = true;
     std::string type = grid->GetType();


### PR DESCRIPTION
@stasj and @clyne - rather than add a review comment on #2992 asking for the following, I think it may be easier/faster to submit a PR with the following changes.

This PR...
1) Merges contour3d with main and resolves conflicts
2) Adds documentation to the new RenderParams functions GetSlicePlaneOrigin(), GetSlicePlaneNormal(), and GetSlicePlaneRotation()
3) Bumps the contour renderer's rotation/orientation/offset controls to the top of the geometry tab.  These are the primary controls the user will be working with.  IMO they should be at the top rather than things like the transform table and copy region from renderer sections.