### PR TITLE
Failures converting data to VDC format #3046

### DIFF
--- a/apps/cfvdccreate/cfvdccreate.cpp
+++ b/apps/cfvdccreate/cfvdccreate.cpp
@@ -272,6 +272,8 @@ int main(int argc, char **argv)
         if (rc < 0) return (1);
 
         for (int i = 0; i < datanames.size(); i++) {
+            if (find(coordnames.begin(), coordnames.end(), datanames[i])!=coordnames.end()) continue;
+
             DC::DataVar dvar;
             dccf.GetDataVarInfo(datanames[i], dvar);
 

--- a/apps/cfvdccreate/cfvdccreate.cpp
+++ b/apps/cfvdccreate/cfvdccreate.cpp
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
         if (rc < 0) return (1);
 
         for (int i = 0; i < datanames.size(); i++) {
-            if (find(coordnames.begin(), coordnames.end(), datanames[i])!=coordnames.end()) continue;
+            if (find(coordnames.begin(), coordnames.end(), datanames[i]) != coordnames.end()) continue;
 
             DC::DataVar dvar;
             dccf.GetDataVarInfo(datanames[i], dvar);

--- a/lib/vdc/VDC.cpp
+++ b/lib/vdc/VDC.cpp
@@ -365,12 +365,13 @@ int VDC::DefineCoordVar(string varname, vector<string> dim_names, string time_di
         return (-1);
     }
 
-    if (_mode == A) {
-        if (_coordVars.find(varname) != _coordVars.end()) {
-            SetErrMsg("Variable \"%s\" already defined", varname.c_str());
-            return (-1);
-        }
-    }
+    // No dulicates. Overwrite previous definition
+    //
+    auto ditr = _dataVars.find(varname);
+    if (ditr != _dataVars.end()) _dataVars.erase(ditr);
+
+    auto citr = _coordVars.find(varname);
+    if (citr != _coordVars.end()) _coordVars.erase(citr);
 
     if (axis == 3 && units.empty()) units = "seconds";
 
@@ -448,12 +449,13 @@ int VDC::_DefineDataVar(string varname, vector<string> dim_names, vector<string>
         return (-1);
     }
 
-    if (_mode == A) {
-        if (_dataVars.find(varname) != _dataVars.end()) {
-            SetErrMsg("Variable \"%s\" already defined", varname.c_str());
-            return (-1);
-        }
-    }
+    // No dulicates. Overwrite previous definition
+    //
+    auto ditr = _dataVars.find(varname);
+    if (ditr != _dataVars.end()) _dataVars.erase(ditr);
+
+    auto citr = _coordVars.find(varname);
+    if (citr != _coordVars.end()) _coordVars.erase(citr);
 
     int rc = _DefineImplicitCoordVars(dim_names, coord_vars, coord_vars);
     if (rc < 0) return (-1);


### PR DESCRIPTION
Fixed #3046 

This change prohibits variables from being defined as both coordinate and data variables in the VDC. At present the VDC cannot support this because the underlying NetCDF API doesn't allow a variable to be defined twice. 