### PR TITLE
more refined bias controls

### DIFF
--- a/apps/vaporgui/FlowEventRouter.cpp
+++ b/apps/vaporgui/FlowEventRouter.cpp
@@ -59,7 +59,7 @@ FlowEventRouter::FlowEventRouter(QWidget *parent, ControlExec *ce) : RenderEvent
             }),
             (new PShowIf(FP::_seedGenModeTag))->Equals((int)FlowSeedMode::RANDOM_BIAS)->Then({
                 (new PIntegerSliderEdit(FP::_randomNumOfSeedsTag, "Seed count"))->SetRange(1, 500),
-                (new PIntegerSliderEdit(FP::_rakeBiasStrength, "Bias weight"))->SetRange(-100, 100),
+                (new PIntegerSliderEdit(FP::_rakeBiasStrength, "Bias weight"))->SetRange(-10000, 10000),
                 new PVariableSelector(FP::_rakeBiasVariable, "Bias Variable")
             }),
             (new PShowIf(FP::_seedGenModeTag))->Equals((int)FlowSeedMode::LIST)->Then({

--- a/apps/vaporgui/FlowEventRouter.cpp
+++ b/apps/vaporgui/FlowEventRouter.cpp
@@ -59,7 +59,8 @@ FlowEventRouter::FlowEventRouter(QWidget *parent, ControlExec *ce) : RenderEvent
             }),
             (new PShowIf(FP::_seedGenModeTag))->Equals((int)FlowSeedMode::RANDOM_BIAS)->Then({
                 (new PIntegerSliderEdit(FP::_randomNumOfSeedsTag, "Seed count"))->SetRange(1, 500),
-                (new PIntegerSliderEdit(FP::_rakeBiasStrength, "Bias weight"))->SetRange(-10000, 10000),
+                (new PIntegerSliderEdit(FP::_rakeBiasStrength, "Bias weight"))->SetRange(-10000, 10000)
+                     ->AllowUserRange(true),
                 new PVariableSelector(FP::_rakeBiasVariable, "Bias Variable")
             }),
             (new PShowIf(FP::_seedGenModeTag))->Equals((int)FlowSeedMode::LIST)->Then({

--- a/lib/render/FlowRenderer.cpp
+++ b/lib/render/FlowRenderer.cpp
@@ -882,7 +882,7 @@ int FlowRenderer::_updateFlowCacheAndStates(const FlowParams *params)
 
     // Check the bias variable and bias strength
     const auto rakeBiasVariable = params->GetRakeBiasVariable();
-    const auto rakeBiasStrength = params->GetRakeBiasStrength() * 100;
+    const auto rakeBiasStrength = params->GetRakeBiasStrength();
     if (_cache_rakeBiasStrength != rakeBiasStrength || _cache_rakeBiasVariable.compare(rakeBiasVariable) != 0) {
         _cache_rakeBiasVariable = rakeBiasVariable;
         _cache_rakeBiasStrength = rakeBiasStrength;


### PR DESCRIPTION
This PR adjusts the flow seed bias control, so that 
1) The new control adjusts at 1/100 of the old refinement level, and
2) The new control exhibits the same adjustment range of the old control. 

Fix

56ea70a715fe2c1e01270a436c77f00587c9b364: [clangTidyOutput.txt](https://output.circle-artifacts.com/output/job/b579e3f2-4d9a-4f5c-b3a7-b1774c0a68dd/artifacts/0/tmp/clangTidyOutput.txt)