### PR TITLE
Revert "Add -f (force) flag to gunzip in build.sh to faciliate rerunning buil…"

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -48,7 +48,7 @@ unset CMAKE_PREFIX_PATH
 SP_DIR="`python -c 'import site; print(site.getsitepackages()[0].replace(\"'$BUILD_PREFIX'\", \"'$PREFIX'\"))'`"
 
 # Our third party libs have a non-standard copy of the GTE library so it is packaged and extracted here.
-unzip -f -d include buildutils/GTE.zip
+unzip -d include buildutils/GTE.zip
 
 if false ; then
 	echo "============================================================"


### PR DESCRIPTION
Reverts NCAR/VAPOR#3197

@clyne - The build script makes a call to unzip, not gunzip. For unzip, the -f flag does as follows:

-f freshen existing files, create none

I think you may have wanted to use one of the following:

-u update files, create if necessary
-o overwrite files WITHOUT prompting

However, I'm unable to reproduce the error you are reporting in this PR, where the build will fail if conda build . is called twice in succession. [This CircleCI pipeline](https://app.circleci.com/pipelines/github/NCAR/VAPOR/5990/workflows/71736ced-2caa-405d-9242-417b0ba5aba0/jobs/14307) is making that double-call on osx, ubuntu, and centos and passes.

The PR for the python test framework is currently not running tests because it hasn't merged with main yet. But if it did, it would fail due to the addition of the -f flag in unzip. I am going to revert this so the test PR can merge and pass health checks. But I'm not sure what to do about the issue you're encountering because I can't reproduce it. Thoughts?