### PR TITLE
Fix issue 3015 - slice renderer missing upper portions of dataset

### DIFF
--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -314,26 +314,26 @@ void RenderParams::SetRefinementLevel(int level)
     SetValueLong(_RefinementLevelTag, "Set refinement level", level);
 
     // Adjust the Box's extents so that it encloses the same percentage of space in the new domain as it did in the old domain
-    Box* b = GetBox();
+    Box *b = GetBox();
     if (b == nullptr) return;
     if (!_classInitialized) return;
 
     VAPoR::CoordType oldBoxMin, oldBoxMax, oldVarMin, oldVarMax;
     VAPoR::CoordType newBoxMin, newBoxMax, newVarMin, newVarMax;
-    
+
     b->GetExtents(oldBoxMin, oldBoxMax);
     _dataMgr->GetVariableExtents(GetCurrentTimestep(), GetVariableName(), oldRefLevel, 0, oldVarMin, oldVarMax);
     _dataMgr->GetVariableExtents(GetCurrentTimestep(), GetVariableName(), level, 0, newVarMin, newVarMax);
 
-    for (int i=0; i<3; i++) {
+    for (int i = 0; i < 3; i++) {
         double oldRange = oldVarMax[i] - oldVarMin[i];
-        double minPercentile = (oldBoxMin[i]-oldVarMin[i]) / oldRange;
-        double maxPercentile = (oldBoxMax[i]-oldVarMin[i]) / oldRange;
+        double minPercentile = (oldBoxMin[i] - oldVarMin[i]) / oldRange;
+        double maxPercentile = (oldBoxMax[i] - oldVarMin[i]) / oldRange;
         double newRange = newVarMax[i] - newVarMin[i];
         newBoxMin[i] = minPercentile * newRange + newVarMin[i];
         newBoxMax[i] = maxPercentile * newRange + newVarMin[i];
     }
-    b->SetExtents( newBoxMin, newBoxMax );
+    b->SetExtents(newBoxMin, newBoxMax);
 }
 
 int RenderParams::GetRefinementLevel() const { return (GetValueLong(_RefinementLevelTag, 0)); }


### PR DESCRIPTION
Fix #3015.

The problem was that the slice was being placed outside of the box's extents.  

At startup, a VDC will have Box classes that encompass the entire domain.  When increasing refinement, the domain will grow but the Box will not grow proportionally.

This fix adjusts the Box extents to be whatever fraction of the domain it encompassed before a refinement level change.    IE - If a Box spans between the 25% and 75% extents on an axis, it will still encompass those percentiles after refinement level changes.