### PR TITLE
Fixed 3011 and 3012 - renderers doesn't work with some VDC data 

### DIFF
--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -2407,11 +2407,11 @@ void DerivedCoordVarStandardOceanSCoordinate::compute_g2(const vector<size_t> &m
 //
 // The atmosphere_hybrid_sigma_pressure_coordinate conversion from pressure
 // to meters unforunately results in a flipped (inverted?) vertical coordinate
-// system with logical grid indices increasing as user coordinates 
-// decrease. I.e. Z[k] > Z[k+1]. In numerous places VAPOR 
+// system with logical grid indices increasing as user coordinates
+// decrease. I.e. Z[k] > Z[k+1]. In numerous places VAPOR
 // expects the grid index and associated vertical coordinate  to be
 // monotonically increasing. This needs to be fixed as this assumption
-// often does not hold true. However it is a big lift. For now, just 
+// often does not hold true. However it is a big lift. For now, just
 // remove the atmosphere_hybrid_sigma_pressure_coordinate converter from
 // the object factory.
 //

--- a/lib/vdc/DerivedVar.cpp
+++ b/lib/vdc/DerivedVar.cpp
@@ -2402,7 +2402,24 @@ void DerivedCoordVarStandardOceanSCoordinate::compute_g2(const vector<size_t> &m
 // Register class with object factory!!!
 //
 
+#ifdef VAPOR3_6_0
+
+//
+// The atmosphere_hybrid_sigma_pressure_coordinate conversion from pressure
+// to meters unforunately results in a flipped (inverted?) vertical coordinate
+// system with logical grid indices increasing as user coordinates 
+// decrease. I.e. Z[k] > Z[k+1]. In numerous places VAPOR 
+// expects the grid index and associated vertical coordinate  to be
+// monotonically increasing. This needs to be fixed as this assumption
+// often does not hold true. However it is a big lift. For now, just 
+// remove the atmosphere_hybrid_sigma_pressure_coordinate converter from
+// the object factory.
+//
+
+
 static DerivedCFVertCoordVarFactoryRegistrar<DerivedCoordVarStandardAHSPC> registrar_atmosphere_hybrid_sigma_pressure_coordinate("atmosphere_hybrid_sigma_pressure_coordinate");
+
+#endif
 
 DerivedCoordVarStandardAHSPC::DerivedCoordVarStandardAHSPC(DC *dc, string mesh, string formula) : DerivedCFVertCoordVar("", dc, mesh, formula)
 {


### PR DESCRIPTION
Fixed #3011 
Fixed #3012 

Had to back out atmosphere_hybrid_sigma_pressure_coordinate added in VAPOR 3.4 because it resulted in a
vertical coordinate system that was decreasing, which VAPOR doesn't currently support :-(