### PR TITLE
Fix #3205 MOM4-JinHeeYuk-ocean_salt

### DIFF
--- a/include/vapor/VolumeAlgorithm.h
+++ b/include/vapor/VolumeAlgorithm.h
@@ -46,6 +46,7 @@ public:
     //! tasks so they won't crash
     virtual bool  RequiresChunkedRendering() = 0;
     virtual float GuestimateFastModeSpeedupFactor() const { return 1; }
+    virtual int CheckHardwareSupport(const Grid *grid) const { return 0; }
 
     static VolumeAlgorithm *NewAlgorithm(const std::string &name, GLManager *gl, VolumeRenderer *renderer);
 

--- a/include/vapor/VolumeCellTraversal.h
+++ b/include/vapor/VolumeCellTraversal.h
@@ -42,6 +42,7 @@ public:
     virtual ShaderProgram *GetShader() const;
     virtual void           SetUniforms(const ShaderProgram *shader) const;
     virtual float          GuestimateFastModeSpeedupFactor() const;
+    virtual int CheckHardwareSupport(const Grid *grid) const;
 
 private:
     Texture3D      _coordTexture;

--- a/include/vapor/VolumeRegular.h
+++ b/include/vapor/VolumeRegular.h
@@ -33,6 +33,7 @@ public:
     virtual ShaderProgram *GetShader() const;
     virtual void           SetUniforms(const ShaderProgram *shader) const;
     virtual float          GuestimateFastModeSpeedupFactor() const;
+    virtual int CheckHardwareSupport(const Grid *grid) const;
 
 protected:
     Texture3D _data;

