### PR TITLE
Fixed Crash when calculating 2D wind speed 

### DIFF
--- a/include/vapor/ConstantGrid.h
+++ b/include/vapor/ConstantGrid.h
@@ -50,7 +50,7 @@ private:
     // They do nothing and return meaningless values.
     // Do not use!
     //
-    std::vector<size_t>        GetCoordDimensions(size_t) const override;
+    DimsType                   GetCoordDimensions(size_t) const override;
     size_t                     GetGeometryDim() const override;
     const DimsType &           GetNodeDimensions() const override;
     const size_t               GetNumNodeDimensions() const override;

--- a/include/vapor/CurvilinearGrid.h
+++ b/include/vapor/CurvilinearGrid.h
@@ -162,7 +162,7 @@ public:
     static std::string GetClassType() { return ("Curvilinear"); }
     std::string        GetType() const override { return (GetClassType()); }
 
-    virtual std::vector<size_t> GetCoordDimensions(size_t dim) const override;
+    virtual DimsType GetCoordDimensions(size_t dim) const override;
 
     virtual size_t GetGeometryDim() const override { return (GetTopologyDim()); };
 

--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -443,6 +443,11 @@ public:
     //!
     virtual void SetInterpolationOrder(int order);
 
+    //! Compute the dimensions of a rectangular region bounded
+    //! by \p min and \p max coordinates
+    //
+    static DimsType Dims(const DimsType &min, const DimsType &max);
+
     //! Return the user coordinates of a grid point
     //!
     //! This method returns the user coordinates of the grid point
@@ -791,6 +796,7 @@ public:
 
         return ((left <= pt[0]) && (right >= pt[0]) && (top <= pt[1]) && (bottom >= pt[1]));
     }
+
 
     VDF_API friend std::ostream &operator<<(std::ostream &o, const Grid &g);
 

--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -124,7 +124,7 @@ public:
     //! a vector of length one with its single component equal to
     //! one is returned.
     //!
-    virtual std::vector<size_t> GetCoordDimensions(size_t dim) const = 0;
+    virtual DimsType GetCoordDimensions(size_t dim) const = 0;
 
     virtual std::string GetType() const = 0;
 

--- a/include/vapor/LayeredGrid.h
+++ b/include/vapor/LayeredGrid.h
@@ -52,7 +52,7 @@ public:
 
     virtual size_t GetGeometryDim() const override { return (3); }
 
-    virtual std::vector<size_t> GetCoordDimensions(size_t dim) const override;
+    virtual DimsType GetCoordDimensions(size_t dim) const override;
 
     static std::string GetClassType() { return ("Layered"); }
     std::string        GetType() const override { return (GetClassType()); }

--- a/include/vapor/PyEngine.h
+++ b/include/vapor/PyEngine.h
@@ -162,8 +162,8 @@ public:
     //! executing \p script. The size of the region copied is given by the
     //! dimensions in \p outputVarDims
     //!
