### PR TITLE
Add conda build check on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,52 @@ jobs:
             https://api.github.com/repos/NCAR/VAPOR/issues/${CIRCLE_PULL_REQUEST##*/} \
             -d "$json"
 
+  build_python_api2:
+    docker:
+      - image: sgpearse/vapor3-centos7:latest
+
+    steps:
+      - run:
+          name: install python
+          command: |
+            yum update
+            yum install -y python3
+            yum install -y python3-pip
+            pip3 install --upgrade pip
+            pip3 install scikit-build command
+
+      - run:
+          name: update cmake
+          command: |
+            #apt remove -y --purge --auto-remove cmake
+            #apt install -y libssl-dev
+            #apt install -y build-essential git
+            #git clone https://github.com/Kitware/CMake/
+            #cd CMake
+            #./bootstrap && make && make install
+
+      - run:
+          name: install miniconda
+          command: |
+            yum install -y wget
+            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+            bash ~/miniconda.sh -b -p ~/miniconda 
+            rm ~/miniconda.sh
+            export PATH=~/miniconda/bin:$PATH
+            source ~/.bashrc
+
+      - checkout
+
+      - run:
+          name: conda build .
+          command: |
+            rm -rf /root/project/build
+            cd /root/project/conda
+            /root/miniconda/bin/conda install -y conda-build
+            /root/miniconda/bin/conda config --add channels conda-forge
+            nohup /root/miniconda/bin/conda build . &
+          no_output_timeout: 60m
+ 
   build_python_api:
     docker:
       - image: sgpearse/vapor3-ubuntu18:latest
@@ -684,6 +730,7 @@ workflows:
   build:
     jobs:
       - build_python_api
+      - build_python_api2
       #- clang-tidy
       #- build_ubuntu18
       #- build_centos7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,9 +375,9 @@ jobs:
           command: |
             rm -rf /root/project/build
             cd /root/project/conda
-            conda install -y conda-build
-            conda config --add channels conda-forge
-            conda build .
+            /root/miniconda/bin/conda install -y conda-build
+            /root/miniconda/bin/conda config --add channels conda-forge
+            /root/miniconda/bin/conda build .
  
   build_ubuntu18:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ jobs:
     docker:
       - image: sgpearse/vapor3-centos7:latest
 
-    resource_class: medium
+    resource_class: large
 
     steps:
       - run:
@@ -389,7 +389,7 @@ jobs:
     docker:
       - image: sgpearse/vapor3-ubuntu18:latest
 
-    resource_class: medium
+    resource_class: large
 
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,8 +356,6 @@ jobs:
             yum install -y python3-pip
             pip3 install --upgrade pip
             pip3 install scikit-build command
-            rm /usr/bin/python
-            ln -s /usr/bin/python3 /usr/bin/python
 
       - run:
           name: update cmake
@@ -385,6 +383,8 @@ jobs:
             rm -rf /root/project/build/*
             rm -f /root/project/site.local
             cd /root/project/build
+            rm /usr/bin/python
+            ln -s /usr/bin/python3 /usr/bin/python
             cmake -DBUILD_PYTHON=ON -DBUILD_GUI=OFF -DBUILD_DOC=ON ..
             make doc
             rm -f CMakeCache.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,8 +381,9 @@ jobs:
           command: |
             yum -y install doxygen
             rm -rf /root/project/build/*
+            rm -f /root/project/site.local
             cd /root/project/build
-            cmake -DBUILD_DOC=ON -DBUILD_PYTHON=ON ..
+            cmake -DBUILD_PYTHON=ON -DBUILD_GUI=OFF -DBUILD_DOC=ON ..
             make doc
             rm -f CMakeCache.txt
             cd /root/project/conda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,6 +378,7 @@ jobs:
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
             /root/miniconda/bin/conda build .
+          no_output_timeout: 30m
  
   build_ubuntu18:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -729,7 +729,7 @@ workflows:
       - build_ubuntu18
       - build_centos7
       - python_api_ubuntu
-      #- python_api_centos
+      - python_api_centos
       #- python_api_osx
       #- foo
       #- test_clang_format

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
           no_output_timeout: 20m
  
       - store_artifacts:
-          path: /root/miniconda/conda_bld/linux_64/*.tar.bz2
+          path: /root/miniconda/conda-bld/linux_64/*.tar.bz2
 
   build_python_api_ubuntu:
     docker:
@@ -434,7 +434,7 @@ jobs:
           no_output_timeout: 30m
  
       - store_artifacts:
-          path: /root/miniconda/conda_bld/linux_64/*.tar.bz2
+          path: /root/miniconda/conda-bld/linux_64/*.tar.bz2
 
   build_ubuntu18:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,6 +361,7 @@ jobs:
       - run:
           name: install miniconda
           command: |
+            apt install -y wget
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
             bash ~/miniconda.sh -b -p ~/miniconda 
             rm ~/miniconda.sh
@@ -372,8 +373,10 @@ jobs:
       - run:
           name: conda build .
           command: |
+            rm -rf /root/project/build
             cd /root/project/conda
-            conda install conda-build
+            conda install -y conda-build
+            conda config --add channels conda-forge
             conda build .
  
   build_ubuntu18:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,8 +345,8 @@ jobs:
             yum -y update
             yum install -y python3
             yum install -y python3-pip
-            pip3 install --upgrade pip
-            pip3 install scikit-build command
+            #pip3 install --upgrade pip
+            #pip3 install scikit-build command
 
       - run:
           name: update cmake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,7 @@ jobs:
             https://api.github.com/repos/NCAR/VAPOR/issues/${CIRCLE_PULL_REQUEST##*/} \
             -d "$json"
 
