### PR TITLE
Allow for saving and loading of the current camera parameters to a file

### DIFF
--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -180,6 +180,8 @@ set (SRCS
 	PStringDropdownHLI.h
 	PColorSelector.cpp
 	PColorSelector.h
+	PFileButton.cpp
+	PFileButton.h
 	PFileSelector.cpp
 	PFileSelector.h
 	PFileSelectorHLI.h

--- a/apps/vaporgui/PButton.h
+++ b/apps/vaporgui/PButton.h
@@ -5,9 +5,6 @@
 
 class VPushButton;
 
-typedef std::function<void(VAPoR::ParamsBase *)> Callback;
-typedef std::function<void(std::string)> Callback2;
-
 //! \class PButton
 //! \brief PWidget wrapper for VPushButton.
 //! \author Stas Jaroszynski
@@ -16,7 +13,9 @@ typedef std::function<void(std::string)> Callback2;
 //! Please don't capture in the callback.
 
 class PButton : public PWidget {
+    typedef std::function<void(VAPoR::ParamsBase *)> Callback;
     VPushButton *                                    _button;
+    const Callback                                   _cb;
     bool                                             _disableUndo = false;
 
 public:
@@ -25,9 +24,9 @@ public:
     PButton *DisableUndo();
 
 protected:
-    const Callback                                   _cb;
-    const Callback2                                   _cb2;
     void updateGUI() const override {}
     bool requireParamsMgr() const override { return _disableUndo; }
-    virtual void clicked();
+
+private:
+    void clicked();
 };

--- a/apps/vaporgui/PButton.h
+++ b/apps/vaporgui/PButton.h
@@ -5,6 +5,9 @@
 
 class VPushButton;
 
+typedef std::function<void(VAPoR::ParamsBase *)> Callback;
+typedef std::function<void(std::string)> Callback2;
+
 //! \class PButton
 //! \brief PWidget wrapper for VPushButton.
 //! \author Stas Jaroszynski
@@ -13,9 +16,7 @@ class VPushButton;
 //! Please don't capture in the callback.
 
 class PButton : public PWidget {
-    typedef std::function<void(VAPoR::ParamsBase *)> Callback;
     VPushButton *                                    _button;
-    const Callback                                   _cb;
     bool                                             _disableUndo = false;
 
 public:
@@ -24,9 +25,9 @@ public:
     PButton *DisableUndo();
 
 protected:
+    const Callback                                   _cb;
+    const Callback2                                   _cb2;
     void updateGUI() const override {}
     bool requireParamsMgr() const override { return _disableUndo; }
-
-private:
-    void clicked();
+    virtual void clicked();
 };

--- a/apps/vaporgui/PCameraControlsSection.cpp
+++ b/apps/vaporgui/PCameraControlsSection.cpp
@@ -16,9 +16,10 @@
 using namespace VAPoR;
 
 PCameraFileGroup::PCameraFileGroup(ControlExec *ce) : PGroup(), _ce(ce) {
-    Add(new PFileOpenSelector(ViewpointParams::CameraDataFileTag, "Camera data file"));
-    Add(new PButton("Apply camera position from file", [this](VAPoR::ParamsBase* p) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SetCameraFromFile();}));
-    Add(new PButton("Save camera position to file", [this](VAPoR::ParamsBase* p) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SaveCameraToFile();}));
+    Add((new PFileSaveSelector(ViewpointParams::LoadCameraDataFileTag, "Target file to load camera settings"))->SetFileTypeFilter("Vapor camera XML file (*.vc3)"));
+    Add(new PButton("Apply camera settings from file", [this](VAPoR::ParamsBase* p) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SetCameraFromFile();}));
+    Add((new PFileOpenSelector(ViewpointParams::SaveCameraDataFileTag, "Target file to save camera settings"))->SetFileTypeFilter("Vapor camera XML file (*.vc3)"));
+    Add(new PButton("Save camera settings to file", [this](VAPoR::ParamsBase* p) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SaveCameraToFile();}));
 }
 
 void PCameraFileGroup::updateGUI() const {

--- a/apps/vaporgui/PCameraControlsSection.cpp
+++ b/apps/vaporgui/PCameraControlsSection.cpp
@@ -5,8 +5,7 @@
 #include "V3DInput.h"
 #include "VGroup.h"
 #include "PFileSelector.h"
-#include "PButton.h"
-#include "PGroup.h"
+#include "PFileButton.h"
 
 // =====================================
 //           PTrackballWidget
@@ -16,10 +15,8 @@
 using namespace VAPoR;
 
 PCameraFileGroup::PCameraFileGroup(ControlExec *ce) : PGroup(), _ce(ce) {
-    Add((new PFileOpenSelector(ViewpointParams::LoadCameraDataFileTag, "Target file to load camera settings"))->SetFileTypeFilter("Vapor camera XML file (*.vc3)"));
-    Add(new PButton("Apply camera settings from file", [this](VAPoR::ParamsBase* p) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SetCameraFromFile();}));
-    Add((new PFileSaveSelector(ViewpointParams::SaveCameraDataFileTag, "Target file to save camera settings"))->SetFileTypeFilter("Vapor camera XML file (*.vc3)"));
-    Add(new PButton("Save camera settings to file", [this](VAPoR::ParamsBase* p) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SaveCameraToFile();}));
+    Add((new PFileWriter("Save camera settings to file", [this](std::string path) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SaveCameraToFile(path); }))->SetFileTypeFilter("Vapor Camera File (*.vc3)"));
+    Add((new PFileReader("Load camera settings from file", [this](std::string path) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SetCameraFromFile(path); }))->SetFileTypeFilter("Vapor Camera File (*.vc3)"));
 }
 
 void PCameraFileGroup::updateGUI() const {

--- a/apps/vaporgui/PCameraControlsSection.cpp
+++ b/apps/vaporgui/PCameraControlsSection.cpp
@@ -16,9 +16,9 @@
 using namespace VAPoR;
 
 PCameraFileGroup::PCameraFileGroup(ControlExec *ce) : PGroup(), _ce(ce) {
-    Add((new PFileSaveSelector(ViewpointParams::LoadCameraDataFileTag, "Target file to load camera settings"))->SetFileTypeFilter("Vapor camera XML file (*.vc3)"));
+    Add((new PFileOpenSelector(ViewpointParams::LoadCameraDataFileTag, "Target file to load camera settings"))->SetFileTypeFilter("Vapor camera XML file (*.vc3)"));
     Add(new PButton("Apply camera settings from file", [this](VAPoR::ParamsBase* p) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SetCameraFromFile();}));
-    Add((new PFileOpenSelector(ViewpointParams::SaveCameraDataFileTag, "Target file to save camera settings"))->SetFileTypeFilter("Vapor camera XML file (*.vc3)"));
+    Add((new PFileSaveSelector(ViewpointParams::SaveCameraDataFileTag, "Target file to save camera settings"))->SetFileTypeFilter("Vapor camera XML file (*.vc3)"));
     Add(new PButton("Save camera settings to file", [this](VAPoR::ParamsBase* p) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SaveCameraToFile();}));
 }
 

