### PR TITLE
Set default height variable to none when switching dimensions

### DIFF
--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -110,7 +110,10 @@ void RenderParams::SetDefaultVariables(int dim = 3, bool secondaryColormapVariab
     vector<string> fieldVarNames(3, "");
     fieldVarNames[0] = _findVarStartingWithLetter(varnames, 'u');
     fieldVarNames[1] = _findVarStartingWithLetter(varnames, 'v');
-    if (dim == 3) fieldVarNames[2] = _findVarStartingWithLetter(varnames, 'w');
+    if (dim == 3) {
+        fieldVarNames[2] = _findVarStartingWithLetter(varnames, 'w');
+        SetHeightVariableName("");
+    }
 
     SetFieldVariableNames(fieldVarNames);
 


### PR DESCRIPTION
Fixes #3053 by setting the height variable to "none" when switching a renderer from operating on 2D variables to 3D variables.