-  build_python_api_centos:
+  python_api_centos:
     docker:
       - image: sgpearse/vapor3-centos7:latest
 
@@ -385,7 +385,7 @@ jobs:
       - store_artifacts:
           path: /root/miniconda/conda-bld/linux_64
 
-  build_python_api_ubuntu:
+  python_api_ubuntu:
     docker:
       - image: sgpearse/vapor3-ubuntu18:latest
 
@@ -739,17 +739,17 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_python_api_centos
       #- clang-tidy
       - build_ubuntu18
       - build_centos7
+      - python_api_centos
       #- foo
       #- test_clang_format
       #- build_win10_installer
       #- build_osx_installer
       #- build_ubuntu18_installer
       #- build_centos7_installer
-      #- build_python_api_ubuntu
+      #- python_api_ubuntu
       #- release_weekly_installers:
       #    requires:
       #      - build_ubuntu18_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,16 +104,15 @@ jobs:
       - run:
           name: Get libomp
           command: |
-            #sudo /opt/local/bin/port selfupdate
-            #(sudo yes || true) | sudo /opt/local/bin/port install libomp
+            sudo /opt/local/bin/port selfupdate
+            (sudo yes || true) | sudo /opt/local/bin/port install libomp
           no_output_timeout: 30m
 
       - run:
-          name: Get clang13
+          name: Get clang12
           command: |
-            sudo /opt/local/bin/port selfupdate
-            (sudo yes || true) | sudo /opt/local/bin/port install clang-13
-            sudo /opt/local/bin/port select --set clang mp-clang-13
+            (sudo yes || true) | sudo /opt/local/bin/port install clang-12
+            sudo /opt/local/bin/port select --set clang mp-clang-12
             /opt/local/bin/clang++ -v > clangVersion.txt
           no_output_timeout: 30m
 
@@ -131,7 +130,7 @@ jobs:
             cd build
             git checkout $CIRCLE_BRANCH
             export PATH=/opt/local/bin:$PATH
-            sudo port select --set clang mp-clang-13
+            sudo port select --set clang mp-clang-12
             cmake -DCPACK_BINARY_DRAGNDROP=ON -DCMAKE_BUILD_TYPE:String=Release -DDIST_INSTALLER:string=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DUSE_OMP=ON ..
             make -j2
             make installer -j2
@@ -384,12 +383,13 @@ jobs:
             rm -rf /root/project/build/*
             rm -f /root/project/site.local
             cd /root/project/build
-            rm /usr/bin/python
-            ln -s /usr/bin/python3 /usr/bin/python
-            cmake -DBUILD_PYTHON=ON -DBUILD_GUI=OFF -DBUILD_DOC=ON ..
-            make doc
-            rm -f CMakeCache.txt
+            #rm /usr/bin/python
+            #ln -s /usr/bin/python3 /usr/bin/python
+            #cmake -DBUILD_PYTHON=ON -DBUILD_GUI=OFF -DBUILD_DOC=ON ..
+            #make doc
+            #rm -f CMakeCache.txt
             cd /root/project/conda
+            export PYTHONPATH=/root/miniconda/lib/python3.9
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
             /root/miniconda/bin/conda build .
@@ -456,15 +456,6 @@ jobs:
             pip3 install scikit-build command
 
       - run:
-          name: update 3rd party libraries
-          command: |
-            rm -rf /usr/local/VAPOR-Deps/2019-Aug
-            pip3 install gdown --upgrade
-            gdown https://drive.google.com/uc?id=1elB8v-UNMzkNmnsJPtxk3cI1zBelJ3Hd
-            filename="/root/project/2019-Aug-Ubuntu.tar.xz"
-            tar -xf ${filename} -C /usr/local/VAPOR-Deps
-
-      - run: 
           name: update cmake
           command: |
             apt remove -y --purge --auto-remove cmake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,48 @@ jobs:
             https://api.github.com/repos/NCAR/VAPOR/issues/${CIRCLE_PULL_REQUEST##*/} \
             -d "$json"
 
+  build_python_api:
+    docker:
+      - image: sgpearse/vapor3-ubuntu18:latest
+
+    steps:
+      - run:
+          name: install python
+          command: |
+            apt-get update
+            apt-get install -y python3
+            apt install -y python3-pip
+            pip3 install --upgrade pip
+            pip3 install scikit-build command
+
+      - run:
+          name: update cmake
+          command: |
+            apt remove -y --purge --auto-remove cmake
+            apt install -y libssl-dev
+            apt install -y build-essential git
+            git clone https://github.com/Kitware/CMake/
+            cd CMake
+            ./bootstrap && make && make install
+
+      - run:
+          name: install miniconda
+          command: |
+            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+            bash ~/miniconda.sh -b -p ~/miniconda 
+            rm ~/miniconda.sh
+            export PATH=~/miniconda/bin:$PATH
+            source ~/.bashrc
+
+      - checkout
+
+      - run:
+          name: conda build .
+          command: |
+            cd /root/project/conda
+            conda install conda-build
+            conda build .
+ 
   build_ubuntu18:
     docker:
       - image: sgpearse/vapor3-ubuntu18:latest
