### PR TITLE
Fix CI build tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,13 +154,18 @@ jobs:
       - checkout
 
       - run:
-          name: update cmake
+          name: update 3rd party libraries
           command: |
-            apt-get update
-            apt remove -y --purge --auto-remove cmake
-            apt-get install -y python3-pip
-            pip3 install cmake --upgrade
-
+            rm -rf /usr/local/VAPOR-Deps/2019-Aug
+            apt update
+            apt install -y python3-pip
+            pip3 install --upgrade pip
+            pip3 install scikit-build command
+            pip3 install gdown
+            gdown https://drive.google.com/uc?id=1elB8v-UNMzkNmnsJPtxk3cI1zBelJ3Hd
+            filename="/root/project/2019-Aug-Ubuntu.tar.xz"
+            tar -xf ${filename} -C /usr/local/VAPOR-Deps
+ 
       - run:
           name: make installer
           command: |
@@ -187,7 +192,16 @@ jobs:
   
     steps:
       - checkout
-  
+
+      - run:
+          name: update 3rd party libraries
+          command: |
+            rm -rf /usr/local/VAPOR-Deps/2019-Aug
+            pip3 install gdown --upgrade
+            gdown https://drive.google.com/uc?id=1In3Q8fA0VCm2en1ncBQI6dzUfatLDA0y
+            filename="/root/project/2019-Aug-CentOS.tar.xz"
+            bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
+ 
       - run:
           name: cmake3 and make
           command: |
@@ -220,14 +234,6 @@ jobs:
             apt install -y aptitude
             aptitude install -y xz-utils pip git curl jq cmake cmake-curses-gui freeglut3-dev libexpat1-dev libglib2.0-0 libdbus-1-3 lsb-release wget software-properties-common clang-tidy
             pip install gdown
-
-      - run:
-          name: update cmake
-          command: |
-            apt-get update
-            apt remove -y --purge --auto-remove cmake
-            apt-get install -y python3-pip
-            pip3 install cmake --upgrade
 
       - run:
           name: Install llvm
@@ -328,16 +334,20 @@ jobs:
           command: |
             apt-get update
             apt-get install -y python3
+            apt install -y python3-pip
+            pip3 install --upgrade pip
+            pip3 install scikit-build command
       - checkout
 
       - run:
-          name: update cmake
+          name: update 3rd party libraries
           command: |
-            apt-get update
-            apt remove -y --purge --auto-remove cmake
-            apt-get install -y python3-pip
-            pip3 install cmake --upgrade
-
+            rm -rf /usr/local/VAPOR-Deps/2019-Aug
+            pip3 install gdown --upgrade
+            gdown https://drive.google.com/uc?id=1elB8v-UNMzkNmnsJPtxk3cI1zBelJ3Hd
+            filename="/root/project/2019-Aug-Ubuntu.tar.xz"
+            tar -xf ${filename} -C /usr/local/VAPOR-Deps
+ 
       - run:
           name: make debug
           command: |
@@ -432,6 +442,15 @@ jobs:
         - checkout
   
         - run:
+            name: update 3rd party libraries
+            command: |
+              rm -rf /usr/local/VAPOR-Deps/2019-Aug
+              pip3 install gdown --upgrade
+              gdown https://drive.google.com/uc?id=1In3Q8fA0VCm2en1ncBQI6dzUfatLDA0y
+              filename="/root/project/2019-Aug-CentOS.tar.xz"
+              bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
+ 
+        - run:
             name: make debug
             command: |
               cd /root/project/build
@@ -501,16 +520,7 @@ jobs:
             apt-get update
             apt-get install -y clang-format-11
             apt-get install -y git
-
       - checkout
-
-      - run:
-          name: update cmake
-          command: |
-            apt-get update
-            apt remove -y --purge --auto-remove cmake
-            apt-get install -y python3-pip
-            pip3 install cmake --upgrade
 
       - run:
           name: run clang-format
@@ -546,14 +556,6 @@ jobs:
 
     steps:
       - checkout
-
-      - run:
-          name: update cmake
-          command: |
-            apt-get update
-            apt remove -y --purge --auto-remove cmake
-            apt-get install -y python3-pip
-            pip3 install cmake --upgrade
 
       - run:
           name: cmake and make
@@ -614,12 +616,13 @@ workflows:
   version: 2
   build:
     jobs:
-      - clang-tidy
+      #- clang-tidy
       - build_ubuntu18