-    static int Calculate(const string &script, vector<string> inputVarNames, vector<vector<size_t>> inputVarDims, vector<float *> inputVarArrays, vector<string> outputVarNames,
-                         vector<vector<size_t>> outputVarDims, vector<float *> outputVarArrays);
+    static int Calculate(const string &script, vector<string> inputVarNames, vector<DimsType> inputVarDims, vector<float *> inputVarArrays, vector<string> outputVarNames,
+                         vector<DimsType> outputVarDims, vector<float *> outputVarArrays);
 
 private:
     class RENDER_API DerivedPythonVar : public DerivedDataVar {
@@ -182,6 +182,8 @@ private:
         int GetDimLensAtLevel(int level, std::vector<size_t> &dims_at_level, std::vector<size_t> &bs_at_level) const;
 
         virtual size_t GetNumRefLevels() const;
+
+        virtual std::vector<size_t> GetCRatios() const { return (_varInfo.GetCRatios()); }
 
         int OpenVariableRead(size_t ts, int level = 0, int lod = 0);
 
@@ -206,13 +208,13 @@ private:
         DataMgr *           _dataMgr;
         bool                _coordFlag;
         DC::FileTable       _fileTable;
-        vector<size_t>      _dims;
+        DimsType            _dims;
         bool                _meshMatchFlag;
         string              _stdoutString;
 
-        int _readRegionAll(int fd, const std::vector<size_t> &min, const std::vector<size_t> &max, float *region);
+        int _readRegionAll(int fd, const DimsType &min, const DimsType &max, float *region);
 
-        int _readRegionSubset(int fd, const std::vector<size_t> &min, const std::vector<size_t> &max, float *region);
+        int _readRegionSubset(int fd, const DimsType &min, const DimsType &max, float *region);
     };
 
     class func_c {
@@ -242,9 +244,9 @@ private:
 
     static void _cleanupDict(PyObject *mainDict, vector<string> keynames);
 
-    static int _c2python(PyObject *dict, vector<string> inputVarNames, vector<vector<size_t>> inputVarDims, vector<float *> inputVarArrays);
+    static int _c2python(PyObject *dict, vector<string> inputVarNames, vector<DimsType> inputVarDims, vector<float *> inputVarArrays);
 
-    static int _python2c(PyObject *dict, vector<string> outputVarNames, vector<vector<size_t>> outputVarDims, vector<float *> outputVarArrays);
+    static int _python2c(PyObject *dict, vector<string> outputVarNames, vector<DimsType> outputVarDims, vector<float *> outputVarArrays);
 
     bool _validOutputVar(string name) const;
     int  _checkOutVars(const vector<string> &outputVarNames) const;

--- a/include/vapor/RegularGrid.h
+++ b/include/vapor/RegularGrid.h
@@ -48,7 +48,7 @@ public:
 
     virtual size_t GetGeometryDim() const override { return (_geometryDim); }
 
-    virtual std::vector<size_t> GetCoordDimensions(size_t dim) const override;
+    virtual DimsType GetCoordDimensions(size_t dim) const override;
 
     static std::string GetClassType() { return ("Regular"); }
     std::string        GetType() const override { return (GetClassType()); }

--- a/include/vapor/StretchedGrid.h
+++ b/include/vapor/StretchedGrid.h
@@ -62,7 +62,7 @@ public:
 
     virtual size_t GetGeometryDim() const override;
 
-    virtual std::vector<size_t> GetCoordDimensions(size_t dim) const override;
+    virtual DimsType GetCoordDimensions(size_t dim) const override;
 
     static std::string GetClassType() { return ("Stretched"); }
     std::string        GetType() const override { return (GetClassType()); }

--- a/include/vapor/UnstructuredGrid2D.h
+++ b/include/vapor/UnstructuredGrid2D.h
@@ -45,7 +45,7 @@ public:
 
     std::shared_ptr<const QuadTreeRectangleP> GetQuadTreeRectangle() const { return (_qtr); }
 
-    virtual std::vector<size_t> GetCoordDimensions(size_t dim) const override;
+    virtual DimsType GetCoordDimensions(size_t dim) const override;
 
     virtual size_t GetGeometryDim() const override;
 

--- a/include/vapor/UnstructuredGrid3D.h
+++ b/include/vapor/UnstructuredGrid3D.h
@@ -38,7 +38,7 @@ public:
     UnstructuredGrid3D() = default;
     virtual ~UnstructuredGrid3D() = default;
 
-    virtual std::vector<size_t> GetCoordDimensions(size_t dim) const override;
+    virtual DimsType GetCoordDimensions(size_t dim) const override;
 
     virtual size_t GetGeometryDim() const override;
 

--- a/include/vapor/UnstructuredGridCoordless.h
+++ b/include/vapor/UnstructuredGridCoordless.h
@@ -41,7 +41,7 @@ public:
     UnstructuredGridCoordless() = default;
     virtual ~UnstructuredGridCoordless() = default;
 
-    virtual std::vector<size_t> GetCoordDimensions(size_t dim) const override { return (std::vector<size_t>(1, 1)); }
+    virtual DimsType GetCoordDimensions(size_t dim) const override { return (DimsType{1, 1, 1}); }
 
     static std::string GetClassType() { return ("UnstructuredCoordless"); }
     std::string        GetType() const override { return (GetClassType()); }

--- a/include/vapor/UnstructuredGridLayered.h
+++ b/include/vapor/UnstructuredGridLayered.h
@@ -41,7 +41,7 @@ public:
 
     std::shared_ptr<const QuadTreeRectangleP> GetQuadTreeRectangle() const { return (_ug2d.GetQuadTreeRectangle()); }
 
-    virtual std::vector<size_t> GetCoordDimensions(size_t dim) const override;
+    virtual DimsType GetCoordDimensions(size_t dim) const override;
 
     virtual size_t GetGeometryDim() const override;
 

--- a/lib/render/PyEngine.cpp
+++ b/lib/render/PyEngine.cpp
@@ -20,7 +20,7 @@ struct varinfo_t {
     {
         _g = NULL;
         _name.clear();
-        _dims = {1,1,1};
+        _dims = {1, 1, 1};
         _coordNames.clear();
         _coordAxes.clear();
         _coordDims.clear();
@@ -98,8 +98,8 @@ void copy_coord(const Grid *g, int axis, float *dst)
 {
     DimsType dims = g->GetCoordDimensions(axis);
 
-    DimsType min = {0,0,0};
-    DimsType max = {dims[0]-1, dims[1]-1, dims[2]-1};
+    DimsType min = {0, 0, 0};
+    DimsType max = {dims[0] - 1, dims[1] - 1, dims[2] - 1};
 
     // Fetch user coordinates from grid. Note: assumes that if coordinate
     // dimensions are less than grid dimensions than the coordinate
@@ -210,11 +210,12 @@ void get_var_info(DataMgr *dataMgr, const vector<Grid *> &gs, const vector<strin
 
 // Remove trailing, degenerate unit dimensions
 //
-size_t number_of_dims(DimsType dims) {
-	size_t n = dims.size();
-	while (n>1 && dims[n-1] <= 1) n--;
+size_t number_of_dims(DimsType dims)
+{
+    size_t n = dims.size();
+    while (n > 1 && dims[n - 1] <= 1) n--;
 
-    return(n);
+    return (n);
 }
 
 };    // namespace
@@ -433,9 +434,8 @@ void PyEngine::_cleanupDict(PyObject *mainDict, vector<string> keynames)
 
 int PyEngine::_c2python(PyObject *dict, vector<string> inputVarNames, vector<DimsType> inputVarDims, vector<float *> inputVarArrays)
 {
-    npy_intp pyDims[3] = {1,1,1};
+    npy_intp pyDims[3] = {1, 1, 1};
     for (int i = 0; i < inputVarNames.size(); i++) {
-
         const DimsType &dims = inputVarDims[i];
         for (int j = 0; j < number_of_dims(dims); j++) { pyDims[number_of_dims(dims) - j - 1] = dims[j]; }
 
@@ -470,7 +470,7 @@ int PyEngine::_python2c(PyObject *dict, vector<string> outputVarNames, vector<Di
             return -1;
         }
 
-        const DimsType        &dims = outputVarDims[i];
+        const DimsType &      dims = outputVarDims[i];
         int                   nd = PyArray_NDIM(varArray);
 
         if (nd != number_of_dims(dims)) {
@@ -504,7 +504,7 @@ PyEngine::DerivedPythonVar::DerivedPythonVar(string varName, string units, DC::X
     _script = script;
     _dataMgr = dataMgr;
     _coordFlag = coordFlag;
-    _dims = {1,1,1};
+    _dims = {1, 1, 1};
     _meshMatchFlag = false;
     _stdoutString.clear();
     if (hasMissing) {
@@ -573,9 +573,7 @@ int PyEngine::DerivedPythonVar::GetDimLensAtLevel(int level, std::vector<size_t>
         int rc = _dataMgr->GetDimLensAtLevel(_inNames[0], level, dims_at_level, -1);
         VAssert(rc >= 0);
     } else {
-        for(int i=0; i<number_of_dims(_dims) && i<_dims.size(); i++) {
-            dims_at_level.push_back(_dims[i]);
-        }
+        for (int i = 0; i < number_of_dims(_dims) && i < _dims.size(); i++) { dims_at_level.push_back(_dims[i]); }
     }
 
     // No blocking
@@ -597,7 +595,7 @@ int PyEngine::DerivedPythonVar::OpenVariableRead(size_t ts, int level, int lod)
     if (level < 0) level = GetNumRefLevels() + level;
 
     if (lod < 0) lod = _varInfo.GetCRatios().size() + lod;
- 
+
     DC::FileTable::FileObject *f = new DC::FileTable::FileObject(ts, _derivedVarName, level, lod);
 
     return (_fileTable.AddEntry(f));
@@ -633,7 +631,7 @@ int PyEngine::DerivedPythonVar::_readRegionAll(int fd, const DimsType &min, cons
     vector<varinfo_t> varInfoVec;
     get_var_info(_dataMgr, variables, _inNames, _coordFlag, varInfoVec);
 
-    vector<DimsType> inputVarDims;
+    vector<DimsType>       inputVarDims;
     vector<string>         inputNames;
     for (int i = 0; i < varInfoVec.size(); i++) {
         const varinfo_t &vref = varInfoVec[i];
@@ -649,7 +647,7 @@ int PyEngine::DerivedPythonVar::_readRegionAll(int fd, const DimsType &min, cons
     vector<size_t> dims_vec, dummy;
     (void)GetDimLensAtLevel(level, dims_vec, dummy);
 
-    DimsType dims = {1,1,1};
+    DimsType dims = {1, 1, 1};
     Grid::CopyToArr3(dims_vec, dims);
     vector<DimsType> outputVarDims = {dims};
 
@@ -704,7 +702,7 @@ int PyEngine::DerivedPythonVar::_readRegionSubset(int fd, const DimsType &min, c
     vector<varinfo_t> varInfoVec;
     get_var_info(_dataMgr, variables, _inNames, _coordFlag, varInfoVec);
 
-    vector<DimsType> inputVarDims;
+    vector<DimsType>       inputVarDims;
     vector<string>         inputNames;
     for (int i = 0; i < varInfoVec.size(); i++) {
         const varinfo_t &vref = varInfoVec[i];
@@ -720,7 +718,7 @@ int PyEngine::DerivedPythonVar::_readRegionSubset(int fd, const DimsType &min, c
     // output and input variable(s) (if they exist) are all defined
     // on the same mesh (they have same dimensions)
     //
-    vector<DimsType> outputVarDims;
+    vector<DimsType>       outputVarDims;
     DimsType               minAbs = {0, 0, 0};
     if (inputVarDims.size()) {
         outputVarDims.push_back(inputVarDims[0]);
@@ -775,10 +773,10 @@ int PyEngine::DerivedPythonVar::_readRegionSubset(int fd, const DimsType &min, c
 
 int PyEngine::DerivedPythonVar::ReadRegion(int fd, const std::vector<size_t> &minVec, const std::vector<size_t> &maxVec, float *region)
 {
-    DimsType min = {0,0,0};
+    DimsType min = {0, 0, 0};
     Grid::CopyToArr3(minVec, min);
 
-    DimsType max = {0,0,0};
+    DimsType max = {0, 0, 0};
     Grid::CopyToArr3(maxVec, max);
 
     if (_meshMatchFlag) {

--- a/lib/vdc/ConstantGrid.cpp
+++ b/lib/vdc/ConstantGrid.cpp
@@ -31,10 +31,9 @@ void ConstantGrid::GetUserExtentsHelper(VAPoR::CoordType &minu, VAPoR::CoordType
 
 bool ConstantGrid::InsideGrid(const VAPoR::CoordType &coords) const { return true; }
 
-std::vector<size_t> ConstantGrid::GetCoordDimensions(size_t) const
+VAPoR::DimsType ConstantGrid::GetCoordDimensions(size_t) const
 {
-    std::vector<size_t> tmp;
-    return tmp;
+    return(VAPoR::DimsType{1,1,1});
 }
 
 size_t ConstantGrid::GetGeometryDim() const { return 3; }

--- a/lib/vdc/ConstantGrid.cpp
+++ b/lib/vdc/ConstantGrid.cpp
@@ -31,10 +31,7 @@ void ConstantGrid::GetUserExtentsHelper(VAPoR::CoordType &minu, VAPoR::CoordType
 
 bool ConstantGrid::InsideGrid(const VAPoR::CoordType &coords) const { return true; }
 
-VAPoR::DimsType ConstantGrid::GetCoordDimensions(size_t) const
-{
-    return(VAPoR::DimsType{1,1,1});
-}
+VAPoR::DimsType ConstantGrid::GetCoordDimensions(size_t) const { return (VAPoR::DimsType{1, 1, 1}); }
 
 size_t ConstantGrid::GetGeometryDim() const { return 3; }
 

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -133,19 +133,17 @@ CurvilinearGrid::CurvilinearGrid(const vector<size_t> &dimsv, const vector<size_
 
 DimsType CurvilinearGrid::GetCoordDimensions(size_t dim) const
 {
-    DimsType dims = {1,1,1};
+    DimsType dims = {1, 1, 1};
 
     if (dim == 0) {
         dims = _xrg.GetDimensions();
     } else if (dim == 1) {
         dims = _yrg.GetDimensions();
     } else if (dim == 2) {
-        if (_terrainFollowing) {
-            dims = _zrg.GetDimensions();
-        } 
+        if (_terrainFollowing) { dims = _zrg.GetDimensions(); }
     }
 
-    return(dims);
+    return (dims);
 }
 
 void CurvilinearGrid::GetBoundingBox(const DimsType &min, const DimsType &max, CoordType &minu, CoordType &maxu) const

--- a/lib/vdc/CurvilinearGrid.cpp
+++ b/lib/vdc/CurvilinearGrid.cpp
@@ -131,27 +131,21 @@ CurvilinearGrid::CurvilinearGrid(const vector<size_t> &dimsv, const vector<size_
     _curvilinearGrid(xrg, yrg, RegularGrid(), vector<double>(), qtr);
 }
 
-vector<size_t> CurvilinearGrid::GetCoordDimensions(size_t dim) const
+DimsType CurvilinearGrid::GetCoordDimensions(size_t dim) const
 {
-    const Grid *ptr = nullptr;
+    DimsType dims = {1,1,1};
+
     if (dim == 0) {
-        ptr = &_xrg;
+        dims = _xrg.GetDimensions();
     } else if (dim == 1) {
-        ptr = &_yrg;
+        dims = _yrg.GetDimensions();
     } else if (dim == 2) {
         if (_terrainFollowing) {
-            ptr = &_zrg;
-        } else {
-            return (vector<size_t>(1, _zcoords.size()));
-        }
-    } else {
-        return (vector<size_t>(1, 1));
+            dims = _zrg.GetDimensions();
+        } 
     }
 
-    auto tmp = ptr->GetDimensions();
-    auto tmp2 = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-    tmp2.resize(ptr->GetNumDimensions());
-    return tmp2;
+    return(dims);
 }
 
 void CurvilinearGrid::GetBoundingBox(const DimsType &min, const DimsType &max, CoordType &minu, CoordType &maxu) const

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -261,9 +261,7 @@ DimsType Grid::Dims(const DimsType &min, const DimsType &max)
 {
     DimsType dims;
 
-    for (int i = 0; i < min.size(); i++) {
-        dims[i] = (max[i] - min[i] + 1);
-    }
+    for (int i = 0; i < min.size(); i++) { dims[i] = (max[i] - min[i] + 1); }
     return (dims);
 }
 

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -257,6 +257,16 @@ void Grid::SetInterpolationOrder(int order)
     _interpolationOrder = order;
 }
 
+DimsType Grid::Dims(const DimsType &min, const DimsType &max)
+{
+    DimsType dims;
+
+    for (int i = 0; i < min.size(); i++) {
+        dims[i] = (max[i] - min[i] + 1);
+    }
+    return (dims);
+}
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // Iterators

--- a/lib/vdc/LayeredGrid.cpp
+++ b/lib/vdc/LayeredGrid.cpp
@@ -56,7 +56,7 @@ LayeredGrid::LayeredGrid(const vector<size_t> &dimsv, const vector<size_t> &bsv,
 
 DimsType LayeredGrid::GetCoordDimensions(size_t dim) const
 {
-    DimsType dims = {1,1,1};
+    DimsType dims = {1, 1, 1};
 
     if (dim == 0) {
         dims[0] = GetDimensions()[0];
@@ -64,9 +64,9 @@ DimsType LayeredGrid::GetCoordDimensions(size_t dim) const
         dims[0] = GetDimensions()[1];
     } else if (dim == 2) {
         dims = _zrg.GetDimensions();
-    } 
+    }
 
-    return(dims);
+    return (dims);
 }
 
 void LayeredGrid::GetUserExtentsHelper(CoordType &minu, CoordType &maxu) const

--- a/lib/vdc/LayeredGrid.cpp
+++ b/lib/vdc/LayeredGrid.cpp
@@ -54,20 +54,19 @@ LayeredGrid::LayeredGrid(const vector<size_t> &dimsv, const vector<size_t> &bsv,
     _layeredGrid(dims, bs, blks, xcoords, ycoords, zrg);
 }
 
-vector<size_t> LayeredGrid::GetCoordDimensions(size_t dim) const
+DimsType LayeredGrid::GetCoordDimensions(size_t dim) const
 {
+    DimsType dims = {1,1,1};
+
     if (dim == 0) {
-        return (vector<size_t>(1, GetDimensions()[0]));
+        dims[0] = GetDimensions()[0];
     } else if (dim == 1) {
-        return (vector<size_t>(1, GetDimensions()[1]));
+        dims[0] = GetDimensions()[1];
     } else if (dim == 2) {
-        auto tmp = _zrg.GetDimensions();
-        auto tmp2 = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-        tmp2.resize(_zrg.GetNumDimensions());
-        return tmp2;
-    } else {
-        return (vector<size_t>(1, 1));
-    }
+        dims = _zrg.GetDimensions();
+    } 
+
+    return(dims);
 }
 
 void LayeredGrid::GetUserExtentsHelper(CoordType &minu, CoordType &maxu) const

--- a/lib/vdc/RegularGrid.cpp
+++ b/lib/vdc/RegularGrid.cpp
@@ -65,21 +65,19 @@ RegularGrid::RegularGrid(const vector<size_t> &dimsv, const vector<size_t> &bsv,
     _regularGrid(minu, maxu);
 }
 
-vector<size_t> RegularGrid::GetCoordDimensions(size_t dim) const
+DimsType RegularGrid::GetCoordDimensions(size_t dim) const
 {
+    DimsType dims = {1,1,1};
+
     if (dim == 0) {
-        return (vector<size_t>(1, GetDimensions()[0]));
+        dims[0] = GetDimensions()[0];
     } else if (dim == 1) {
-        return (vector<size_t>(1, GetDimensions()[1]));
+        dims[0] = GetDimensions()[1];
     } else if (dim == 2) {
-        if (GetNumDimensions() == 3) {
-            return (vector<size_t>(1, GetDimensions()[2]));
-        } else {
-            return (vector<size_t>(1, 1));
-        }
-    } else {
-        return (vector<size_t>(1, 1));
+        dims[0] = GetDimensions()[2];
     }
+
+    return(dims);
 }
 
 float RegularGrid::GetValueNearestNeighbor(const CoordType &coords) const

--- a/lib/vdc/RegularGrid.cpp
+++ b/lib/vdc/RegularGrid.cpp
@@ -67,7 +67,7 @@ RegularGrid::RegularGrid(const vector<size_t> &dimsv, const vector<size_t> &bsv,
 
 DimsType RegularGrid::GetCoordDimensions(size_t dim) const
 {
-    DimsType dims = {1,1,1};
+    DimsType dims = {1, 1, 1};
 
     if (dim == 0) {
         dims[0] = GetDimensions()[0];
@@ -77,7 +77,7 @@ DimsType RegularGrid::GetCoordDimensions(size_t dim) const
         dims[0] = GetDimensions()[2];
     }
 
-    return(dims);
+    return (dims);
 }
 
 float RegularGrid::GetValueNearestNeighbor(const CoordType &coords) const

--- a/lib/vdc/StretchedGrid.cpp
+++ b/lib/vdc/StretchedGrid.cpp
@@ -48,13 +48,11 @@ size_t StretchedGrid::GetGeometryDim() const { return (_zcoords.size() == 0 ? 2 
 
 DimsType StretchedGrid::GetCoordDimensions(size_t dim) const
 {
-    DimsType dims = {1,1,1};
+    DimsType dims = {1, 1, 1};
 
-    if (dim < 3) {
-        dims[0] = GetDimensions()[dim];
-    } 
+    if (dim < 3) { dims[0] = GetDimensions()[dim]; }
 
-    return(dims);
+    return (dims);
 }
 
 void StretchedGrid::GetBoundingBox(const DimsType &min, const DimsType &max, CoordType &minu, CoordType &maxu) const

--- a/lib/vdc/StretchedGrid.cpp
+++ b/lib/vdc/StretchedGrid.cpp
@@ -46,13 +46,15 @@ StretchedGrid::StretchedGrid(const vector<size_t> &dims, const vector<size_t> &b
 
 size_t StretchedGrid::GetGeometryDim() const { return (_zcoords.size() == 0 ? 2 : 3); }
 
-vector<size_t> StretchedGrid::GetCoordDimensions(size_t dim) const
+DimsType StretchedGrid::GetCoordDimensions(size_t dim) const
 {
+    DimsType dims = {1,1,1};
+
     if (dim < 3) {
-        return (vector<size_t>(1, GetDimensions()[dim]));
-    } else {
-        return (vector<size_t>(1, 1));
-    }
+        dims[0] = GetDimensions()[dim];
+    } 
+
+    return(dims);
 }
 
 void StretchedGrid::GetBoundingBox(const DimsType &min, const DimsType &max, CoordType &minu, CoordType &maxu) const

--- a/lib/vdc/UnstructuredGrid2D.cpp
+++ b/lib/vdc/UnstructuredGrid2D.cpp
@@ -53,27 +53,20 @@ UnstructuredGrid2D::UnstructuredGrid2D(const std::vector<size_t> &vertexDims, co
     if (!_qtr) { _qtr = _makeQuadTreeRectangle(); }
 }
 
-vector<size_t> UnstructuredGrid2D::GetCoordDimensions(size_t dim) const
+DimsType UnstructuredGrid2D::GetCoordDimensions(size_t dim) const
 {
-    const Grid *ptr = nullptr;
+
+    DimsType dims = {1,1,1};
 
     if (dim == 0) {
-        ptr = &_xug;
+        dims = _xug.GetDimensions();
     } else if (dim == 1) {
-        ptr = &_yug;
+        dims = _yug.GetDimensions();
     } else if (dim == 2) {
-        if (GetGeometryDim() == 3)
-            ptr = &_zug;
-        else
-            return (vector<size_t>(1, 1));
-    } else {
-        return (vector<size_t>(1, 1));
+        dims = _zug.GetDimensions();
     }
 
-    auto tmp = ptr->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-    dims.resize(ptr->GetNumDimensions());
-    return dims;
+    return (dims);
 }
 
 size_t UnstructuredGrid2D::GetGeometryDim() const { return (_zug.GetNumDimensions() == 0 ? 2 : 3); }

--- a/lib/vdc/UnstructuredGrid2D.cpp
+++ b/lib/vdc/UnstructuredGrid2D.cpp
@@ -55,8 +55,7 @@ UnstructuredGrid2D::UnstructuredGrid2D(const std::vector<size_t> &vertexDims, co
 
 DimsType UnstructuredGrid2D::GetCoordDimensions(size_t dim) const
 {
-
-    DimsType dims = {1,1,1};
+    DimsType dims = {1, 1, 1};
 
     if (dim == 0) {
         dims = _xug.GetDimensions();

--- a/lib/vdc/UnstructuredGrid3D.cpp
+++ b/lib/vdc/UnstructuredGrid3D.cpp
@@ -52,7 +52,7 @@ UnstructuredGrid3D::UnstructuredGrid3D(const std::vector<size_t> &vertexDims, co
 
 DimsType UnstructuredGrid3D::GetCoordDimensions(size_t dim) const
 {
-    DimsType dims = {1,1,1};
+    DimsType dims = {1, 1, 1};
 
     if (dim == 0) {
         dims = _xug.GetDimensions();
@@ -60,9 +60,9 @@ DimsType UnstructuredGrid3D::GetCoordDimensions(size_t dim) const
         dims = _yug.GetDimensions();
     } else if (dim == 2) {
         dims = _zug.GetDimensions();
-    } 
+    }
 
-    return(dims);
+    return (dims);
 }
 
 

--- a/lib/vdc/UnstructuredGrid3D.cpp
+++ b/lib/vdc/UnstructuredGrid3D.cpp
@@ -50,24 +50,19 @@ UnstructuredGrid3D::UnstructuredGrid3D(const std::vector<size_t> &vertexDims, co
 }
 
 
-vector<size_t> UnstructuredGrid3D::GetCoordDimensions(size_t dim) const
+DimsType UnstructuredGrid3D::GetCoordDimensions(size_t dim) const
 {
-    const Grid *ptr = nullptr;
+    DimsType dims = {1,1,1};
 
     if (dim == 0) {
-        ptr = &_xug;
+        dims = _xug.GetDimensions();
     } else if (dim == 1) {
-        ptr = &_yug;
+        dims = _yug.GetDimensions();
     } else if (dim == 2) {
-        ptr = &_zug;
-    } else {
-        return (vector<size_t>(1, 1));
-    }
+        dims = _zug.GetDimensions();
+    } 
 
-    auto tmp = ptr->GetDimensions();
-    auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-    dims.resize(ptr->GetNumDimensions());
-    return dims;
+    return(dims);
 }
 
 

--- a/lib/vdc/UnstructuredGridLayered.cpp
+++ b/lib/vdc/UnstructuredGridLayered.cpp
@@ -55,7 +55,7 @@ UnstructuredGridLayered::UnstructuredGridLayered(const std::vector<size_t> &vert
 
 DimsType UnstructuredGridLayered::GetCoordDimensions(size_t dim) const
 {
-    DimsType dims = {1,1,1};
+    DimsType dims = {1, 1, 1};
 
     if (dim == 0) {
         dims = _ug2d.GetCoordDimensions(dim);
@@ -63,7 +63,7 @@ DimsType UnstructuredGridLayered::GetCoordDimensions(size_t dim) const
         dims = _ug2d.GetCoordDimensions(dim);
     } else if (dim == 2) {
         dims = _zug.GetDimensions();
-    } 
+    }
 
     return (dims);
 }

--- a/lib/vdc/UnstructuredGridLayered.cpp
+++ b/lib/vdc/UnstructuredGridLayered.cpp
@@ -53,20 +53,19 @@ UnstructuredGridLayered::UnstructuredGridLayered(const std::vector<size_t> &vert
     VAssert(location == NODE);
 }
 
-vector<size_t> UnstructuredGridLayered::GetCoordDimensions(size_t dim) const
+DimsType UnstructuredGridLayered::GetCoordDimensions(size_t dim) const
 {
+    DimsType dims = {1,1,1};
+
     if (dim == 0) {
-        return (_ug2d.GetCoordDimensions(dim));
+        dims = _ug2d.GetCoordDimensions(dim);
     } else if (dim == 1) {
-        return (_ug2d.GetCoordDimensions(dim));
+        dims = _ug2d.GetCoordDimensions(dim);
     } else if (dim == 2) {
-        auto tmp = _zug.GetDimensions();
-        auto dims = std::vector<size_t>{tmp[0], tmp[1], tmp[2]};
-        dims.resize(_zug.GetNumDimensions());
-        return dims;
-    } else {
-        return (vector<size_t>(1, 1));
-    }
+        dims = _zug.GetDimensions();
+    } 
+
+    return (dims);
 }
 
 size_t UnstructuredGridLayered::GetGeometryDim() const { return (3); }

--- a/test_apps/pyengine/test_pyengine.cpp
+++ b/test_apps/pyengine/test_pyengine.cpp
@@ -66,9 +66,9 @@ void test_calculate()
     //	string script = "C = sqrt(A) + B";
     string                 script = "C = A + B";
     vector<string>         inputVarNames = {"A", "B"};
-    vector<DimsType> inputVarDims = {dims, dims};
+    vector<DimsType>       inputVarDims = {dims, dims};
     vector<string>         outputVarNames = {"C"};
-    vector<DimsType> outputVarDims = {dims};
+    vector<DimsType>       outputVarDims = {dims};
 
     float *A = new float[vproduct(dims)];
     float *B = new float[vproduct(dims)];

--- a/test_apps/pyengine/test_pyengine.cpp
+++ b/test_apps/pyengine/test_pyengine.cpp
@@ -19,7 +19,7 @@ using namespace std;
 using namespace Wasp;
 using namespace VAPoR;
 
-size_t vproduct(vector<size_t> a)
+size_t vproduct(DimsType a)
 {
     size_t ntotal = 1;
 
@@ -62,13 +62,13 @@ void test_calculate()
     int rc = PyEngine::Initialize();
     if (rc < 0) return;
 
-    vector<size_t> dims = {1000, 1000, 10};
+    DimsType dims = {1000, 1000, 10};
     //	string script = "C = sqrt(A) + B";
     string                 script = "C = A + B";
     vector<string>         inputVarNames = {"A", "B"};
-    vector<vector<size_t>> inputVarDims = {dims, dims};
+    vector<DimsType> inputVarDims = {dims, dims};
     vector<string>         outputVarNames = {"C"};
-    vector<vector<size_t>> outputVarDims = {dims};
+    vector<DimsType> outputVarDims = {dims};
 
     float *A = new float[vproduct(dims)];
     float *B = new float[vproduct(dims)];


### PR DESCRIPTION
Fixed #3059

PyEngine was still using vector<size_t> to represent grid indices.  Converted to DimsType