@@ -637,9 +679,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - clang-tidy
-      - build_ubuntu18
-      - build_centos7
+      - build_python_api
+      #- clang-tidy
+      #- build_ubuntu18
+      #- build_centos7
       #- foo
       #- test_clang_format
       #- build_win10_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ jobs:
       - run:
           name: install python
           command: |
-            yum update
+            yum -y update
             yum install -y python3
             yum install -y python3-pip
             pip3 install --upgrade pip
@@ -364,20 +364,22 @@ jobs:
             yum install -y wget
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
             bash ~/miniconda.sh -b -p ~/miniconda 
-            rm ~/miniconda.sh
-            export PATH=~/miniconda/bin:$PATH
-            source ~/.bashrc
 
       - checkout
 
       - run:
           name: conda build .
           command: |
-            rm -rf /root/project/build
+            yum -y install doxygen
+            rm -rf /root/project/build/*
+            cd /root/project/build
+            cmake -DBUILD_DOC=ON -DBUILD_PYTHON=ON ..
+            make doc
+            rm -f CMakeCache.txt
             cd /root/project/conda
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
-            nohup /root/miniconda/bin/conda build . &
+            /root/miniconda/bin/conda build .
           no_output_timeout: 60m
  
   build_python_api:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ jobs:
       - run:
           name: install python
           command: |
-            yum -y update
+            yum -y update || true
             yum install -y python3 || true
             yum install -y python3-pip || true
             pip3 install --upgrade pip || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,6 @@ jobs:
             conda install -y conda-build
             conda config --add channels conda-forge
             conda build .
-            mkdir /root/miniconda/conda-bld/linux-64/tarBallDir
             mkdir /usr/local/conda-bld/linux-64/tarBallDir
             mv /usr/local/conda-bld/linux-64/tarBallDir/*.tar.bz2 /usr/local/conda-bld/linux-64/tarBallDir
  
@@ -408,7 +407,6 @@ jobs:
           name: conda build .
           command: |
             cd /Users/distiller/project/conda
-            #export PYTHONPATH=/root/miniconda/lib/python3.9
             /Users/distiller/miniconda/bin/conda install -y conda-build anaconda conda-verify
             /Users/distiller/miniconda/bin/conda config --add channels conda-forge
             /Users/distiller/miniconda/bin/conda build .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
       - run:
           name: Get clang13
           command: |
+            sudo /opt/local/bin/port selfupdate
             (sudo yes || true) | sudo /opt/local/bin/port install clang-13
             sudo /opt/local/bin/port select --set clang mp-clang-13
             /opt/local/bin/clang++ -v > clangVersion.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,8 +345,8 @@ jobs:
             yum -y update
             yum install -y python3 || true
             yum install -y python3-pip || true
-            pip3 install --upgrade pip
-            pip3 install scikit-build command
+            pip3 install --upgrade pip || true
+            pip3 install scikit-build command || true
 
       - run:
           name: update cmake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
           no_output_timeout: 20m
  
       - store_artifacts:
-          path: /root/miniconda/conda-bld/linux_64
+          path: /root/miniconda/conda-bld/linux-64
 
   python_api_ubuntu:
     docker:
@@ -434,7 +434,7 @@ jobs:
           no_output_timeout: 30m
  
       - store_artifacts:
-          path: /root/miniconda/conda-bld/linux_64
+          path: /root/miniconda/conda-bld/linux-64
 
   build_ubuntu18:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ jobs:
             cd /root/project/conda
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
-            nohup /root/miniconda/bin/conda build .
+            nohup /root/miniconda/bin/conda build . &
           no_output_timeout: 60m
  
   build_ubuntu18:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,10 +343,10 @@ jobs:
           name: install python
           command: |
             yum -y update
-            yum install -y python3
+            yum install -y python3 || true
             yum install -y python3-pip
-            #pip3 install --upgrade pip
-            #pip3 install scikit-build command
+            pip3 install --upgrade pip
+            pip3 install scikit-build command
 
       - run:
           name: update cmake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,14 +339,14 @@ jobs:
       - image: sgpearse/vapor3-centos7:latest
 
     steps:
-       - run:
-           name: update 3rd party libraries
-           command: |
-             rm -rf /usr/local/VAPOR-Deps/2019-Aug
-             pip3 install gdown --upgrade
-             gdown https://drive.google.com/uc?id=1S9DwySMnQrBuUUZGKolD__WQrjTmLgyn
-             filename="/root/project/2019-Aug-CentOS.tar.xz"
-             bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
+      - run:
+          name: update 3rd party libraries
+          command: |
+            rm -rf /usr/local/VAPOR-Deps/2019-Aug
+            pip3 install gdown --upgrade
+            gdown https://drive.google.com/uc?id=1S9DwySMnQrBuUUZGKolD__WQrjTmLgyn
+            filename="/root/project/2019-Aug-CentOS.tar.xz"
+            bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
 
       - run:
           name: install python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,15 @@ jobs:
       - image: sgpearse/vapor3-centos7:latest
 
     steps:
+        - run:
+            name: update 3rd party libraries
+            command: |
+              rm -rf /usr/local/VAPOR-Deps/2019-Aug
+              pip3 install gdown --upgrade
+              gdown https://drive.google.com/uc?id=1S9DwySMnQrBuUUZGKolD__WQrjTmLgyn
+              filename="/root/project/2019-Aug-CentOS.tar.xz"
+              bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
+
       - run:
           name: install python
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,6 +401,8 @@ jobs:
     docker:
       - image: sgpearse/vapor3-ubuntu18:latest
 
+    resource_class: medium
+
     steps:
       - run:
           name: install python
@@ -441,8 +443,11 @@ jobs:
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
             nohup /root/miniconda/bin/conda build . &
-          no_output_timeout: 60m
+          no_output_timeout: 30m
  
+      - store_artifacts:
+          path: /root/miniconda/conda_bld/linux_64/*.tar.bz2
+
   build_ubuntu18:
     docker:
       - image: sgpearse/vapor3-ubuntu18:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,11 +334,11 @@ jobs:
             https://api.github.com/repos/NCAR/VAPOR/issues/${CIRCLE_PULL_REQUEST##*/} \
             -d "$json"
 
