### PR TITLE
Fix #3042 - slice crash

### DIFF
--- a/apps/vaporgui/VizWin.cpp
+++ b/apps/vaporgui/VizWin.cpp
@@ -666,8 +666,10 @@ void VizWin::_renderHelper(bool fast)
 
     if (_getCurrentMouseMode() == MouseModeParams::GetRegionModeName()) {
         updateManip();
-        if (_getRenderParams() && _getRenderParams()->GetOrientable()) { _updateOriginGlyph(); }
-        if (_getRenderParams()->GetOrientable()) _drawContourSliceQuad();
+        if (_getRenderParams() && _getRenderParams()->GetOrientable()) { 
+            _updateOriginGlyph();
+            _drawContourSliceQuad();
+        }
     } else if (vParams->GetProjectionType() == ViewpointParams::MapOrthographic) {
 #ifndef WIN32
         _glManager->PixelCoordinateSystemPush();

--- a/apps/vaporgui/VizWin.cpp
+++ b/apps/vaporgui/VizWin.cpp
@@ -666,7 +666,7 @@ void VizWin::_renderHelper(bool fast)
 
     if (_getCurrentMouseMode() == MouseModeParams::GetRegionModeName()) {
         updateManip();
-        if (_getRenderParams() && _getRenderParams()->GetOrientable()) { 
+        if (_getRenderParams() && _getRenderParams()->GetOrientable()) {
             _updateOriginGlyph();
             _drawContourSliceQuad();
         }


### PR DESCRIPTION
@stasj thanks for pointing this out.  I thought that I had added the quad drawing into the "same block" that we talked about last week.  

I think the "same block" change was undone along with a clang-format command that I backed out, where the formatter touched more than I wanted it to.  clang-format bites again...