### PR TITLE
Add default variable logic for particle renderer

### DIFF
--- a/include/vapor/RenderParams.h
+++ b/include/vapor/RenderParams.h
@@ -479,6 +479,7 @@ private:
     static const string _currentTimestepTag;
 
     string _findVarStartingWithLetter(std::vector<string> searchVars, char letter);
+    string _findVarEndingWithLetter(std::vector<string> searchVars, char letter);
 
 public:
     static const string _variableNameTag;

--- a/lib/params/ParticleParams.cpp
+++ b/lib/params/ParticleParams.cpp
@@ -54,4 +54,6 @@ void ParticleParams::_init()
     SetValueDouble(PhongDiffuseTag, "", .8);
     SetValueDouble(PhongSpecularTag, "", 0.);
     SetValueDouble(PhongShininessTag, "", 2.);
+
+    RenderParams::SetDefaultVariables(3, true);
 }

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -108,12 +108,20 @@ void RenderParams::SetDefaultVariables(int dim = 3, bool secondaryColormapVariab
     vector<string> varnames;
     varnames = _dataMgr->GetDataVarNames(dim);
 
+    // Try to find U, V, and W vector variables
     vector<string> fieldVarNames(3, "");
     fieldVarNames[0] = _findVarStartingWithLetter(varnames, 'u');
     fieldVarNames[1] = _findVarStartingWithLetter(varnames, 'v');
     if (dim == 3) {
         fieldVarNames[2] = _findVarStartingWithLetter(varnames, 'w');
         SetHeightVariableName("");
+    }
+
+    // If we can't find U or V, look for variables that correspond with the X, Y, and Z dimensions such as bx, by, and bz
+    if (fieldVarNames[0] == "" || fieldVarNames[1] == "") {
+        fieldVarNames[0] = _findVarEndingWithLetter(varnames, 'x');
+        fieldVarNames[1] = _findVarEndingWithLetter(varnames, 'y');
+        if (dim == 3) fieldVarNames[2] = _findVarEndingWithLetter(varnames, 'z');
     }
 
     SetFieldVariableNames(fieldVarNames);
@@ -656,6 +664,16 @@ string RenderParams::_findVarStartingWithLetter(vector<string> searchVars, char 
     }
     return "";
 }
+
+string RenderParams::_findVarEndingWithLetter(vector<string> searchVars, char letter)
+{
+    for (auto &element : searchVars) {
+        int last = element.size()-1;
+        if (element[last] == letter || element[last] == toupper(letter)) { return element; }
+    }
+    return "";
+}
+
 //////////////////////////////////////////////////////////////////////////
 //
 // RenParamsFactory Class


### PR DESCRIPTION
Fixes #3246 by adding new logic for selecting default field variables.  If Vapor cannot detect X and Y variables beginning with U or V, then we search for variables that end in X, Y, and (if 3d) Z.

This applies to the use cases of 1) magnetic fields (bx, by, and bz) and our DCP standard naming convention (vel_x, vel_y, and vel_z).