### PR TITLE
change random num. of seed maximum to 2500

### DIFF
--- a/apps/vaporgui/FlowEventRouter.cpp
+++ b/apps/vaporgui/FlowEventRouter.cpp
@@ -55,10 +55,12 @@ FlowEventRouter::FlowEventRouter(QWidget *parent, ControlExec *ce) : RenderEvent
                 (new PIntegerSliderEdit(FP::_zGridNumOfSeedsTag, "Z axis seeds"))->SetRange(1, 50),
             }),
             (new PShowIf(FP::_seedGenModeTag))->Equals((int)FlowSeedMode::RANDOM)->Then({
-                (new PIntegerSliderEdit(FP::_randomNumOfSeedsTag, "Seed count"))->SetRange(1, 2500),
+                (new PIntegerSliderEdit(FP::_randomNumOfSeedsTag, "Seed count"))->SetRange(1, 2500)
+                 ->AllowUserRange(true),
             }),
             (new PShowIf(FP::_seedGenModeTag))->Equals((int)FlowSeedMode::RANDOM_BIAS)->Then({
-                (new PIntegerSliderEdit(FP::_randomNumOfSeedsTag, "Seed count"))->SetRange(1, 2500),
+                (new PIntegerSliderEdit(FP::_randomNumOfSeedsTag, "Seed count"))->SetRange(1, 2500)
+                ->AllowUserRange(true),
                 (new PIntegerSliderEdit(FP::_rakeBiasStrength, "Bias weight"))->SetRange(-100, 100),
                 new PVariableSelector(FP::_rakeBiasVariable, "Bias Variable")
             }),

--- a/apps/vaporgui/FlowEventRouter.cpp
+++ b/apps/vaporgui/FlowEventRouter.cpp
@@ -55,10 +55,10 @@ FlowEventRouter::FlowEventRouter(QWidget *parent, ControlExec *ce) : RenderEvent
                 (new PIntegerSliderEdit(FP::_zGridNumOfSeedsTag, "Z axis seeds"))->SetRange(1, 50),
             }),
             (new PShowIf(FP::_seedGenModeTag))->Equals((int)FlowSeedMode::RANDOM)->Then({
-                (new PIntegerSliderEdit(FP::_randomNumOfSeedsTag, "Seed count"))->SetRange(1, 500),
+                (new PIntegerSliderEdit(FP::_randomNumOfSeedsTag, "Seed count"))->SetRange(1, 2500),
             }),
             (new PShowIf(FP::_seedGenModeTag))->Equals((int)FlowSeedMode::RANDOM_BIAS)->Then({
-                (new PIntegerSliderEdit(FP::_randomNumOfSeedsTag, "Seed count"))->SetRange(1, 500),
+                (new PIntegerSliderEdit(FP::_randomNumOfSeedsTag, "Seed count"))->SetRange(1, 2500),
                 (new PIntegerSliderEdit(FP::_rakeBiasStrength, "Bias weight"))->SetRange(-100, 100),
                 new PVariableSelector(FP::_rakeBiasVariable, "Bias Variable")
             }),


### PR DESCRIPTION
This PR changes the maximum number of seeds from 500 to 2500, in both Random and Random w/ Bias modes.

Fix #3115

98cabd1894a06f3ecd4961a203673b4d3566fb4c: [clangTidyOutput.txt](https://output.circle-artifacts.com/output/job/0aafb690-714f-47e0-86e8-000ef84b1e89/artifacts/0/tmp/clangTidyOutput.txt)