-      - build_centos7
+      #- build_centos7
+      #- foo
       #- test_clang_format
       #- build_win10_installer
-      #- build_osx_installer
+      - build_osx_installer
       #- build_ubuntu18_installer
       #- build_centos7_installer
       #- release_weekly_installers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
           command: |
             rm -rf /usr/local/VAPOR-Deps/2019-Aug
             pip3 install gdown --upgrade
-            gdown https://drive.google.com/uc?id=1In3Q8fA0VCm2en1ncBQI6dzUfatLDA0y
+            gdown https://drive.google.com/uc?id=1S9DwySMnQrBuUUZGKolD__WQrjTmLgyn
             filename="/root/project/2019-Aug-CentOS.tar.xz"
             bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
  
@@ -467,7 +467,7 @@ jobs:
             command: |
               rm -rf /usr/local/VAPOR-Deps/2019-Aug
               pip3 install gdown --upgrade
-              gdown https://drive.google.com/uc?id=1In3Q8fA0VCm2en1ncBQI6dzUfatLDA0y
+              gdown https://drive.google.com/uc?id=1S9DwySMnQrBuUUZGKolD__WQrjTmLgyn
               filename="/root/project/2019-Aug-CentOS.tar.xz"
               bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,16 @@ jobs:
             tar -xf ${filename} -C /usr/local/VAPOR-Deps
  
       - run:
+          name: update cmake
+          command: |
+            apt remove -y --purge --auto-remove cmake
+            apt install -y libssl-dev
+            apt install -y build-essential git
+            git clone https://github.com/Kitware/CMake/
+            cd CMake
+            ./bootstrap && make && make install
+
+      - run:
           name: make installer
           command: |
             cd /root/project/build
@@ -627,13 +637,13 @@ workflows:
   version: 2
   build:
     jobs:
-      #- clang-tidy
+      - clang-tidy
       - build_ubuntu18
-      #- build_centos7
+      - build_centos7
       #- foo
       #- test_clang_format
       #- build_win10_installer
-      - build_osx_installer
+      #- build_osx_installer
       #- build_ubuntu18_installer
       #- build_centos7_installer
       #- release_weekly_installers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,16 +341,12 @@ jobs:
       - run:
           name: update cmake
           command: |
-            apt remove --purge --auto-remove cmake
-            apt update && \
-            apt install -y software-properties-common lsb-release && \
-            apt clean all
-            wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-            sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
-            apt install kitware-archive-keyring
-            rm /etc/apt/trusted.gpg.d/kitware.gpg
-            apt update
-            apt install cmake
+            apt remove -y --purge --auto-remove cmake
+            apt install -y libssl-dev
+            apt install build-essential git
+            git clone https://github.com/Kitware/CMake/
+            cd CMake
+            ./bootstrap && make && sudo make install
 
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ jobs:
           command: |
             apt remove -y --purge --auto-remove cmake
             apt install -y libssl-dev
-            apt install build-essential git
+            apt install -y build-essential git
             git clone https://github.com/Kitware/CMake/
             cd CMake
             ./bootstrap && make && sudo make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,6 +337,21 @@ jobs:
             apt install -y python3-pip
             pip3 install --upgrade pip
             pip3 install scikit-build command
+
+      - run:
+          name: update cmake
+          command: |
+            apt remove --purge --auto-remove cmake
+            apt update && \
+            apt install -y software-properties-common lsb-release && \
+            apt clean all
+            wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+            sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
+            apt install kitware-archive-keyring
+            rm /etc/apt/trusted.gpg.d/kitware.gpg
+            apt update
+            apt install cmake
+
       - checkout
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
 
   build_osx_installer:
     macos:
-      xcode: "13.2.0"
+      xcode: "13.4.1"
     steps:
       - run:
           name: Make VAPOR-Deps
@@ -346,7 +346,7 @@ jobs:
             apt install -y build-essential git
             git clone https://github.com/Kitware/CMake/
             cd CMake
-            ./bootstrap && make && sudo make install
+            ./bootstrap && make && make install
 
       - checkout
 
@@ -585,7 +585,7 @@ jobs:
 
   release_weekly_installers:
     macos:
-      xcode: "12.4.0"
+      xcode: "13.4.1"
     steps:
       - checkout
       #- run:


### PR DESCRIPTION
This fixes builds and warning checks on Ubuntu and Centos.  OSX is still broken though.  Work-in-progress code is included for fixing OSX in this PR.

Fixes #3170.