### PR TITLE
#3029 Add a show/hide option for origin specification

### DIFF
--- a/apps/vaporgui/PShowIf.cpp
+++ b/apps/vaporgui/PShowIf.cpp
@@ -3,10 +3,7 @@
 #include <vapor/ParamsBase.h>
 #include <vapor/VAssert.h>
 
-PShowIf::PShowIf(std::string tag) : PWidgetWrapper(tag, _group = new PGroup)
-{
-    _test = std::unique_ptr<Test>(new TestLongEquals(getTag(), true));
-}
+PShowIf::PShowIf(std::string tag) : PWidgetWrapper(tag, _group = new PGroup) { _test = std::unique_ptr<Test>(new TestLongEquals(getTag(), true)); }
 
 PShowIf *PShowIf::Equals(long l)
 {

--- a/apps/vaporgui/PShowIf.cpp
+++ b/apps/vaporgui/PShowIf.cpp
@@ -3,7 +3,10 @@
 #include <vapor/ParamsBase.h>
 #include <vapor/VAssert.h>
 
-PShowIf::PShowIf(std::string tag) : PWidgetWrapper(tag, _group = new PGroup) {}
+PShowIf::PShowIf(std::string tag) : PWidgetWrapper(tag, _group = new PGroup)
+{
+    _test = std::unique_ptr<Test>(new TestLongEquals(getTag(), true));
+}
 
 PShowIf *PShowIf::Equals(long l)
 {

--- a/apps/vaporgui/PSliceOriginSelector.cpp
+++ b/apps/vaporgui/PSliceOriginSelector.cpp
@@ -21,11 +21,12 @@ PSliceOriginSelector::PSliceOriginSelector() : PSection("Slice Origin")
     Add({
         new PLabel("Slice origin is shown in-scene as a yellow crosshair"),
         new PCheckbox("GUI_ShowOrigin", "Show Origin Controls"),
-        (new PShowIf("GUI_ShowOrigin"))->Then({
-            _xSlider,
-            _ySlider,
-            _zSlider,
-        }),
+        (new PShowIf("GUI_ShowOrigin"))
+            ->Then({
+                _xSlider,
+                _ySlider,
+                _zSlider,
+            }),
     });
 }
 

--- a/apps/vaporgui/PSliceOriginSelector.cpp
+++ b/apps/vaporgui/PSliceOriginSelector.cpp
@@ -1,6 +1,8 @@
 #include "PSliceOriginSelector.h"
 #include "PSliderEditHLI.h"
 #include "PLabel.h"
+#include "PShowIf.h"
+#include "PCheckbox.h"
 #include <vapor/SliceParams.h>
 #include <assert.h>
 
@@ -16,10 +18,15 @@ PSliceOriginSelector::PSliceOriginSelector() : PSection("Slice Origin")
     _ySlider->EnableDynamicUpdate();
     _zSlider->EnableDynamicUpdate();
 
-    Add(_xSlider);
-    Add(_ySlider);
-    Add(_zSlider);
-    Add(new PLabel("Slice origin is shown in-scene as a yellow crosshair"));
+    Add({
+        new PLabel("Slice origin is shown in-scene as a yellow crosshair"),
+        new PCheckbox("GUI_ShowOrigin", "Show Origin Controls"),
+        (new PShowIf("GUI_ShowOrigin"))->Then({
+            _xSlider,
+            _ySlider,
+            _zSlider,
+        }),
+    });
 }
 
 void PSliceOriginSelector::updateGUI() const


### PR DESCRIPTION
#3029

<img width="400" alt="ss" src="https://user-images.githubusercontent.com/2772687/154210260-2d8b376a-c442-4ba3-9fc8-f5f28d19bc0c.png">

