### PR TITLE
Add green quad to Slice Renderer's geometry mode

### DIFF
--- a/apps/vaporgui/VizWin.cpp
+++ b/apps/vaporgui/VizWin.cpp
@@ -667,7 +667,7 @@ void VizWin::_renderHelper(bool fast)
     if (_getCurrentMouseMode() == MouseModeParams::GetRegionModeName()) {
         updateManip();
         if (_getRenderParams() && _getRenderParams()->GetOrientable()) { _updateOriginGlyph(); }
-        if (dynamic_cast<ContourParams *>(_getRenderParams()) || dynamic_cast<SliceParams *>(_getRenderParams())) _drawContourSliceQuad();
+        if (_getRenderParams()->GetOrientable()) _drawContourSliceQuad();
     } else if (vParams->GetProjectionType() == ViewpointParams::MapOrthographic) {
 #ifndef WIN32
         _glManager->PixelCoordinateSystemPush();

--- a/include/vapor/ContourParams.h
+++ b/include/vapor/ContourParams.h
@@ -99,9 +99,6 @@ public:
     void SetTFLock(bool lock);
     bool GetTFLock();
 
-    void              SetSlicePlaneQuad(const vector<CoordType> &quad);
-    vector<CoordType> GetSlicePlaneQuad() const;
-
 private:
     void                _init();
     static const string _thicknessScaleTag;

--- a/include/vapor/RenderParams.h
+++ b/include/vapor/RenderParams.h
@@ -440,14 +440,14 @@ protected:
     virtual bool GetUseSingleColorDefault() const { return false; }
 
 private:
-    void                   _init();
-    void                   _calculateStride(string varName);
-    int                    _stride;
-    ParamsContainer *      _TFs;
-    Box *                  _Box;
-    ColorbarPbase *        _Colorbar;
-    Transform *            _transform;
-    bool                   _classInitialized;    //
+    void             _init();
+    void             _calculateStride(string varName);
+    int              _stride;
+    ParamsContainer *_TFs;
+    Box *            _Box;
+    ColorbarPbase *  _Colorbar;
+    Transform *      _transform;
+    bool             _classInitialized;    //
     std::vector<CoordType> _slicePlaneQuad;
 
     static const string _EnabledTag;

--- a/include/vapor/RenderParams.h
+++ b/include/vapor/RenderParams.h
@@ -423,6 +423,14 @@ public:
     //! \param[in] Value to use for the plane origin on the Z axis.
     void SetZSlicePlaneOrigin(double zOrigin);
 
+    //! Set the values for a quad that encloses an arbitrary user-defined plane
+    //! \param[in] A std::vector<CoordType> of size 4, containing the locations of four vertices.
+    void SetSlicePlaneQuad(const std::vector<CoordType> &quad) { _slicePlaneQuad = quad; }
+
+    //! Return the values for a quad that encloses an arbitrary user-defined plane
+    //! \retval A std::vector<CoordType> of size 4, containing the locations of four vertices.
+    std::vector<CoordType> GetSlicePlaneQuad() const { return _slicePlaneQuad; }
+
 protected:
     DataMgr *_dataMgr;
     int      _maxDim;
@@ -432,14 +440,15 @@ protected:
     virtual bool GetUseSingleColorDefault() const { return false; }
 
 private:
-    void             _init();
-    void             _calculateStride(string varName);
-    int              _stride;
-    ParamsContainer *_TFs;
-    Box *            _Box;
-    ColorbarPbase *  _Colorbar;
-    Transform *      _transform;
-    bool             _classInitialized;    //
+    void                   _init();
+    void                   _calculateStride(string varName);
+    int                    _stride;
+    ParamsContainer *      _TFs;
+    Box *                  _Box;
+    ColorbarPbase *        _Colorbar;
+    Transform *            _transform;
+    bool                   _classInitialized;    //
+    std::vector<CoordType> _slicePlaneQuad;
 
     static const string _EnabledTag;
     static const string _histoScaleTag;

--- a/include/vapor/RenderParams.h
+++ b/include/vapor/RenderParams.h
@@ -440,14 +440,14 @@ protected:
     virtual bool GetUseSingleColorDefault() const { return false; }
 
 private:
-    void             _init();
-    void             _calculateStride(string varName);
-    int              _stride;
-    ParamsContainer *_TFs;
-    Box *            _Box;
-    ColorbarPbase *  _Colorbar;
-    Transform *      _transform;
-    bool             _classInitialized;    //
+    void                   _init();
+    void                   _calculateStride(string varName);
+    int                    _stride;
+    ParamsContainer *      _TFs;
+    Box *                  _Box;
+    ColorbarPbase *        _Colorbar;
+    Transform *            _transform;
+    bool                   _classInitialized;    //
     std::vector<CoordType> _slicePlaneQuad;
 
     static const string _EnabledTag;

--- a/lib/params/ContourParams.cpp
+++ b/lib/params/ContourParams.cpp
@@ -230,10 +230,6 @@ bool ContourParams::GetTFLock()
     return true;
 }
 
-void ContourParams::SetSlicePlaneQuad(const vector<CoordType> &quad) { _slicePlaneQuad = quad; }
-
-vector<CoordType> ContourParams::GetSlicePlaneQuad() const { return _slicePlaneQuad; }
-
 ContourParams::Contours::Contours(ParamsBase::StateSave *ssave) : ParamsBase(ssave, Contours::GetClassType()) {}
 
 ContourParams::Contours::Contours(ParamsBase::StateSave *ssave, XmlNode *node) : ParamsBase(ssave, node) {}

--- a/lib/render/SliceRenderer.cpp
+++ b/lib/render/SliceRenderer.cpp
@@ -239,6 +239,13 @@ int SliceRenderer::_regenerateSlice()
                      corner4[0], corner4[1], corner4[2],
                      corner2[0], corner2[1], corner2[2]};
 
+    SliceParams *p = dynamic_cast<SliceParams *>(GetActiveParams());
+    std::vector<CoordType> sliceQuad = { {corner1[0], corner1[1], corner1[2]},
+                                         {corner3[0], corner3[1], corner3[2]},
+                                         {corner4[0], corner4[1], corner4[2]},
+                                         {corner2[0], corner2[1], corner2[2]}};
+    p->SetSlicePlaneQuad(sliceQuad);
+
     delete grid3d;
     if (slice == nullptr) {
         Wasp::MyBase::SetErrMsg("Unable to perform SliceGridAlongPlane() with current Grid");


### PR DESCRIPTION
For consistency with the ContourRenderer, this PR adds a green quad to Slice Renderer's geometry mode.