### PR TITLE
Fixed #2840 - Show the number of cores OpenMP has available to it

### DIFF
--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -1,3 +1,4 @@
+#include <vapor/OpenMPSupport.h>
 #include <QVBoxLayout>
 #include <AppSettingsMenu.h>
 #include <SettingsParams.h>
@@ -87,6 +88,13 @@ public:
 
 AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(), _params(nullptr)
 {
+
+    int nthreads = 1;
+#pragma omp parallel
+    {
+        if (omp_get_thread_num() == 0) nthreads = omp_get_num_threads();
+    }
+
     _settings = new PGroup({
         new PSection("Automatic Session Recovery",
                      {
@@ -101,7 +109,7 @@ AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(
                      {
                          new PCheckboxHLI<SettingsParams>("Check for and show notices on startup", &SettingsParams::GetAutoCheckForNotices, &SettingsParams::SetAutoCheckForNotices),
                          new PCheckboxHLI<SettingsParams>("Automatically stretch domain", &SettingsParams::GetAutoStretchEnabled, &SettingsParams::SetAutoStretchEnabled),
-                         new PCheckbox(SettingsParams::UseAllCoresTag, "Use all available cores for multithreaded tasks"),
+                         new PCheckbox(SettingsParams::UseAllCoresTag, "Use all (" + std::to_string(nthreads) + ") available cores for multithreaded tasks"),
                          new PSubGroup({(new PIntegerInputHLI<SettingsParams>("Limit threads to", &SettingsParams::GetNumThreads, &SettingsParams::SetNumThreads))
                                             ->SetRange(1, 1024)
                                             ->EnableBasedOnParam(SettingsParams::UseAllCoresTag, false)}),

--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -88,7 +88,6 @@ public:
 
 AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(), _params(nullptr)
 {
-
     int nthreads = 1;
 #pragma omp parallel
     {

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -1582,8 +1582,10 @@ void MainForm::helpAbout()
                               "Web site: http://www.vapor.ucar.edu\n"
                               "Contact: vapor@ucar.edu\n"
                               "Version: "
-                            + string(Version::GetFullVersionString().c_str()) + "\n"
-                              "OpenMP Threads: " + std::to_string(nthreads);
+                            + string(Version::GetFullVersionString().c_str())
+                            + "\n"
+                              "OpenMP Threads: "
+                            + std::to_string(nthreads);
 
     _banner = new BannerGUI(this, banner_file_name, -1, true, banner_text.c_str(), "http://www.vapor.ucar.edu");
 }

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -69,7 +69,6 @@
 #include <vapor/DCCF.h>
 #include <vapor/DCBOV.h>
 #include <vapor/DCUGRID.h>
-#include <vapor/OpenMPSupport.h>
 
 
 #include "VizWinMgr.h"
@@ -394,7 +393,6 @@ MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, s
     //
     SettingsParams *sP = GetSettingsParams();
     _controlExec->SetCacheSize(sP->GetCacheMB());
-    _controlExec->SetNumThreads(sP->GetNumThreads());
 
     _vizWinMgr = new VizWinMgr(this, _mdiArea, _controlExec);
 
@@ -489,6 +487,8 @@ MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, s
 
     if (interactive && GetSettingsParams()->GetAutoCheckForUpdates()) CheckForUpdates();
     if (interactive && GetSettingsParams()->GetAutoCheckForNotices()) CheckForNotices();
+
+    _controlExec->SetNumThreads(GetSettingsParams()->GetNumThreads());
 }
 
 
@@ -1567,11 +1567,6 @@ void MainForm::redo()
 
 void MainForm::helpAbout()
 {
-    int nthreads = 1;
-#pragma omp parallel
-    {
-        nthreads = omp_get_num_threads();
-    }
     std::string banner_file_name = "vapor_banner.png";
     if (_banner) delete _banner;
     std::string banner_text = "Visualization and Analysis Platform for atmospheric, Oceanic and "
@@ -1582,10 +1577,7 @@ void MainForm::helpAbout()
                               "Web site: http://www.vapor.ucar.edu\n"
                               "Contact: vapor@ucar.edu\n"
                               "Version: "
-                            + string(Version::GetFullVersionString().c_str())
-                            + "\n"
-                              "OpenMP Threads: "
-                            + std::to_string(nthreads);
+                            + string(Version::GetFullVersionString().c_str());
 
     _banner = new BannerGUI(this, banner_file_name, -1, true, banner_text.c_str(), "http://www.vapor.ucar.edu");
 }

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -69,6 +69,8 @@
 #include <vapor/DCCF.h>
 #include <vapor/DCBOV.h>
 #include <vapor/DCUGRID.h>
+#include <vapor/OpenMPSupport.h>
+
 
 #include "VizWinMgr.h"
 #include "VizSelectCombo.h"
@@ -1565,6 +1567,11 @@ void MainForm::redo()
 
 void MainForm::helpAbout()
 {
+    int nthreads = 1;
+#pragma omp parallel
+    {
+        nthreads = omp_get_num_threads();
+    }
     std::string banner_file_name = "vapor_banner.png";
     if (_banner) delete _banner;
     std::string banner_text = "Visualization and Analysis Platform for atmospheric, Oceanic and "
@@ -1575,7 +1582,8 @@ void MainForm::helpAbout()
                               "Web site: http://www.vapor.ucar.edu\n"
                               "Contact: vapor@ucar.edu\n"
                               "Version: "
-                            + string(Version::GetFullVersionString().c_str());
+                            + string(Version::GetFullVersionString().c_str()) + "\n"
+                              "OpenMP Threads: " + std::to_string(nthreads);
 
     _banner = new BannerGUI(this, banner_file_name, -1, true, banner_text.c_str(), "http://www.vapor.ucar.edu");
 }

--- a/lib/vdc/QuadTreeRectangleP.cpp
+++ b/lib/vdc/QuadTreeRectangleP.cpp
@@ -19,7 +19,7 @@ QuadTreeRectangleP::QuadTreeRectangleP(float left, float top, float right, float
     int nthreads = 1;
 #pragma omp parallel
     {
-        nthreads = omp_get_num_threads();
+        if (omp_get_thread_num() == 0) nthreads = omp_get_num_threads();
     }
 
     // We split the quadtree along the X-axis to create one subtree for


### PR DESCRIPTION
Fixed #2840

The number of cores available to OpenMP (as returned by omp_get_num_threads()) is now displayed under Vapor/About-Vapor. Maybe there is a better place for this?