### PR TITLE
Issue 3085 - DC::GetAttNames() not returning global attributes

### DIFF
--- a/lib/vdc/DCCF.cpp
+++ b/lib/vdc/DCCF.cpp
@@ -21,6 +21,15 @@ using namespace std;
 
 namespace {
 
+DC::XType netcdf_to_dc_xtype(int t) {
+    switch (t) { 
+    case NC_DOUBLE: return(DC::XType::DOUBLE);
+    case NC_INT64: return(DC::XType::INT64);
+    case NC_CHAR: return(DC::XType::TEXT);
+    default: return(DC::XType::INVALID);
+    }
+}
+
 #ifdef UNUSED_FUNCTION
 // Product of elements in a vector
 //
@@ -292,6 +301,11 @@ std::vector<string> DCCF::getAttNames(string varname) const
 
 DC::XType DCCF::getAttType(string varname, string attname) const
 {
+
+    if (varname.empty()) {
+        return(netcdf_to_dc_xtype(_ncdfc->GetAttType("", attname)));
+    }
+
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);
     if (!status) return (DC::INVALID);

--- a/lib/vdc/DCCF.cpp
+++ b/lib/vdc/DCCF.cpp
@@ -236,7 +236,7 @@ template<class T> bool DCCF::_getAttTemplate(string varname, string attname, T &
 {
     if (varname.empty()) {
         _ncdfc->GetAtt("", attname, values);
-        return(true);
+        return (true);
     }
 
     DC::BaseVar var;
@@ -275,7 +275,7 @@ bool DCCF::getAtt(string varname, string attname, string &values) const
 
 std::vector<string> DCCF::getAttNames(string varname) const
 {
-    if (varname.empty()) return(_ncdfc->GetAttNames(""));
+    if (varname.empty()) return (_ncdfc->GetAttNames(""));
 
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);

--- a/lib/vdc/DCCF.cpp
+++ b/lib/vdc/DCCF.cpp
@@ -234,6 +234,11 @@ std::vector<string> DCCF::getAuxVarNames() const
 
 template<class T> bool DCCF::_getAttTemplate(string varname, string attname, T &values) const
 {
+    if (varname.empty()) {
+        _ncdfc->GetAtt("", attname, values);
+        return(true);
+    }
+
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);
     if (!status) return (status);
@@ -270,6 +275,8 @@ bool DCCF::getAtt(string varname, string attname, string &values) const
 
 std::vector<string> DCCF::getAttNames(string varname) const
 {
+    if (varname.empty()) return(_ncdfc->GetAttNames(""));
+
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);
     if (!status) return (vector<string>());

--- a/lib/vdc/DCMPAS.cpp
+++ b/lib/vdc/DCMPAS.cpp
@@ -336,6 +336,11 @@ int DCMPAS::initialize(const vector<string> &files, const std::vector<string> &o
 
 template<class T> bool DCMPAS::_getAttTemplate(string varname, string attname, T &values) const
 {
+    if (varname.empty()) {
+        _ncdfc->GetAtt("", attname, values);
+        return(true);
+    }
+
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);
     if (!status) return (status);
@@ -372,6 +377,8 @@ bool DCMPAS::getAtt(string varname, string attname, string &values) const
 
 std::vector<string> DCMPAS::getAttNames(string varname) const
 {
+    if (varname.empty()) return(_ncdfc->GetAttNames(""));
+
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);
     if (!status) return (vector<string>());

--- a/lib/vdc/DCMPAS.cpp
+++ b/lib/vdc/DCMPAS.cpp
@@ -215,6 +215,16 @@ template<class T> int _xgetVar(NetCDFCollection *ncdfc, size_t ts, string varnam
 
     return (ncdfc->Close(fd));
 }
+
+DC::XType netcdf_to_dc_xtype(int t) {
+    switch (t) {
+    case NC_DOUBLE: return(DC::XType::DOUBLE);
+    case NC_INT64: return(DC::XType::INT64);
+    case NC_CHAR: return(DC::XType::TEXT);
+    default: return(DC::XType::INVALID);
+    }
+}
+
 };    // namespace
 
 DCMPAS::DCMPAS()
@@ -394,6 +404,10 @@ std::vector<string> DCMPAS::getAttNames(string varname) const
 
 DC::XType DCMPAS::getAttType(string varname, string attname) const
 {
+    if (varname.empty()) {
+        return(netcdf_to_dc_xtype(_ncdfc->GetAttType("", attname)));
+    }
+
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);
     if (!status) return (DC::INVALID);

--- a/lib/vdc/DCMPAS.cpp
+++ b/lib/vdc/DCMPAS.cpp
@@ -338,7 +338,7 @@ template<class T> bool DCMPAS::_getAttTemplate(string varname, string attname, T
 {
     if (varname.empty()) {
         _ncdfc->GetAtt("", attname, values);
-        return(true);
+        return (true);
     }
 
     DC::BaseVar var;
@@ -377,7 +377,7 @@ bool DCMPAS::getAtt(string varname, string attname, string &values) const
 
 std::vector<string> DCMPAS::getAttNames(string varname) const
 {
-    if (varname.empty()) return(_ncdfc->GetAttNames(""));
+    if (varname.empty()) return (_ncdfc->GetAttNames(""));
 
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);

--- a/lib/vdc/DCWRF.cpp
+++ b/lib/vdc/DCWRF.cpp
@@ -37,6 +37,15 @@ float read_scalar_float_attr(NetCDFCollection *ncdfc, string varname, string att
     return ((float)dvalues[0]);
 }
 
+DC::XType netcdf_to_dc_xtype(int t) {
+    switch (t) {
+    case NC_DOUBLE: return(DC::XType::DOUBLE);
+    case NC_INT64: return(DC::XType::INT64);
+    case NC_CHAR: return(DC::XType::TEXT);
+    default: return(DC::XType::INVALID);
+    }
+}
+
 };    // namespace
 
 DCWRF::DCWRF()
@@ -323,6 +332,10 @@ std::vector<string> DCWRF::getAttNames(string varname) const
 
 DC::XType DCWRF::getAttType(string varname, string attname) const
 {
+    if (varname.empty()) {
+        return(netcdf_to_dc_xtype(_ncdfc->GetAttType("", attname)));
+    }
+
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);
     if (!status) return (DC::INVALID);

--- a/lib/vdc/DCWRF.cpp
+++ b/lib/vdc/DCWRF.cpp
@@ -265,10 +265,9 @@ std::vector<string> DCWRF::getCoordVarNames() const
 
 template<class T> bool DCWRF::_getAttTemplate(string varname, string attname, T &values) const
 {
-
     if (varname.empty()) {
         _ncdfc->GetAtt("", attname, values);
-        return(true);
+        return (true);
     }
 
     DC::BaseVar var;
@@ -307,8 +306,7 @@ bool DCWRF::getAtt(string varname, string attname, string &values) const
 
 std::vector<string> DCWRF::getAttNames(string varname) const
 {
-
-    if (varname.empty()) return(_ncdfc->GetAttNames(""));
+    if (varname.empty()) return (_ncdfc->GetAttNames(""));
 
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);

--- a/lib/vdc/DCWRF.cpp
+++ b/lib/vdc/DCWRF.cpp
@@ -265,6 +265,12 @@ std::vector<string> DCWRF::getCoordVarNames() const
 
 template<class T> bool DCWRF::_getAttTemplate(string varname, string attname, T &values) const
 {
+
+    if (varname.empty()) {
+        _ncdfc->GetAtt("", attname, values);
+        return(true);
+    }
+
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);
     if (!status) return (status);
@@ -301,6 +307,9 @@ bool DCWRF::getAtt(string varname, string attname, string &values) const
 
 std::vector<string> DCWRF::getAttNames(string varname) const
 {
+
+    if (varname.empty()) return(_ncdfc->GetAttNames(""));
+
     DC::BaseVar var;
     bool        status = getBaseVarInfo(varname, var);
     if (!status) return (vector<string>());


### PR DESCRIPTION
Fixes #3085 

Accessing global attributes was never implemented by the DC* classes.