--- a/include/vapor/glutil.h
+++ b/include/vapor/glutil.h
@@ -100,6 +100,10 @@ RENDER_API void doubleToString(const double val, std::string &result, int digits
 //
 RENDER_API std::string oglGetErrMsg(std::vector<int> status);
 
+//! Returns free RAM in kilobytes
+//! Returns -1 if not supported
+RENDER_API int oglGetFreeMemory();
+
 //! Test readyness of OpenGL frame buffer, GL_FRAMEBUFFER
 //!
 RENDER_API bool FrameBufferReady();

--- a/lib/render/Renderer.cpp
+++ b/lib/render/Renderer.cpp
@@ -131,7 +131,7 @@ int Renderer::paintGL(bool fast)
     vector<int> status;
     bool        ok = oglStatusOK(status);
     if (!ok) {
-        SetErrMsg("OpenGL error : %s", oglGetErrMsg(status).c_str());
+        SetErrMsg("%s", oglGetErrMsg(status).c_str());
         return (-1);
     }
     return (0);

--- a/lib/render/Texture.cpp
+++ b/lib/render/Texture.cpp
@@ -55,14 +55,14 @@ int Texture::TexImage(int internalFormat, int width, int height, int depth, unsi
     VAssert(_nDims >= 3 || depth == 0);
 
     if (_nDims == 3) {
-        int max3DTexDim;
+        GLint max3DTexDim;
         glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE, &max3DTexDim);
         if (width > max3DTexDim || height > max3DTexDim || depth > max3DTexDim) {
             Wasp::MyBase::SetErrMsg("Texture size (%lix%lix%li) not supported by GPU (max supported size per dim is %i)\n", width, height, depth, max3DTexDim);
             return -1;
         }
     } else {
-        int max2DTexDim;
+        GLint max2DTexDim;
         glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max2DTexDim);
         if (width > max2DTexDim || height > max2DTexDim) {
             Wasp::MyBase::SetErrMsg("Texture size (%lix%li) not supported by GPU (max supported size per dim is %i)\n", width, height, max2DTexDim);

--- a/lib/render/Texture.cpp
+++ b/lib/render/Texture.cpp
@@ -1,6 +1,7 @@
 #include <vapor/Texture.h>
 #include <vapor/glutil.h>
-#include "vapor/VAssert.h"
+#include <vapor/MyBase.h>
+#include <vapor/VAssert.h>
 
 using namespace VAPoR;
 
@@ -52,6 +53,23 @@ int Texture::TexImage(int internalFormat, int width, int height, int depth, unsi
     VAssert(Initialized());
     VAssert(_nDims >= 2 || height == 0);
     VAssert(_nDims >= 3 || depth == 0);
+
+    if (_nDims == 3) {
+        int max3DTexDim;
+        glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE, &max3DTexDim);
+        if (width > max3DTexDim || height > max3DTexDim || depth > max3DTexDim) {
+            Wasp::MyBase::SetErrMsg("Texture size (%lix%lix%li) not supported by GPU (max supported size per dim is %i)\n", width, height, depth, max3DTexDim);
+            return -1;
+        }
+    } else {
+        int max2DTexDim;
+        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max2DTexDim);
+        if (width > max2DTexDim || height > max2DTexDim) {
+            Wasp::MyBase::SetErrMsg("Texture size (%lix%li) not supported by GPU (max supported size per dim is %i)\n", width, height, max2DTexDim);
+            return -1;
+        }
+    }
+
     _width = width;
     _height = height;
     _depth = depth;

--- a/lib/render/VolumeCellTraversal.cpp
+++ b/lib/render/VolumeCellTraversal.cpp
@@ -412,6 +412,26 @@ void VolumeCellTraversal::SetUniforms(const ShaderProgram *s) const
 
 float VolumeCellTraversal::GuestimateFastModeSpeedupFactor() const { return 2; }
 
+int VolumeCellTraversal::CheckHardwareSupport(const Grid *grid) const
+{
+    int ret = VolumeRegular::CheckHardwareSupport(grid);
+    if (ret < 0)
+        return ret;
+
+    long freeKB = oglGetFreeMemory();
+    if (freeKB >= 0) {
+        auto dims = grid->GetDimensions();
+        long estimatedMinimumB = dims[0]*dims[1]*dims[2] * sizeof(float) * 4;
+        long estimatedMinimumKB = estimatedMinimumB/1024;
+        if (freeKB < estimatedMinimumKB) {
+            Wasp::MyBase::SetErrMsg("Not enough GPU RAM free (%liMB free, need at least %liMB)\n", freeKB/1024, estimatedMinimumKB/1024);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
 bool VolumeCellTraversal::_needsHighPrecisionTriangleRoutine(const Grid *grid)
 {
     vector<double> extentsMin, extentsMax;

--- a/lib/render/VolumeRenderer.cpp
+++ b/lib/render/VolumeRenderer.cpp
@@ -358,8 +358,11 @@ int VolumeRenderer::_loadData()
         }
     }
 
-    int ret = _algorithm->LoadData(grid);
-    _lastRenderTime = 10000;
+    int ret = _algorithm->CheckHardwareSupport(grid);
+    if (ret == 0) {
+        ret = _algorithm->LoadData(grid);
+        _lastRenderTime = 10000;
+    }
     delete grid;
     return ret;
 }

--- a/lib/render/glutil.cpp
+++ b/lib/render/glutil.cpp
@@ -69,11 +69,55 @@ bool oglStatusOK(vector<int> &status)
     return (true);
 }
 
+static const char *_glErrorStr(int err)
+{
+    switch (err) {
+#define ERR_TO_STR(E) case E: return #E
+        ERR_TO_STR(GL_NO_ERROR);
+        ERR_TO_STR(GL_INVALID_ENUM);
+        ERR_TO_STR(GL_INVALID_VALUE);
+        ERR_TO_STR(GL_INVALID_OPERATION);
+        ERR_TO_STR(GL_INVALID_FRAMEBUFFER_OPERATION);
+        ERR_TO_STR(GL_OUT_OF_MEMORY);
+//        ERR_TO_STR(GL_STACK_UNDERFLOW);
+//        ERR_TO_STR(GL_STACK_OVERFLOW);
+    default: return "GL_UNKNOWN_ERROR";
+    }
+}
+
 string oglGetErrMsg(vector<int> status)
 {
     string msg;
-    for (int i = 0; i < status.size(); i++) msg += "Error #" + std::to_string(status[i]) + "\n";
+    for (auto e : status) {
+        msg += "OpenGL Error: ";
+        msg += _glErrorStr(e);
+        msg += " (#" + std::to_string(e) + ")\n";
+    }
     return msg;
+}
+
+int oglGetFreeMemory()
+{
+#define TEXTURE_FREE_MEMORY_ATI 0x87FC
+#define GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX 0x9049
+    int buf[4];
+    vector<int> _;
+
+    memset(buf, 0, sizeof(buf));
+    glGetIntegerv(TEXTURE_FREE_MEMORY_ATI, buf);
+    if (buf[0] > 0)
+        return buf[0];
+
+    oglStatusOK(_);
+
+    memset(buf, 0, sizeof(buf));
+    glGetIntegerv(GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, buf);
+    if (buf[0] > 0)
+        return buf[0];
+
+    oglStatusOK(_);
+
+    return -1;
 }
 
 int __CheckGLError(const char *file, int line, const char *msg)

--- a/lib/render/glutil.cpp
+++ b/lib/render/glutil.cpp
@@ -100,7 +100,7 @@ int oglGetFreeMemory()
 {
 #define TEXTURE_FREE_MEMORY_ATI 0x87FC
 #define GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX 0x9049
-    int buf[4];
+    GLint buf[4];
     vector<int> _;
 
     memset(buf, 0, sizeof(buf));


### PR DESCRIPTION
This dataset was triggering issues with different OpenGL driver limitations depending on the system. This PR adds proper error handling for these scenarios. It also adds a mechanism for predicting the amount of GPU RAM required to render a dataset and lets the user know right away if they don't have enough, rather than making them wait for the GPU RAM to overflow and get an error (only works for vendors with extensions for querying GPU RAM since this is not supported in the OpenGL spec). Finally, it improves OpenGL error reporting overall by replacing the old `OpenGL Error #1234` messages with proper error strings.

Fix #3205