### PR TITLE
Update cmake on Ubuntu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -616,11 +616,11 @@ workflows:
     jobs:
       - clang-tidy
       - build_ubuntu18
-      #- build_centos7
-      - test_clang_format
+      - build_centos7
+      #- test_clang_format
       #- build_win10_installer
       #- build_osx_installer
-      - build_ubuntu18_installer
+      #- build_ubuntu18_installer
       #- build_centos7_installer
       #- release_weekly_installers:
       #    requires:


### PR DESCRIPTION
Updates our CircleCI build systems to cmake's latest version provided by pip. Currently 3.22.5.

Installation log can be found [here](https://app.circleci.com/pipelines/github/NCAR/VAPOR/5780/workflows/f2fc453e-f619-4ade-a657-4c0652adec89/jobs/13713/parallel-runs/0/steps/0-103).