### PR TITLE
Relax python api dependency compatibility

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -40,23 +40,23 @@ requirements:
     - mesalib=21.2.5
   run:
     # Run only
-    - xarray=2022.3.0
-    - matplotlib=3.3.2 #=3.3.4
-    - ipython=8.3.0 #=8.1.1
-    - jupyter=1.0.0
-    - py-opencv=4.5.3
-    - cppyy=2.2.0 # If this is in build conda will load an old clang compiler which fails to compile macOS headers
+    - xarray=2022 #=2022.3.0
+    - matplotlib=3 #=3.3.2
+    - ipython=8 #=8.3.0 
+    - jupyter=1 #=1.0.0
+    - py-opencv=4 #=4.5.3
+    - cppyy=2.2 #=2.2.0 If this is in build conda will load an old clang compiler which fails to compile macOS headers
     # Both
-    - python=3.9.5
-    - numpy=1.21.4
-    - assimp=5.0.1
-    - freetype=2.10.4
-    - hdf5=1.12.1
-    - jpeg=9e
-    - geotiff=1.6.0
-    - udunits2=2.2.26
-    - netcdf4=1.5.8
-    - libtiff=4.3.0
-    - proj=7.2.0
-    - glm=0.9.9.4
-    - mesalib=21.2.5
+    - python=3.9 # pin_compatible('python') selects python 3.10 which is not compatible
+    - {{ pin_compatible('numpy') }}
+    - {{ pin_compatible('assimp') }}
+    - {{ pin_compatible('freetype') }}
+    - {{ pin_compatible('hdf5') }}
+    - {{ pin_compatible('jpeg') }}
+    - {{ pin_compatible('geotiff') }}
+    - {{ pin_compatible('udunits2') }}
+    - {{ pin_compatible('netcdf4') }}
+    - {{ pin_compatible('libtiff') }}
+    - {{ pin_compatible('proj') }}
+    - {{ pin_compatible('glm') }}
+    - {{ pin_compatible('mesalib') }}


### PR DESCRIPTION
This PR relaxes the Python API's dependency compatibility. For python runtime dependencies, these were changed to the major release versions except for more troublesome libraries. For linked dependencies, it mostly uses Conda's built in functionality. In my testing I have found it to be unreliable in certain cases however the config in this PR has worked as expected in my testing so far. The build dependencies remain locked for stability.

Fix #3141