-  build_python_api2:
+  build_python_api_centos:
     docker:
       - image: sgpearse/vapor3-centos7:latest
 
-    resource_class: large
+    resource_class: medium
 
     steps:
       - run:
@@ -360,16 +360,6 @@ jobs:
             pip3 install scikit-build command
 
       - run:
-          name: update cmake
-          command: |
-            #apt remove -y --purge --auto-remove cmake
-            #apt install -y libssl-dev
-            #apt install -y build-essential git
-            #git clone https://github.com/Kitware/CMake/
-            #cd CMake
-            #./bootstrap && make && make install
-
-      - run:
           name: install miniconda
           command: |
             yum install -y wget
@@ -385,19 +375,17 @@ jobs:
             rm -rf /root/project/build/*
             rm -f /root/project/site.local
             cd /root/project/build
-            #rm /usr/bin/python
-            #ln -s /usr/bin/python3 /usr/bin/python
-            #cmake -DBUILD_PYTHON=ON -DBUILD_GUI=OFF -DBUILD_DOC=ON ..
-            #make doc
-            #rm -f CMakeCache.txt
             cd /root/project/conda
             export PYTHONPATH=/root/miniconda/lib/python3.9
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
             /root/miniconda/bin/conda build .
-          no_output_timeout: 60m
+          no_output_timeout: 20m
  
-  build_python_api:
+      - store_artifacts:
+          path: /root/miniconda/conda_bld/linux_64/*.tar.bz2
+
+  build_python_api_ubuntu:
     docker:
       - image: sgpearse/vapor3-ubuntu18:latest
 
@@ -751,17 +739,17 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_python_api
-      - build_python_api2
+      - build_python_api_centos
       #- clang-tidy
-      #- build_ubuntu18
-      #- build_centos7
+      - build_ubuntu18
+      - build_centos7
       #- foo
       #- test_clang_format
       #- build_win10_installer
       #- build_osx_installer
       #- build_ubuntu18_installer
       #- build_centos7_installer
+      #- build_python_api_ubuntu
       #- release_weekly_installers:
       #    requires:
       #      - build_ubuntu18_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,14 +339,14 @@ jobs:
       - image: sgpearse/vapor3-centos7:latest
 
     steps:
-        - run:
-            name: update 3rd party libraries
-            command: |
-              rm -rf /usr/local/VAPOR-Deps/2019-Aug
-              pip3 install gdown --upgrade
-              gdown https://drive.google.com/uc?id=1S9DwySMnQrBuUUZGKolD__WQrjTmLgyn
-              filename="/root/project/2019-Aug-CentOS.tar.xz"
-              bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
+       - run:
+           name: update 3rd party libraries
+           command: |
+             rm -rf /usr/local/VAPOR-Deps/2019-Aug
+             pip3 install gdown --upgrade
+             gdown https://drive.google.com/uc?id=1S9DwySMnQrBuUUZGKolD__WQrjTmLgyn
+             filename="/root/project/2019-Aug-CentOS.tar.xz"
+             bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
 
       - run:
           name: install python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,23 +341,23 @@ jobs:
     resource_class: large
 
     steps:
-      - run:
-          name: update 3rd party libraries
-          command: |
-            rm -rf /usr/local/VAPOR-Deps/2019-Aug
-            pip3 install gdown --upgrade
-            gdown https://drive.google.com/uc?id=1S9DwySMnQrBuUUZGKolD__WQrjTmLgyn
-            filename="/root/project/2019-Aug-CentOS.tar.xz"
-            bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
+      #- run:
+      #    name: update 3rd party libraries
+      #    command: |
+      #      rm -rf /usr/local/VAPOR-Deps/2019-Aug
+      #      pip3 install gdown --upgrade
+      #      gdown https://drive.google.com/uc?id=1S9DwySMnQrBuUUZGKolD__WQrjTmLgyn
+      #      filename="/root/project/2019-Aug-CentOS.tar.xz"
+      #      bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
 
-      - run:
-          name: install python
-          command: |
-            yum -y update || true
-            yum install -y python3
-            yum install -y python3-pip
-            pip3 install --upgrade pip
-            pip3 install scikit-build command
+      #- run:
+      #    name: install python
+      #    command: |
+      #      yum -y update || true
+      #      yum install -y python3
+      #      yum install -y python3-pip
+      #      pip3 install --upgrade pip
+      #      pip3 install scikit-build command
 
       - run:
           name: install miniconda
@@ -371,23 +371,27 @@ jobs:
       - run:
           name: conda build .
           command: |
-            yum -y install doxygen
+            #yum -y install doxygen
             rm -rf /root/project/build/*
             rm -f /root/project/site.local
             cd /root/project/build
             cd /root/project/conda
-            export PYTHONPATH=/root/miniconda/lib/python3.9
+            #export PYTHONPATH=/root/miniconda/lib/python3.9
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
             /root/miniconda/bin/conda build .
+            mkdir /root/miniconda/conda-bld/linux-64/tarBallDir
+            mv /root/miniconda/conda-bld/linux-64/*.tar.bz2 /root/miniconda/conda-bld/linux-64/tarBallDir
+            #mv /root/miniconda/conda-bld/linux-64/*.tar.bz2 tarBallDir
           no_output_timeout: 20m
  
       - store_artifacts:
-          path: /root/miniconda/conda-bld/linux-64
+          path: /root/miniconda/conda-bld/linux-64/tarBallDir
 
   python_api_ubuntu:
     docker:
-      - image: sgpearse/vapor3-ubuntu18:latest
+      #- image: sgpearse/vapor3-ubuntu18:latest
+      - image: conda/miniconda3
 
     resource_class: large
 
@@ -401,15 +405,15 @@ jobs:
             pip3 install --upgrade pip
             pip3 install scikit-build command
 
-      - run:
-          name: update cmake
-          command: |
-            apt remove -y --purge --auto-remove cmake
-            apt install -y libssl-dev
-            apt install -y build-essential git
-            git clone https://github.com/Kitware/CMake/
-            cd CMake
-            ./bootstrap && make && make install
+      #- run:
+      #    name: update cmake
+      #    command: |
+      #      apt remove -y --purge --auto-remove cmake
+      #      apt install -y libssl-dev
+      #      apt install -y build-essential git
+      #      git clone https://github.com/Kitware/CMake/
+      #      cd CMake
+      #      ./bootstrap && make && make install
 
       - run:
           name: install miniconda
@@ -430,11 +434,93 @@ jobs:
             cd /root/project/conda
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
-            nohup /root/miniconda/bin/conda build . &
+            /root/miniconda/bin/conda build .
+            mkdir /root/miniconda/conda-bld/linux-64/tarBallDir
+            mv /root/miniconda/conda-bld/linux-64/*.tar.bz2 /root/miniconda/conda-bld/linux-64/tarBallDir
           no_output_timeout: 30m
  
       - store_artifacts:
-          path: /root/miniconda/conda-bld/linux-64
+          path: /root/miniconda/conda-bld/linux-64/tarBallDir
+
+  python_api_osx:
+    macos:
+      xcode: "13.4.1"
+
+    resource_class: large
+
+    steps:
+
+      - checkout
+
+      #- run:
+      #    name: Get cmake
+      #    command: |
+      #      brew install cmake
+
+      #- run:
+      #    name: Get MacPorts
+      #    command: |
+      #      curl -k -O https://distfiles.macports.org/MacPorts/MacPorts-2.7.1.tar.bz2
+      #      tar xf MacPorts-2.7.1.tar.bz2
+      #      cd MacPorts-2.7.1/
+      #      ./configure
+      #      make -j2
+      #      sudo make install -j2
+
+      - run:
+          name: Get libomp
+          command: |
+            #sudo /opt/local/bin/port selfupdate
+            #(sudo yes || true) | sudo /opt/local/bin/port install libomp
+          no_output_timeout: 30m
+
+      #- run:
+      #    name: Get clang13
+      #    command: |
+      #      sudo /opt/local/bin/port selfupdate
+      #      (sudo yes || true) | sudo /opt/local/bin/port install clang-13
+      #      sudo /opt/local/bin/port select --set clang mp-clang-13
+      #      /opt/local/bin/clang++ -v > clangVersion.txt
+      #    no_output_timeout: 30m
+
+      #- run:
+      #    name: install python
+      #    command: |
+      #      brew install python3
+      #      pip3 install --upgrade pip
+      #      pip3 install scikit-build command
+
+      - run:
+          name: install miniconda
+          command: |
+            brew install wget
+            wget https://repo.continuum.io/miniconda/Miniconda3-py39_4.9.2-MacOSX-x86_64.sh -O ~/miniconda.sh
+            bash ~/miniconda.sh -b -p ~/miniconda
+
+      - run:
+          name: conda build .
+          command: |
+      #      sudo /opt/local/bin/port select --set clang mp-clang-13
+      #      brew install doxygen
+            #rm -rf /root/project/build/*
+            #rm -f /root/project/site.local
+            #cd /root/project/build
+            cd /Users/distiller/project/conda
+            export PYTHONPATH=/root/miniconda/lib/python3.9
+            /Users/distiller/miniconda/bin/conda install -y conda-build anaconda conda-verify
+            /Users/distiller/miniconda/bin/conda config --add channels conda-forge
+            /Users/distiller/miniconda/bin/conda build .
+            mkdir -p /tmp/workspace/installers
+            mv /Users/distiller/miniconda/conda-bld/osx-64/*.tar.bz2 /tmp/workspace/installers
+          no_output_timeout: 30m
+
+      - store_artifacts:
+          path: /tmp/workspace/installers
+
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - installers
 
   build_ubuntu18:
     docker:
@@ -740,9 +826,11 @@ workflows:
   build:
     jobs:
       #- clang-tidy
-      - build_ubuntu18
-      - build_centos7
+      #- build_ubuntu18
+      #- build_centos7
       - python_api_centos
+      - python_api_ubuntu
+      - python_api_osx
       #- foo
       #- test_clang_format
       #- build_win10_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,10 +343,10 @@ jobs:
           name: install python
           command: |
             yum -y update || true
-            yum install -y python3 || true
-            yum install -y python3-pip || true
-            pip3 install --upgrade pip || true
-            pip3 install scikit-build command || true
+            yum install -y python3
+            yum install -y python3-pip
+            pip3 install --upgrade pip
+            pip3 install scikit-build command
 
       - run:
           name: update cmake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,32 +373,11 @@ jobs:
     resource_class: large
 
     steps:
-    #  - run:
-    #      name: install python
-    #      command: |
-    #        apt-get update
-    #        apt-get install -y python3
-    #        apt install -y python3-pip
-    #        pip3 install --upgrade pip
-    #        pip3 install scikit-build command
-
-      - run:
-          name: install miniconda
-          command: |
-            apt-get update
-            apt install -y wget
-            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-            bash ~/miniconda.sh -b -p ~/miniconda 
-            rm ~/miniconda.sh
-            export PATH=~/miniconda/bin:$PATH
-            source ~/.bashrc
-
       - checkout
 
       - run:
           name: conda build .
           command: |
-            ls /root/project
             cd /root/project/conda
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
@@ -417,44 +396,6 @@ jobs:
 
       - checkout
 
-      #- run:
-      #    name: Get cmake
-      #    command: |
-      #      brew install cmake
-
-      #- run:
-      #    name: Get MacPorts
-      #    command: |
-      #      curl -k -O https://distfiles.macports.org/MacPorts/MacPorts-2.7.1.tar.bz2
-      #      tar xf MacPorts-2.7.1.tar.bz2
-      #      cd MacPorts-2.7.1/
-      #      ./configure
-      #      make -j2
-      #      sudo make install -j2
-
-      - run:
-          name: Get libomp
-          command: |
-            #sudo /opt/local/bin/port selfupdate
-            #(sudo yes || true) | sudo /opt/local/bin/port install libomp
-          no_output_timeout: 30m
-
-      #- run:
-      #    name: Get clang13
-      #    command: |
-      #      sudo /opt/local/bin/port selfupdate
-      #      (sudo yes || true) | sudo /opt/local/bin/port install clang-13
-      #      sudo /opt/local/bin/port select --set clang mp-clang-13
-      #      /opt/local/bin/clang++ -v > clangVersion.txt
-      #    no_output_timeout: 30m
-
-      #- run:
-      #    name: install python
-      #    command: |
-      #      brew install python3
-      #      pip3 install --upgrade pip
-      #      pip3 install scikit-build command
-
       - run:
           name: install miniconda
           command: |
@@ -465,13 +406,7 @@ jobs:
       - run:
           name: conda build .
           command: |
-            #sudo /opt/local/bin/port select --set clang mp-clang-13
-            #brew install doxygen
-            #rm -rf /root/project/build/*
-            #rm -f /root/project/site.local
-            #cd /root/project/build
             cd /Users/distiller/project/conda
-            export PYTHONPATH=/root/miniconda/lib/python3.9
             /Users/distiller/miniconda/bin/conda install -y conda-build anaconda conda-verify
             /Users/distiller/miniconda/bin/conda config --add channels conda-forge
             /Users/distiller/miniconda/bin/conda build .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,14 +379,15 @@ jobs:
           name: conda build .
           command: |
             cd /root/project/conda
-            /root/miniconda/bin/conda install -y conda-build
-            /root/miniconda/bin/conda config --add channels conda-forge
-            /root/miniconda/bin/conda build .
+            conda install -y conda-build
+            conda config --add channels conda-forge
+            conda build .
             mkdir /root/miniconda/conda-bld/linux-64/tarBallDir
-            mv /root/miniconda/conda-bld/linux-64/*.tar.bz2 /root/miniconda/conda-bld/linux-64/tarBallDir
+            mkdir /usr/local/conda-bld/linux-64/tarBallDir
+            mv /usr/local/conda-bld/linux-64/tarBallDir/*.tar.bz2 /usr/local/conda-bld/linux-64/tarBallDir
  
       - store_artifacts:
-          path: /root/miniconda/conda-bld/linux-64/tarBallDir
+          path: /usr/local/conda-bld/linux-64/tarBallDir
 
   python_api_osx:
     macos:
@@ -407,6 +408,7 @@ jobs:
           name: conda build .
           command: |
             cd /Users/distiller/project/conda
+            #export PYTHONPATH=/root/miniconda/lib/python3.9
             /Users/distiller/miniconda/bin/conda install -y conda-build anaconda conda-verify
             /Users/distiller/miniconda/bin/conda config --add channels conda-forge
             /Users/distiller/miniconda/bin/conda build .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
 
   python_api_centos:
     docker:
-      - image: centos7
+      - image: centos:7
 
     resource_class: large
 
@@ -368,7 +368,7 @@ jobs:
 
   python_api_ubuntu:
     docker:
-      - image: conda/miniconda3
+      - image: conda/miniconda3 # Debian based docker image
 
     resource_class: large
 
@@ -729,15 +729,13 @@ workflows:
       - build_ubuntu18
       - build_centos7
       - python_api_ubuntu
-      - python_api_centos
+      #- python_api_centos
       #- python_api_osx
-      #- foo
       #- test_clang_format
       #- build_win10_installer
       #- build_osx_installer
       #- build_ubuntu18_installer
       #- build_centos7_installer
-      #- python_api_ubuntu
       #- release_weekly_installers:
       #    requires:
       #      - build_ubuntu18_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,9 +353,6 @@ jobs:
       - run:
           name: conda build .
           command: |
-            rm -rf /root/project/build/*
-            rm -f /root/project/site.local
-            cd /root/project/build
             cd /root/project/conda
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
@@ -393,7 +390,6 @@ jobs:
       xcode: "13.4.1"
 
     steps:
-
       - checkout
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,24 +341,6 @@ jobs:
     resource_class: large
 
     steps:
-      #- run:
-      #    name: update 3rd party libraries
-      #    command: |
-      #      rm -rf /usr/local/VAPOR-Deps/2019-Aug
-      #      pip3 install gdown --upgrade
-      #      gdown https://drive.google.com/uc?id=1S9DwySMnQrBuUUZGKolD__WQrjTmLgyn
-      #      filename="/root/project/2019-Aug-CentOS.tar.xz"
-      #      bsdtar -xf ${filename} -C /usr/local/VAPOR-Deps
-
-      #- run:
-      #    name: install python
-      #    command: |
-      #      yum -y update || true
-      #      yum install -y python3
-      #      yum install -y python3-pip
-      #      pip3 install --upgrade pip
-      #      pip3 install scikit-build command
-
       - run:
           name: install miniconda
           command: |
@@ -371,26 +353,21 @@ jobs:
       - run:
           name: conda build .
           command: |
-            #yum -y install doxygen
             rm -rf /root/project/build/*
             rm -f /root/project/site.local
             cd /root/project/build
             cd /root/project/conda
-            #export PYTHONPATH=/root/miniconda/lib/python3.9
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
             /root/miniconda/bin/conda build .
             mkdir /root/miniconda/conda-bld/linux-64/tarBallDir
             mv /root/miniconda/conda-bld/linux-64/*.tar.bz2 /root/miniconda/conda-bld/linux-64/tarBallDir
-            #mv /root/miniconda/conda-bld/linux-64/*.tar.bz2 tarBallDir
-          no_output_timeout: 20m
  
       - store_artifacts:
           path: /root/miniconda/conda-bld/linux-64/tarBallDir
 
   python_api_ubuntu:
     docker:
-      #- image: sgpearse/vapor3-ubuntu18:latest
       - image: conda/miniconda3
 
     resource_class: large
@@ -404,16 +381,6 @@ jobs:
             apt install -y python3-pip
             pip3 install --upgrade pip
             pip3 install scikit-build command
-
-      #- run:
-      #    name: update cmake
-      #    command: |
-      #      apt remove -y --purge --auto-remove cmake
-      #      apt install -y libssl-dev
-      #      apt install -y build-essential git
-      #      git clone https://github.com/Kitware/CMake/
-      #      cd CMake
-      #      ./bootstrap && make && make install
 
       - run:
           name: install miniconda
@@ -437,7 +404,6 @@ jobs:
             /root/miniconda/bin/conda build .
             mkdir /root/miniconda/conda-bld/linux-64/tarBallDir
             mv /root/miniconda/conda-bld/linux-64/*.tar.bz2 /root/miniconda/conda-bld/linux-64/tarBallDir
-          no_output_timeout: 30m
  
       - store_artifacts:
           path: /root/miniconda/conda-bld/linux-64/tarBallDir
@@ -445,8 +411,6 @@ jobs:
   python_api_osx:
     macos:
       xcode: "13.4.1"
-
-    resource_class: large
 
     steps:
 
@@ -500,8 +464,8 @@ jobs:
       - run:
           name: conda build .
           command: |
-      #      sudo /opt/local/bin/port select --set clang mp-clang-13
-      #      brew install doxygen
+            #sudo /opt/local/bin/port select --set clang mp-clang-13
+            #brew install doxygen
             #rm -rf /root/project/build/*
             #rm -f /root/project/site.local
             #cd /root/project/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
             /root/miniconda/bin/conda build .
-          no_output_timeout: 30m
+          no_output_timeout: 60m
  
   build_ubuntu18:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,6 +356,8 @@ jobs:
             yum install -y python3-pip
             pip3 install --upgrade pip
             pip3 install scikit-build command
+            rm /usr/bin/python
+            ln -s /usr/bin/python3 /usr/bin/python
 
       - run:
           name: update cmake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
           no_output_timeout: 20m
  
       - store_artifacts:
-          path: /root/miniconda/conda-bld/linux_64/*.tar.bz2
+          path: /root/miniconda/conda-bld/linux_64
 
   build_python_api_ubuntu:
     docker:
@@ -434,7 +434,7 @@ jobs:
           no_output_timeout: 30m
  
       - store_artifacts:
-          path: /root/miniconda/conda-bld/linux_64/*.tar.bz2
+          path: /root/miniconda/conda-bld/linux_64
 
   build_ubuntu18:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ jobs:
             cd /root/project/conda
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge
-            /root/miniconda/bin/conda build .
+            nohup /root/miniconda/bin/conda build .
           no_output_timeout: 60m
  
   build_ubuntu18:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
 
   python_api_centos:
     docker:
-      - image: sgpearse/vapor3-centos7:latest
+      - image: centos7
 
     resource_class: large
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,6 +338,8 @@ jobs:
     docker:
       - image: sgpearse/vapor3-centos7:latest
 
+    resource_class: large
+
     steps:
       - run:
           name: update 3rd party libraries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,18 +373,19 @@ jobs:
     resource_class: large
 
     steps:
-      - run:
-          name: install python
-          command: |
-            apt-get update
-            apt-get install -y python3
-            apt install -y python3-pip
-            pip3 install --upgrade pip
-            pip3 install scikit-build command
+    #  - run:
+    #      name: install python
+    #      command: |
+    #        apt-get update
+    #        apt-get install -y python3
+    #        apt install -y python3-pip
+    #        pip3 install --upgrade pip
+    #        pip3 install scikit-build command
 
       - run:
           name: install miniconda
           command: |
+            apt-get update
             apt install -y wget
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
             bash ~/miniconda.sh -b -p ~/miniconda 
@@ -397,7 +398,7 @@ jobs:
       - run:
           name: conda build .
           command: |
-            rm -rf /root/project/build
+            ls /root/project
             cd /root/project/conda
             /root/miniconda/bin/conda install -y conda-build
             /root/miniconda/bin/conda config --add channels conda-forge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,15 +104,15 @@ jobs:
       - run:
           name: Get libomp
           command: |
-            sudo /opt/local/bin/port selfupdate
-            (sudo yes || true) | sudo /opt/local/bin/port install libomp
+            #sudo /opt/local/bin/port selfupdate
+            #(sudo yes || true) | sudo /opt/local/bin/port install libomp
           no_output_timeout: 30m
 
       - run:
-          name: Get clang12
+          name: Get clang13
           command: |
-            (sudo yes || true) | sudo /opt/local/bin/port install clang-12
-            sudo /opt/local/bin/port select --set clang mp-clang-12
+            (sudo yes || true) | sudo /opt/local/bin/port install clang-13
+            sudo /opt/local/bin/port select --set clang mp-clang-13
             /opt/local/bin/clang++ -v > clangVersion.txt
           no_output_timeout: 30m
 
@@ -130,7 +130,7 @@ jobs:
             cd build
             git checkout $CIRCLE_BRANCH
             export PATH=/opt/local/bin:$PATH
-            sudo port select --set clang mp-clang-12
+            sudo port select --set clang mp-clang-13
             cmake -DCPACK_BINARY_DRAGNDROP=ON -DCMAKE_BUILD_TYPE:String=Release -DDIST_INSTALLER:string=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DUSE_OMP=ON ..
             make -j2
             make installer -j2
@@ -726,11 +726,11 @@ workflows:
   build:
     jobs:
       #- clang-tidy
-      #- build_ubuntu18
-      #- build_centos7
-      - python_api_centos
+      - build_ubuntu18
+      - build_centos7
       - python_api_ubuntu
-      - python_api_osx
+      #- python_api_centos
+      #- python_api_osx
       #- foo
       #- test_clang_format
       #- build_win10_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,7 @@ jobs:
           command: |
             yum -y update
             yum install -y python3 || true
-            yum install -y python3-pip
+            yum install -y python3-pip || true
             pip3 install --upgrade pip
             pip3 install scikit-build command
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
             conda config --add channels conda-forge
             conda build .
             mkdir /usr/local/conda-bld/linux-64/tarBallDir
-            mv /usr/local/conda-bld/linux-64/tarBallDir/*.tar.bz2 /usr/local/conda-bld/linux-64/tarBallDir
+            mv /usr/local/conda-bld/linux-64/*.tar.bz2 /usr/local/conda-bld/linux-64/tarBallDir
  
       - store_artifacts:
           path: /usr/local/conda-bld/linux-64/tarBallDir


### PR DESCRIPTION
Fixes #3133, by adding a compilation check for the conda .tar.bz2 package.  This tar.bz2 file, and all intermediate compilation files are stored as artifacts on CircleCI.