### PR TITLE
Remove macro from ParticleRenderer.h

### DIFF
--- a/include/vapor/ParticleRenderer.h
+++ b/include/vapor/ParticleRenderer.h
@@ -20,21 +20,8 @@
 #ifndef ParticleRENDERER_H
 #define ParticleRENDERER_H
 
-//<<<<<<< HEAD
-//#include <GL/glew.h>
 #include <glm/glm.hpp>
 #include <vapor/glutil.h>
-#ifdef Darwin
-    #include <OpenGL/gl.h>
-    #include <OpenGL/glu.h>
-#else
-    #include <GL/gl.h>
-    #include <GL/glu.h>
-#endif
-
-//=======
-//#include <vapor/glutil.h>
-//>>>>>>> main
 #include "vapor/VAssert.h"
 
 #include <vapor/Renderer.h>


### PR DESCRIPTION
This slipped by in the glyph PR.  It does not break Vapor's build, but it does break the build for generating the conda tar.bz2 package.