--- a/apps/vaporgui/PCameraControlsSection.cpp
+++ b/apps/vaporgui/PCameraControlsSection.cpp
@@ -1,17 +1,10 @@
-#include <QFileDialog>
-
 #include <vapor/ViewpointParams.h>
-#include <vapor/FileUtils.h>
-
 #include "ErrorReporter.h"
 #include "PCameraControlsSection.h"
 #include "PFileButton.h"
-#include "PLineItem.h"
 #include "VLineItem.h"
 #include "V3DInput.h"
 #include "VGroup.h"
-#include "VPushButton.h"
-#include "PButton.h"
 
 // =====================================
 //           PTrackballWidget

--- a/apps/vaporgui/PCameraControlsSection.cpp
+++ b/apps/vaporgui/PCameraControlsSection.cpp
@@ -4,7 +4,6 @@
 #include "VLineItem.h"
 #include "V3DInput.h"
 #include "VGroup.h"
-#include "PFileSelector.h"
 #include "PFileButton.h"
 
 // =====================================

--- a/apps/vaporgui/PCameraControlsSection.cpp
+++ b/apps/vaporgui/PCameraControlsSection.cpp
@@ -4,7 +4,9 @@
 #include "VLineItem.h"
 #include "V3DInput.h"
 #include "VGroup.h"
