### PR TITLE
Update citation information

### DIFF
--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -1,0 +1,23 @@
+Citation
+________
+
+VAPOR is developed as an Open Source application by the National Center for Atmospheric Research, under the sponsorship of the National Science Foundation. Continued support for VAPOR is de
+pendent on demonstrable evidence of the software's value to the scientific community. You are free to use VAPOR as permitted under the terms and conditions of the license. We kindly request, however, that you cite VAPOR in your publications and presentations. We suggest the following citations as appropriate:
+
+For journal articles, proceedings, etc.,
+we request:
+
+**Visualization & Analysis Systems Technologies. (2022) Visualization and Analysis Platform for Ocean, Atmosphere, and Solar Researchers (VAPOR version 3.6.1) [Software].  Boulder, CO: UCAR/NCAR - Computational and Information System Lab.  doi:10.5065/d6j38qhc**
+
+For presentations, posters, etc.,
+we suggest:
+
+::
+
+    Imagery produced by VAPOR (www.vapor.ucar.edu), a product of the Computational Information Systems Laboratory at the National Center for Atmospheric Research
+
+or simply the URL when space does not permit otherwise:
+
+::
+
+   www.vapor.ucar.edu

--- a/docs/downloads/downloads.rst
+++ b/docs/downloads/downloads.rst
@@ -19,3 +19,5 @@ Installation Instructions
     installationInstructions/osxInstallation.rst
     installationInstructions/linuxInstallation.rst
     installationInstructions/windowsInstallation.rst
+
+.. include:: ../citation.rst

--- a/docs/licenseAndCitation.rst
+++ b/docs/licenseAndCitation.rst
@@ -86,45 +86,4 @@ Vapor 3 makes use of the third party software listed below.  In addition to the 
 | GetGitRevisionDescription.cmake | :ref:`Boost V1 <boostLicense>`        |
 +---------------------------------+---------------------------------------+
 
-
-
-.. _citation:
-
-Citation
-________
-
-VAPOR is developed as an Open Source application by the National Center for Atmospheric Research, under the sponsorship of the National Science Foundation. Continued support for VAPOR is dependent on demonstrable evidence of the software's value to the scientific community. You are free to use VAPOR as permitted under the terms and conditions of the license. We kindly request, however, that you cite VAPOR in your publications and presentations. We suggest the following citations as appropriate:
-
-For journal articles, proceedings, etc.,
-we request:
-
-    Li, Shaomeng; Jaroszynski, Stanislaw; Pearse, Scott; Orf, Leigh; Clyne, John. 2019. "VAPOR: A Visualization Package Tailored to Analyze Simulation Data in Earth System Science." *Atmosphere* 10, no. 9: 488. 
-
-::
-
-    @Article{atmos10090488,
-    AUTHOR = {Li, Shaomeng and Jaroszynski, Stanislaw and Pearse, Scott and Orf, Leigh and Clyne, John},
-    TITLE = {VAPOR: A Visualization Package Tailored to Analyze Simulation Data in Earth System Science},
-    JOURNAL = {Atmosphere},
-    VOLUME = {10},
-    YEAR = {2019},
-    NUMBER = {9},
-    ARTICLE-NUMBER = {488},
-    URL = {https://www.mdpi.com/2073-4433/10/9/488},
-    ISSN = {2073-4433},
-    DOI = {10.3390/atmos10090488}
-    }
-
-
-For presentations, posters, etc.,
-we suggest:
-
-::
-
-    Imagery produced by VAPOR (www.vapor.ucar.edu), a product of the Computational Information Systems Laboratory at the National Center for Atmospheric Research
-
-or simply the URL when space does not permit otherwise:
-
-:: 
-
-   www.vapor.ucar.edu
+.. include:: citation.rst


### PR DESCRIPTION
This PR adds citation information to Vapor's downloads webpage, to comply with software reproducibility guidelines #3084.

[Downloads page w/ citation](https://vapor.readthedocs.io/en/issue_3084part1/downloads/downloads.html)
[Downloads page w/o citation](https://vapor.readthedocs.io/en/readthedocs/downloads/downloads.html)