### PR TITLE
Fix broken Linux builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -776,10 +776,10 @@ workflows:
       #- build_python_api_centos
       #- build_python_api_osx
       #- test_clang_format
-      - build_win10_installer
-      - build_osx_installer
-      - build_ubuntu18_installer
-      - build_centos7_installer
+      #- build_win10_installer
+      #- build_osx_installer
+      #- build_ubuntu18_installer
+      #- build_centos7_installer
       #- release_weekly_installers:
       #    requires:
       #      - build_ubuntu18_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -776,10 +776,10 @@ workflows:
       #- build_python_api_centos
       #- build_python_api_osx
       #- test_clang_format
-      #- build_win10_installer
-      #- build_osx_installer
-      #- build_ubuntu18_installer
-      #- build_centos7_installer
+      - build_win10_installer
+      - build_osx_installer
+      - build_ubuntu18_installer
+      - build_centos7_installer
       #- release_weekly_installers:
       #    requires:
       #      - build_ubuntu18_installer

--- a/apps/vaporgui/main.cpp
+++ b/apps/vaporgui/main.cpp
@@ -151,7 +151,6 @@ int           main(int argc, char **argv)
     setlocale(LC_ALL, "C");
 
 // For Mac and Linux, set the PYTHONHOME in this app
-#if PRE_PYTHON_API_REFACTOR
 #ifndef WIN32
     const char *s = getenv("PYTHONHOME");
     string      phome = s ? s : "";
@@ -173,7 +172,6 @@ int           main(int argc, char **argv)
         setenv("PYTHONHOME", phome.c_str(), 1);
     }
     MyBase::SetDiagMsg("PYTHONHOME = %s", phome.c_str());
-#endif
 #endif
 
     VAPoR::SetHDF5PluginPath();


### PR DESCRIPTION
Fixes #3190 which fixes the installer build on casper, as well as all other Linux platforms.  A lot of investigation for deleting two lines of code, but c'est les vis.