-
+#include "PFileSelector.h"
+#include "PButton.h"
+#include "PGroup.h"
 
 // =====================================
 //           PTrackballWidget
@@ -12,6 +14,17 @@
 
 
 using namespace VAPoR;
+
+PCameraFileGroup::PCameraFileGroup(ControlExec *ce) : PGroup(), _ce(ce) {
+    Add(new PFileOpenSelector(ViewpointParams::CameraDataFileTag, "Camera data file"));
+    Add(new PButton("Apply camera position from file", [this](VAPoR::ParamsBase* p) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SetCameraFromFile();}));
+    Add(new PButton("Save camera position to file", [this](VAPoR::ParamsBase* p) { NavigationUtils::GetActiveViewpointParams(this->_ce)->SaveCameraToFile();}));
+}
+
+void PCameraFileGroup::updateGUI() const {
+    auto params = NavigationUtils::GetActiveViewpointParams(_ce);
+    for (PWidget *child : _children) child->Update(params);
+}
 
 PTrackballWidget::PTrackballWidget(ControlExec *ce) : PWidget("", _group = new VGroup()), _ce(ce)
 {

--- a/apps/vaporgui/PCameraControlsSection.h
+++ b/apps/vaporgui/PCameraControlsSection.h
@@ -12,6 +12,7 @@
 
 class VGroup;
 class V3DInput;
+class VPushButton;
 
 class PTrackballWidget : public PWidget {
     ControlExec *_ce;
@@ -54,9 +55,12 @@ protected:
 
 class PCameraFileGroup : public PGroup {
     ControlExec* _ce;
+    VGroup *     _group;
+    VPushButton* _loadFileButton;
 
 public:
     PCameraFileGroup(ControlExec* ce);
+    void SetAllCameras(std::string& path);
 
 protected:
     void updateGUI() const override;

--- a/apps/vaporgui/PCameraControlsSection.h
+++ b/apps/vaporgui/PCameraControlsSection.h
@@ -12,7 +12,6 @@
 
 class VGroup;
 class V3DInput;
-class VPushButton;
 
 class PTrackballWidget : public PWidget {
     ControlExec *_ce;
@@ -56,7 +55,6 @@ protected:
 class PCameraFileGroup : public PGroup {
     ControlExec* _ce;
     VGroup *     _group;
-    VPushButton* _loadFileButton;
 
 public:
     PCameraFileGroup(ControlExec* ce);

--- a/apps/vaporgui/PCameraControlsSection.h
+++ b/apps/vaporgui/PCameraControlsSection.h
@@ -7,6 +7,7 @@
 
 
 #include "PWidget.h"
+#include "PGroup.h"
 #include <vapor/NavigationUtils.h>
 
 class VGroup;
@@ -51,6 +52,16 @@ protected:
 };
 
 
+class PCameraFileGroup : public PGroup {
+    ControlExec* _ce;
+
+public:
+    PCameraFileGroup(ControlExec* ce);
+
+protected:
+    void updateGUI() const override;
+};
+
 // =====================================
 //        PCameraControlsSection
 // =====================================
@@ -65,6 +76,7 @@ public:
     PSection("Camera Controls", {
         new PTrackballWidget(ce),
         new PCameraProjectionWidget(ce),
+        new PCameraFileGroup(ce)
     }) {}
     // clang-format on
 };

--- a/apps/vaporgui/PFileButton.cpp
+++ b/apps/vaporgui/PFileButton.cpp
@@ -1,0 +1,34 @@
+#include "PFileButton.h"
+#include "VPushButton.h"
+#include <QFileDialog>
+#include <vapor/ParamsBase.h>
+#include <vapor/FileUtils.h>
+
+PFileButton::PFileButton(const std::string label, Callback cb) : PWidget("", _button= new VPushButton(label)), _cb(cb)
+{
+    QObject::connect(_button, &VPushButton::ButtonClicked, this, &PFileButton::clicked);
+}
+
+void PFileButton::updateGUI() const {}
+
+PFileButton *PFileButton::SetFileTypeFilter(const std::string &filter)
+{
+    _fileTypeFilter = QString::fromStdString(filter);
+    return this;
+}
+
+void PFileButton::clicked()
+{
+    std::string defaultPath = Wasp::FileUtils::HomeDir();
+
+    QString qSelectedPath = selectPath(defaultPath);
+    if (qSelectedPath.isNull()) return;
+
+    _cb(qSelectedPath.toStdString());
+}
+
+bool PFileButton::requireParamsMgr() const { return false; }
+
+QString PFileWriter::selectPath(const std::string &defaultPath) const { return QFileDialog::getSaveFileName(nullptr, "Select a file", QString::fromStdString(defaultPath), _fileTypeFilter); }
+
+QString PFileReader::selectPath(const std::string &defaultPath) const { return QFileDialog::getOpenFileName(nullptr, "Select a save file", QString::fromStdString(defaultPath), _fileTypeFilter); }

--- a/apps/vaporgui/PFileButton.h
+++ b/apps/vaporgui/PFileButton.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "PWidget.h"
+
+class VPushButton;
+class QString;
+
+
+//! \class PFileButton
+//! Creates a Qt text box and select button that allows users to pick a file path synced with the paramsdatabase using the PWidget interface.
+//! \copydoc PWidget
+
+class PFileButton : public PWidget {
+    Q_OBJECT
+
+private:
+    typedef std::function<void(std::string)> Callback;
+    Callback _cb;
+    VPushButton* _button;
+
+public:
+    PFileButton(const std::string label, Callback cb);
+    //! Sets the fileTypeFilter parameter in the QFileDialog popup functions.
+    PFileButton *SetFileTypeFilter(const std::string &filter);
+    //    PFileButton *UseDefaultPathSetting(const std::string &tag);
+
+protected:
+    QString _fileTypeFilter = "All Files (*)";
+
+    void            updateGUI() const override;
+    bool            requireParamsMgr() const override;
+    virtual QString selectPath(const std::string &defaultPath) const = 0;
+
+//private slots:
+    void clicked();
+};
+
+//! \class PFileOpenSelector
+//! A PFileButton that provides an Open File dialog
+//! \copydoc PFileReader
+
+class PFileReader : public PFileButton {
+    Q_OBJECT
+public:
+    using PFileButton::PFileButton;
+
+protected:
+    virtual QString selectPath(const std::string &defaultPath) const override;
+};
+
+//! \class PFileSaveSelector
+//! A PFileButton that provides a Save File dialog
+//! \copydoc PFileReader
+
+class PFileWriter : public PFileButton {
+    Q_OBJECT
+public:
+    using PFileButton::PFileButton;
+
+protected:
+    virtual QString selectPath(const std::string &defaultPath) const override;
+};

--- a/include/vapor/ViewpointParams.h
+++ b/include/vapor/ViewpointParams.h
@@ -278,7 +278,8 @@ public:
     static const string UseCustomFramebufferTag;
     static const string CustomFramebufferWidthTag;
     static const string CustomFramebufferHeightTag;
-    static const string CameraDataFileTag;
+    static const string LoadCameraDataFileTag;
+    static const string SaveCameraDataFileTag;
 
 private:
     ParamsContainer *m_VPs = nullptr;

--- a/include/vapor/ViewpointParams.h
+++ b/include/vapor/ViewpointParams.h
@@ -25,6 +25,7 @@
 #include <vapor/Transform.h>
 
 #include <memory>
+#include <fstream>
 
 namespace VAPoR {
 
@@ -231,6 +232,68 @@ public:
     //
     vector<string> GetTransformNames() const { return (_transforms->GetNames()); }
 
+    int SetCameraFromFile(); /*{
+        //Viewpoint *    vp = getCurrentViewpoint();
+
+        XmlParser xmlparser;
+
+        XmlNode *node = new XmlNode();
+
+        std::string path = GetValueString("OpenCameraFile","");
+        int rc = xmlparser.LoadFromFile(node, path);
+        if (rc < 0) {
+            MyBase::SetErrMsg("Failed to read file %s : %M", path.c_str());
+            return (-1);
+        }
+
+        // Create a new MapperFunction from the XmlNode tree
+        //
+        //XmlNode *        parent = this->GetNode()->GetParent();
+        Viewpoint* v     = new Viewpoint(_ssave, node);
+
+        // Assign (copy) new TF to this object
+        //
+        //this = *vp;
+        //this->GetNode()->SetParent(parent);
+
+        SetCurrentViewpoint(v);
+
+        // Delete the new tree
+        //
+        delete v;
+
+        _ssave->Save(_node, "Load camera from file");
+
+        return (0);
+    }*/
+    
+    int SaveCameraToFile();/* {
+        std::string path = GetValueString("SaveCameraFile","");
+        ofstream out(path);
+        std::cout << "path " << path << std::endl;
+        if (!out) {
+            MyBase::SetErrMsg("Failed to open file %s : %M", path.c_str());
+            return (-1);
+        }
+
+        std::cout << "A" << std::endl;
+
+        Viewpoint *    vp = getCurrentViewpoint();
+        XmlNode *node = vp->GetNode();
+
+        out << *node;
+
+        if (out.bad()) {
+            MyBase::SetErrMsg("Failed to write file %s : %M", path.c_str());
+            return (-1);
+        }
+        out.close();
+
+        std::cout << "B" << std::endl;
+
+        return (0);
+    }*/
+
 #ifdef VAPOR3_0_0_ALPHA
     //! Determine the current diameter of the visible scene.
     //! Calculated as 2*Dist*tan(theta*.5) where theta is the camera angle,
@@ -269,6 +332,8 @@ public:
     static const string UseCustomFramebufferTag;
     static const string CustomFramebufferWidthTag;
     static const string CustomFramebufferHeightTag;
+    static const string OpenCameraFileTag;
+    static const string SaveCameraFileTag;
 
 private:
     ParamsContainer *m_VPs = nullptr;

--- a/include/vapor/ViewpointParams.h
+++ b/include/vapor/ViewpointParams.h
@@ -232,67 +232,13 @@ public:
     //
     vector<string> GetTransformNames() const { return (_transforms->GetNames()); }
 
-    int SetCameraFromFile(); /*{
-        //Viewpoint *    vp = getCurrentViewpoint();
-
-        XmlParser xmlparser;
-
-        XmlNode *node = new XmlNode();
-
-        std::string path = GetValueString("OpenCameraFile","");
-        int rc = xmlparser.LoadFromFile(node, path);
-        if (rc < 0) {
-            MyBase::SetErrMsg("Failed to read file %s : %M", path.c_str());
-            return (-1);
-        }
-
-        // Create a new MapperFunction from the XmlNode tree
-        //
-        //XmlNode *        parent = this->GetNode()->GetParent();
-        Viewpoint* v     = new Viewpoint(_ssave, node);
-
-        // Assign (copy) new TF to this object
-        //
-        //this = *vp;
-        //this->GetNode()->SetParent(parent);
-
-        SetCurrentViewpoint(v);
-
-        // Delete the new tree
-        //
-        delete v;
-
-        _ssave->Save(_node, "Load camera from file");
-
-        return (0);
-    }*/
+    //! Set the current camera position, direction, up vector, and origin from a given xml file
+    //! \retval integer indicating success (0) or failure (-1)
+    int SetCameraFromFile();
     
-    int SaveCameraToFile();/* {
-        std::string path = GetValueString("SaveCameraFile","");
-        ofstream out(path);
-        std::cout << "path " << path << std::endl;
-        if (!out) {
-            MyBase::SetErrMsg("Failed to open file %s : %M", path.c_str());
-            return (-1);
-        }
-
-        std::cout << "A" << std::endl;
-
-        Viewpoint *    vp = getCurrentViewpoint();
-        XmlNode *node = vp->GetNode();
-
-        out << *node;
-
-        if (out.bad()) {
-            MyBase::SetErrMsg("Failed to write file %s : %M", path.c_str());
-            return (-1);
-        }
-        out.close();
-
-        std::cout << "B" << std::endl;
-
-        return (0);
-    }*/
+    //! Save the current camera position, direction, up vector, and origin to an xml file
+    //! \retval integer indicating success (0) or failure (-1)
+    int SaveCameraToFile();
 
 #ifdef VAPOR3_0_0_ALPHA
     //! Determine the current diameter of the visible scene.
@@ -332,8 +278,7 @@ public:
     static const string UseCustomFramebufferTag;
     static const string CustomFramebufferWidthTag;
     static const string CustomFramebufferHeightTag;
-    static const string OpenCameraFileTag;
-    static const string SaveCameraFileTag;
+    static const string CameraDataFileTag;
 
 private:
     ParamsContainer *m_VPs = nullptr;

--- a/include/vapor/ViewpointParams.h
+++ b/include/vapor/ViewpointParams.h
@@ -234,11 +234,11 @@ public:
 
     //! Set the current camera position, direction, up vector, and origin from a given xml file
     //! \retval integer indicating success (0) or failure (-1)
-    int SetCameraFromFile();
+    int SetCameraFromFile(const std::string &path);
     
     //! Save the current camera position, direction, up vector, and origin to an xml file
     //! \retval integer indicating success (0) or failure (-1)
-    int SaveCameraToFile();
+    int SaveCameraToFile(const std::string &path);
 
 #ifdef VAPOR3_0_0_ALPHA
     //! Determine the current diameter of the visible scene.
@@ -278,8 +278,6 @@ public:
     static const string UseCustomFramebufferTag;
     static const string CustomFramebufferWidthTag;
     static const string CustomFramebufferHeightTag;
-    static const string LoadCameraDataFileTag;
-    static const string SaveCameraDataFileTag;
 
 private:
     ParamsContainer *m_VPs = nullptr;

--- a/lib/params/ViewpointParams.cpp
+++ b/lib/params/ViewpointParams.cpp
@@ -41,8 +41,6 @@ using namespace Wasp;
 const string ViewpointParams::UseCustomFramebufferTag = "UseCustomFramebuffer";
 const string ViewpointParams::CustomFramebufferWidthTag = "CustomFramebufferWidth";
 const string ViewpointParams::CustomFramebufferHeightTag = "CustomFramebufferHeight";
-const string ViewpointParams::LoadCameraDataFileTag = "LoadCameraDataFile";
-const string ViewpointParams::SaveCameraDataFileTag = "SaveCameraDataFile";
 
 const string ViewpointParams::_viewPointsTag = "Viewpoints";
 const string ViewpointParams::_transformsTag = "Transforms";
@@ -315,12 +313,11 @@ vector<double> ViewpointParams::GetStretchFactors() const
     return (val);
 }
 
-int ViewpointParams::SetCameraFromFile() {
+int ViewpointParams::SetCameraFromFile(const std::string &path) {
     XmlParser xmlparser;
 
     XmlNode *node = new XmlNode();
 
-    std::string path = GetValueString(ViewpointParams::LoadCameraDataFileTag,"");
     int rc = xmlparser.LoadFromFile(node, path);
     if (rc < 0) {
         MyBase::SetErrMsg("Failed to read file %s : %M", path.c_str());
@@ -337,8 +334,7 @@ int ViewpointParams::SetCameraFromFile() {
     return (0);
 }
 
-int ViewpointParams::SaveCameraToFile() {
-    std::string path = GetValueString(ViewpointParams::SaveCameraDataFileTag,"");
+int ViewpointParams::SaveCameraToFile(const std::string &path) {
     ofstream out(path);
     if (!out) {
         MyBase::SetErrMsg("Failed to open file %s : %M", path.c_str());

--- a/lib/params/ViewpointParams.cpp
+++ b/lib/params/ViewpointParams.cpp
@@ -41,8 +41,7 @@ using namespace Wasp;
 const string ViewpointParams::UseCustomFramebufferTag = "UseCustomFramebuffer";
 const string ViewpointParams::CustomFramebufferWidthTag = "CustomFramebufferWidth";
 const string ViewpointParams::CustomFramebufferHeightTag = "CustomFramebufferHeight";
-const string ViewpointParams::OpenCameraFileTag = "OpenCameraFile";
-const string ViewpointParams::SaveCameraFileTag = "SaveCameraFile";
+const string ViewpointParams::CameraDataFileTag = "CameraDataFile";
 
 const string ViewpointParams::_viewPointsTag = "Viewpoints";
 const string ViewpointParams::_transformsTag = "Transforms";
@@ -327,20 +326,9 @@ int ViewpointParams::SetCameraFromFile() {
         return (-1);
     }
 
-    // Create a new MapperFunction from the XmlNode tree
-    //
-    //XmlNode *        parent = this->GetNode()->GetParent();
     Viewpoint* v     = new Viewpoint(_ssave, node);
-
-    // Assign (copy) new TF to this object
-    //
-    //*this = *vp;
-    //this->GetNode()->SetParent(parent);
-
     SetCurrentViewpoint(v);
 
-    // Delete the new tree
-    //
     delete v;
 
     _ssave->Save(_node, "Load camera from file");

--- a/lib/params/ViewpointParams.cpp
+++ b/lib/params/ViewpointParams.cpp
@@ -41,7 +41,8 @@ using namespace Wasp;
 const string ViewpointParams::UseCustomFramebufferTag = "UseCustomFramebuffer";
 const string ViewpointParams::CustomFramebufferWidthTag = "CustomFramebufferWidth";
 const string ViewpointParams::CustomFramebufferHeightTag = "CustomFramebufferHeight";
-const string ViewpointParams::CameraDataFileTag = "CameraDataFile";
+const string ViewpointParams::LoadCameraDataFileTag = "LoadCameraDataFile";
+const string ViewpointParams::SaveCameraDataFileTag = "SaveCameraDataFile";
 
 const string ViewpointParams::_viewPointsTag = "Viewpoints";
 const string ViewpointParams::_transformsTag = "Transforms";
@@ -319,7 +320,7 @@ int ViewpointParams::SetCameraFromFile() {
 
     XmlNode *node = new XmlNode();
 
-    std::string path = GetValueString(ViewpointParams::CameraDataFileTag,"");
+    std::string path = GetValueString(ViewpointParams::LoadCameraDataFileTag,"");
     int rc = xmlparser.LoadFromFile(node, path);
     if (rc < 0) {
         MyBase::SetErrMsg("Failed to read file %s : %M", path.c_str());
@@ -337,7 +338,7 @@ int ViewpointParams::SetCameraFromFile() {
 }
 
 int ViewpointParams::SaveCameraToFile() {
-    std::string path = GetValueString(ViewpointParams::CameraDataFileTag,"");
+    std::string path = GetValueString(ViewpointParams::SaveCameraDataFileTag,"");
     ofstream out(path);
     if (!out) {
         MyBase::SetErrMsg("Failed to open file %s : %M", path.c_str());


### PR DESCRIPTION
This isn't intended to be included in 3.7 but it's something that I've been needing for visualization work, so I'll mark this as postponed.

> If we are working on multiple datasets that have the same domain and we want to use the same camera position among them, we need to manually enter 16 values into Vapor.  Currently I'm have a dataset like this that is run at four different resolutions.  Each time I need to change the camera perspective, I change it on one session then manually enter those values into the other three.  This means 48 manual entries per camera change, which is tedious prone to error.

This PR allows the user to save and load the camera state as an .xml file across different sessions from the Scene/Viewpoint tab.

Note: The PButtons that save or load a camera file make callbacks to ViewpointParams functions that may fail if they cannot open the targeted file.  Upon failure, we report the error, but I don't know how to capture the return code from the lambda callback.  @stasj do you have any thoughts on this?

![Screen Shot 2022-09-19 at 2 56 06 PM](https://user-images.githubusercontent.com/9522770/191114926-945b96a7-a6bb-4765-af35-0f29baf27a03.png)
