### PR TITLE
Clang tidy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
             newBody=""
             newBody=${lineArray[@]//\\n/\\r\\n}              # Add windows carraige return \r on line endings
 
-            newBody="${newBody}\r\n${artifacts}"
+            newBody="${newBody}\r\n\r\n${artifacts}"
             json="{\"body\":\"$newBody\"}"                   # Apply our re-written PR body in json format
 
             # Add linke to PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
             newBody=""
             newBody=${lineArray[@]//\\n/\\r\\n}              # Add windows carraige return \r on line endings
 
-            newBody="${newBody}\r\n\r\nStatic analysis for committ ${CIRCLE_SHA1}:\r\n${artifacts}"
+            newBody="${newBody}\r\n\r\nStatic analysis for commit ${CIRCLE_SHA1}:\r\n${artifacts}"
             json="{\"body\":\"$newBody\"}"                   # Apply our re-written PR body in json format
 
             # Add linke to PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
             newBody=""
             newBody=${lineArray[@]//\\n/\\r\\n}              # Add windows carraige return \r on line endings
 
-            newBody="${newBody}\r\n\r\n${artifacts}"
+            newBody="${newBody}\r\n\r\nStatic analysis for committ ${CIRCLE_SHA1}${artifacts}"
             json="{\"body\":\"$newBody\"}"                   # Apply our re-written PR body in json format
 
             # Add linke to PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,54 +201,51 @@ jobs:
 
   clang-tidy:
     docker:
-      - image: sgpearse/vapor3-ubuntu18:latest
+      - image: ubuntu:latest
 
     steps:
       - run:
-          name: Check for PR
+          name: Install dependencies
           command: |
             apt-get update
-            apt-get install -y jq
-
-            pr_response=$(curl --location --request GET \
-                "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" \
-                -u $GH_USER:$GITHUB_TOKEN)
-
-            if [ $(echo $pr_response | jq length) -eq 0 ]; then
-              echo "No PR found to update"
-              exit 0
-            fi
+            apt upgrade -y
+            apt install -y aptitude
+            aptitude install -y xz-utils pip git curl jq cmake cmake-curses-gui freeglut3-dev libexpat1-dev libglib2.0-0 libdbus-1-3 lsb-release wget software-properties-common clang-tidy
+            pip install gdown
 
       - run:
-          name: install clang-tidy
+          name: Install llvm
           command: |
-            apt-get update
-            apt-get install -y clang
-            apt-get install -y clang-tidy-10
+            add-apt-repository -y universe
+            wget https://apt.llvm.org/llvm.sh
+            chmod +x llvm.sh
+            yes '' | ./llvm.sh 14 || if [[ $? -eq 141 ]]; then true; else exit $?; fi # Feed "yes" to all of the script's questions and igore error 141
+
+      - run: 
+          name: Get third party libraries
+          command: |
+            mkdir -p /usr/local/VAPOR-Deps
+            cd /usr/local/VAPOR-Deps
+            gdown https://drive.google.com/uc?id=1elB8v-UNMzkNmnsJPtxk3cI1zBelJ3Hd
+            tar xf 2019-Aug-Ubuntu.tar.xz
 
       - run:
-          name: clang-tidy
+          name: Run clang-tidy
           command: |
             git clone https://github.com/NCAR/VAPOR.git /root/VAPOR
             cd /root/VAPOR
             git checkout $CIRCLE_BRANCH
-            cmake .            
+            apt install -y libomp-dev
+            cmake . \
+            -DCMAKE_BUILD_TYPE:String=Release \
+            -DCMAKE_CXX_COMPILER=clang++-14 \
+            -DCMAKE_C_COMPILER=clang-14 \
+            -DBUILD_TEST_APPS=ON \
+            -DUSE_OMP=ON
             make -j4
             git diff $(git merge-base --fork-point origin/main HEAD) HEAD | \
-            /usr/lib/llvm-10/share/clang/clang-tidy-diff.py -path /root/VAPOR -p1 -checks=cppcoreguidelines* 2>&1    | \
+            /usr/bin/clang-tidy-diff-14.py -path /root/VAPOR -p1 -checks=cppcoreguidelines* 2>&1    | \
             tee /tmp/clangTidyOutput.txt
-
-      - run:
-          name: check for clang-tidy warnings
-          command: |
-            while read line; do
-              if [[ "$line" == *"warning"* ]]; then
-                if [[ "$line" != *"generated"* || "$line" != *"Supressed"* ]]; then
-                  #exit -1
-                  exit 0 
-                fi
-              fi
-            done < /tmp/clangTidyOutput.txt
 
       - store_artifacts:
           path: /tmp/clangTidyOutput.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
             newBody=""
             newBody=${lineArray[@]//\\n/\\r\\n}              # Add windows carraige return \r on line endings
 
-            newBody="${newBody}\r\n\r\nStatic analysis for committ ${CIRCLE_SHA1}${artifacts}"
+            newBody="${newBody}\r\n\r\nStatic analysis for committ ${CIRCLE_SHA1}:\r\n${artifacts}"
             json="{\"body\":\"$newBody\"}"                   # Apply our re-written PR body in json format
 
             # Add linke to PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,8 @@ jobs:
             # If clang-tidy has already been reported in this PR, remove that report
             if [[ "${lineArray[-1]}" == *"clangTidyOutput.txt"* ]]; then
                 echo "  *** Previous clangTidyOutput.txt report found.  Replacing with new version. ***"
-                unset lineArray[-1]
+                unset lineArray[-1]  # delete line with commit hash
+                unset lineArray[-1]  # delete line with clangTidyOutput.txt
             else
                 lineArray+=("\\n\\n")
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
             newBody=""
             newBody=${lineArray[@]//\\n/\\r\\n}              # Add windows carraige return \r on line endings
 
-            newBody="${newBody}\r\n\r\nStatic analysis for commit ${CIRCLE_SHA1}:\r\n${artifacts}"
+            newBody="${newBody}\r\n\r\n${CIRCLE_SHA1}:${artifacts}"
             json="{\"body\":\"$newBody\"}"                   # Apply our re-written PR body in json format
 
             # Add linke to PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,7 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             -u "$GITHUB_TOKEN:" | jq '.items[0].url')
             artifacts="${artifacts//\"}"                         # remove quotes from string
-            artifacts=" [clangTidyOutput.txt]($artifacts)"       # make hyperlink
+            artifacts=" [clangTidyOutput.txt]($artifacts)"       # make hyperlink 
 
             # Temporarily remove windows carraige return \r
             originalBody=$(curl https://api.github.com/repos/NCAR/VAPOR/pulls/${CIRCLE_PULL_REQUEST##*/} | jq '.body')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,111 @@ jobs:
           paths:
             - installers
 
+  clang-tidy:
+    docker:
+      - image: sgpearse/vapor3-ubuntu18:latest
+
+    steps:
+      - run:
+          name: Check for PR
+          command: |
+            apt-get update
+            apt-get install -y jq
+
+            pr_response=$(curl --location --request GET \
+                "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" \
+                -u $GH_USER:$GITHUB_TOKEN)
+
+            if [ $(echo $pr_response | jq length) -eq 0 ]; then
+              echo "No PR found to update"
+              exit 0
+            fi
+
+      - run:
+          name: install clang-tidy
+          command: |
+            apt-get update
+            apt-get install -y clang
+            apt-get install -y clang-tidy-10
+
+      - run:
+          name: clang-tidy
+          command: |
+            git clone https://github.com/NCAR/VAPOR.git /root/VAPOR
+            cd /root/VAPOR
+            git checkout $CIRCLE_BRANCH
+            cmake .            
+            make -j4
+            git diff $(git merge-base --fork-point origin/main HEAD) HEAD | \
+            /usr/lib/llvm-10/share/clang/clang-tidy-diff.py -path /root/VAPOR -p1 -checks=cppcoreguidelines* 2>&1    | \
+            tee /tmp/clangTidyOutput.txt
+
+      - run:
+          name: check for clang-tidy warnings
+          command: |
+            while read line; do
+              if [[ "$line" == *"warning"* ]]; then
+                if [[ "$line" != *"generated"* || "$line" != *"Supressed"* ]]; then
+                  #exit -1
+                  exit 0 
+                fi
+              fi
+            done < /tmp/clangTidyOutput.txt
+
+      - store_artifacts:
+          path: /tmp/clangTidyOutput.txt
+
+      - run:
+          name: Copy artifact link to PR
+          command: |
+            # acquire clang-tidy report artifact
+            artifacts=$(curl \
+            -X GET "https://circleci.com/api/v2/project/github/NCAR/VAPOR/$CIRCLE_BUILD_NUM/artifacts" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -u "$GITHUB_TOKEN:" | jq '.items[0].url')
+            artifacts="${artifacts//\"}"                         # remove quotes from string
+            artifacts=" [clangTidyOutput.txt]($artifacts)"       # make hyperlink
+
+            # Temporarily remove windows carraige return \r
+            originalBody=$(curl https://api.github.com/repos/NCAR/VAPOR/pulls/${CIRCLE_PULL_REQUEST##*/} | jq '.body')
+            lineArray=(${originalBody//\\r\\n/\\n})
+
+            # Remove leading " at the start of the first element
+            firstElement=${lineArray[0]}
+            if [[ ${firstElement::1} == "\"" ]]
+            then
+                lineArray[0]="${firstElement:1}"
+            fi
+
+            # Remove trailing " at the end of the last element
+            lastElement=${lineArray[-1]}
+            if [[ ${lastElement: -1} == "\"" ]]
+            then
+                lineArray[-1]=${lastElement::-1}
+            fi
+
+            # If clang-tidy has already been reported in this PR, remove that report
+            if [[ "${lineArray[-1]}" == *"clangTidyOutput.txt"* ]]; then
+                echo "  *** Previous clangTidyOutput.txt report found.  Replacing with new version. ***"
+                unset lineArray[-1]
+            else
+                lineArray+=("\\n\\n")
+            fi
+
+            newBody=""
+            newBody=${lineArray[@]//\\n/\\r\\n}              # Add windows carraige return \r on line endings
+
+            newBody="${newBody}${artifacts}"
+            json="{\"body\":\"$newBody\"}"                   # Apply our re-written PR body in json format
+
+            # Add linke to PR
+            curl \
+            -X PATCH \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token $CIRCLE_CLANG_TIDY_TOKEN" \
+            https://api.github.com/repos/NCAR/VAPOR/issues/${CIRCLE_PULL_REQUEST##*/} \
+            -d "$json"
+
   build_ubuntu18:
     docker:
       - image: sgpearse/vapor3-ubuntu18:latest
@@ -470,8 +575,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_ubuntu18
-      - build_centos7
+      - clang-tidy
+      #- build_ubuntu18
+      #- build_centos7
+      #- foo
       #- test_clang_format
       #- build_win10_installer
       #- build_osx_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
             newBody=""
             newBody=${lineArray[@]//\\n/\\r\\n}              # Add windows carraige return \r on line endings
 
-            newBody="${newBody}${artifacts}"
+            newBody="${newBody}\r\n${artifacts}"
             json="{\"body\":\"$newBody\"}"                   # Apply our re-written PR body in json format
 
             # Add linke to PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,8 +573,8 @@ workflows:
   build:
     jobs:
       - clang-tidy
-      #- build_ubuntu18
-      #- build_centos7
+      - build_ubuntu18
+      - build_centos7
       #- foo
       #- test_clang_format
       #- build_win10_installer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ include (buildutils/OpenMPInstaller.cmake)
 
 set (CMAKE_CXX_STANDARD 11)
 
+set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
 	# Set the possible values of build type for cmake-gui
@@ -109,8 +111,8 @@ include (site_files/site.NCAR OPTIONAL)
 include (site.local           OPTIONAL)
 
 include_directories ("${PROJECT_SOURCE_DIR}/include")
-include_directories (${THIRD_PARTY_INC_DIR})
-include_directories (${THIRD_PARTY_INC_DIR}/freetype2)
+include_directories (SYSTEM ${THIRD_PARTY_INC_DIR})
+include_directories (SYSTEM ${THIRD_PARTY_INC_DIR}/freetype2)
 link_directories (${THIRD_PARTY_LIB_DIR})
 link_directories (${PYTHONPATH})
 list (APPEND CMAKE_PREFIX_PATH ${THIRD_PARTY_LIB_DIR})
@@ -120,11 +122,11 @@ if (WIN32)
 	include_directories (${NUMPY_INCLUDE_DIR})
 	get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
 else ()
-	include_directories (${THIRD_PARTY_INC_DIR}/python${PYTHONVERSION}m)
+	include_directories (SYSTEM ${THIRD_PARTY_INC_DIR}/python${PYTHONVERSION}m)
 
     # I'm not sure why we only have include files for python3.6, and not python3.6m.
     # 
-	include_directories (${THIRD_PARTY_LIB_DIR}/python${PYTHONVERSION}/site-packages/numpy/core/include)
+	include_directories (SYSTEM ${THIRD_PARTY_LIB_DIR}/python${PYTHONVERSION}/site-packages/numpy/core/include)
 endif ()
 if (BUILD_VDC)
 	link_directories (${PYTHONPATH}/lib-dynload)
@@ -138,7 +140,7 @@ find_library(JPEG jpeg)
 
 if (BUILD_GUI)
 	find_package (OpenGL REQUIRED)
-	include_directories (${OPENGL_INCLUDE_DIRS})
+	include_directories (SYSTEM ${OPENGL_INCLUDE_DIRS})
 	if (WIN32)
 		find_library (GLEW glew32)
 	else ()


### PR DESCRIPTION
Fixes #2759.

This PR adds a clang-tidy check on differences between the current branch and the **base** of the current branch. This uses checks based on the c++ core guidelines.

Note the "SYSTEM" keyword that has been added to our system include directories in CMakeLists.txt. This replaces the -I compile flag with -isystem, which prevents clang-tidy from scanning system files. Additionally, the CMAKE_EXPORT_COMPILE_COMMANDS has been added, which generates a json file of the build commands for each compilation unit. This is needed for clang-tidy as well.

A **post-commit** hook can be implemented by putting the following command in VAPOR/.git/hooks/pre-commit. Replace /usr/local/opt/llvm/share/clang/clang-tidy-diff.py with the path to your installed clang-tidy-diff.py script, and replace /Users/pearse/VAPOR2/build with the path to your build directory.

#!/bin/sh
git diff $(git merge-base --fork-point origin/main HEAD) **~/VAPOR** | \
**/usr/local/opt/llvm/share/clang/clang-tidy-diff.py** -path **~/VAPOR/build** -p1 -checks=cppcoreguidelines* 2>&1 | \
tee 



a17eba4fffcf4e9b2d63d91c213ec50fca05493d: [clangTidyOutput.txt](https://output.circle-artifacts.com/output/job/7ccff233-953b-441a-8d81-12b498148372/artifacts/0/tmp/clangTidyOutput.txt)