### PR TITLE
Fix #3216 - Broken directional particles

### DIFF
--- a/include/vapor/ParticleRenderer.h
+++ b/include/vapor/ParticleRenderer.h
@@ -67,12 +67,12 @@ private:
         std::vector<std::string> fieldVars;
     } _cacheParams;
 
-    struct _vertex {
+    struct Vertex {
         glm::vec3  point;
         float      value;
     };
 
-    std::vector<_vertex> _particles;
+    std::vector<Vertex> _particles;
 
     std::vector<int> _streamSizes;
 

--- a/include/vapor/ParticleRenderer.h
+++ b/include/vapor/ParticleRenderer.h
@@ -94,8 +94,7 @@ private:
     void _resetColormapCache();
     int  _generateParticlesLegacy(Grid*& grid, std::vector<Grid*>& vecGrids);
     int  _getGrids(Grid*& grid, std::vector<Grid*>& vecGrids) const;
-    void _generateTextureData();
-    void _generateParticleData(const Grid* grid, const std::vector<Grid*>& vecGrids);
+    void _generateTextureData(const Grid* grid, const std::vector<Grid*>& vecGrids);
     void _renderParticlesLegacy(const Grid* grid, const std::vector<Grid*>& vecGrids) const;
     int  _renderParticlesHelper();
     void _prepareColormap();

--- a/lib/render/ParticleRenderer.cpp
+++ b/lib/render/ParticleRenderer.cpp
@@ -408,7 +408,7 @@ void ParticleRenderer::_generateTextureData(const Grid* grid, const std::vector<
 
     glBindVertexArray(_VAO);
     glBindBuffer(GL_ARRAY_BUFFER, _VBO);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(_vertex) * _particles.size(), _particles.data(), GL_STREAM_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex) * _particles.size(), _particles.data(), GL_STREAM_DRAW);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 


### PR DESCRIPTION
Fixes #3216 which found that the particles change direction when their length was adjusted.  This also combines the functions _generateTextureData() and ~_generateTextureData()~ _generateParticleData() to avoid unnecessarily iterating over all particle positions twice.