### PR TITLE
Add M1 installer to weekly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -955,8 +955,8 @@ workflows:
         - schedule:
              cron: "05 00 * * 4" #Mountain Standard Time +6
              filters:
-             #  branches:
-             #    only: main
+               branches:
+                 only: main
       jobs:
         - build_ubuntu18_installer
         - build_centos7_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           paths:
             - installers
 
-  build_osx_installer:
+  setup_osx:
     macos:
       xcode: "13.4.1"
     steps:
@@ -68,10 +68,6 @@ jobs:
             sudo mkdir -p /usr/local/VAPOR-Deps
             sudo chmod -R 777 /usr/local/VAPOR-Deps
             sudo chown -R `whoami` /usr/local/VAPOR-Deps
-
-      #- restore_cache:
-      #    keys:
-      #      - clang12jafiojeoa;ij;eaw
 
       - checkout
 
@@ -118,11 +114,70 @@ jobs:
             /opt/local/bin/clang++ -v > clangVersion.txt
           no_output_timeout: 30m
 
-      #- save_cache:
-      #    key: clang12jafiojeoa;ij;eaw
-      #    paths:
-      #      - /opt/local/bin
-      #      - /opt/local/lib/libomp
+      - save_cache:
+          key: osx-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - /usr/local/VAPOR-Deps
+            - /opt/local/bin
+
+  build_osx_installer:
+    macos:
+      xcode: "13.4.1"
+    steps:
+      #- restore_cache:
+      #    keys:
+      #      - osx-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Make VAPOR-Deps
+          command: |
+            sudo mkdir -p /usr/local/VAPOR-Deps
+            sudo chmod -R 777 /usr/local/VAPOR-Deps
+            sudo chown -R `whoami` /usr/local/VAPOR-Deps
+
+      - checkout
+
+      - run:
+          name: Get third party libraries
+          command: |
+            pip3 install gdown
+            sudo mkdir -p /usr/local/VAPOR-Deps
+            sudo chmod 777 /usr/local/VAPOR-Deps
+            cd /usr/local/VAPOR-Deps
+            gdown https://drive.google.com/uc?id=1Q-IXlP_OgZSXsWKmT-smyrW9xnR-dUfg
+            cd /usr/local/VAPOR-Deps
+            tar xf 2019-Aug-Darwin.tar.xz -C /usr/local/VAPOR-Deps
+            chmod -R 777 /usr/local/VAPOR-Deps
+
+      - run:
+          name: Get cmake
+          command: |
+            brew install cmake
+
+      - run:
+          name: Get MacPorts
+          command: |
+            curl -k -O https://distfiles.macports.org/MacPorts/MacPorts-2.7.1.tar.bz2
+            tar xf MacPorts-2.7.1.tar.bz2
+            cd MacPorts-2.7.1/
+            ./configure
+            make -j2
+            sudo make install -j2
+
+      - run:
+          name: Get libomp
+          command: |
+            #sudo /opt/local/bin/port selfupdate
+            #(sudo yes || true) | sudo /opt/local/bin/port install libomp
+          no_output_timeout: 30m
+
+      - run:
+          name: Get clang13
+          command: |
+            sudo /opt/local/bin/port selfupdate
+            (sudo yes || true) | sudo /opt/local/bin/port install clang-13
+            sudo /opt/local/bin/port select --set clang mp-clang-13
+            /opt/local/bin/clang++ -v > clangVersion.txt
+          no_output_timeout: 30m
 
       - run:
           name: make VAPOR
@@ -133,7 +188,13 @@ jobs:
             git checkout $CIRCLE_BRANCH
             export PATH=/opt/local/bin:$PATH
             sudo port select --set clang mp-clang-13
-            cmake -DCPACK_BINARY_DRAGNDROP=ON -DCMAKE_BUILD_TYPE:String=Release -DDIST_INSTALLER:string=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DUSE_OMP=ON ..
+            cmake -DCPACK_BINARY_DRAGNDROP=ON \
+                  -DCMAKE_BUILD_TYPE:String=Release \
+                  -DDIST_INSTALLER:string=ON \
+                  -DCMAKE_CXX_COMPILER=clang++ \
+                  -DCMAKE_C_COMPILER=clang \
+                  -DUSE_OMP=ON \
+                  ..
             make -j2
             make installer -j2
             mkdir -p /tmp/workspace/installers
@@ -147,6 +208,91 @@ jobs:
           root: *workspace_root
           paths:
             - installers
+
+  build_M1_installer:
+    macos:
+      xcode: "13.4.1"
+    steps:
+      # Saving and restoring cache takes forever, so we must repeat build_osx_steps verbatim
+      #- restore_cache:
+      #    keys:
+      #      - osx-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Make VAPOR-Deps
+          command: |
+            sudo mkdir -p /usr/local/VAPOR-Deps
+            sudo chmod -R 777 /usr/local/VAPOR-Deps
+            sudo chown -R `whoami` /usr/local/VAPOR-Deps
+
+      - checkout
+
+      - run:
+          name: Get third party libraries
+          command: |
+            pip3 install gdown
+            sudo mkdir -p /usr/local/VAPOR-Deps
+            sudo chmod 777 /usr/local/VAPOR-Deps
+            cd /usr/local/VAPOR-Deps
+            gdown https://drive.google.com/uc?id=1Q-IXlP_OgZSXsWKmT-smyrW9xnR-dUfg
+            cd /usr/local/VAPOR-Deps
+            tar xf 2019-Aug-Darwin.tar.xz -C /usr/local/VAPOR-Deps
+            chmod -R 777 /usr/local/VAPOR-Deps
+
+      - run:
+          name: Get cmake
+          command: |
+            brew install cmake
+
+      - run:
+          name: Get MacPorts
+          command: |
+            curl -k -O https://distfiles.macports.org/MacPorts/MacPorts-2.7.1.tar.bz2
+            tar xf MacPorts-2.7.1.tar.bz2
+            cd MacPorts-2.7.1/
+            ./configure
+            make -j2
+            sudo make install -j2
+
+      - run:
+          name: Get clang13
+          command: |
+            sudo /opt/local/bin/port selfupdate
+            (sudo yes || true) | sudo /opt/local/bin/port install clang-13
+            sudo /opt/local/bin/port select --set clang mp-clang-13
+            /opt/local/bin/clang++ -v > clangVersion.txt
+          no_output_timeout: 30m
+      - run:
+          name: make VAPOR
+          command: |
+            cp site_files/site.NCAR site.local
+            mkdir build
+            cd build
+            git checkout $CIRCLE_BRANCH
+            export PATH=/opt/local/bin:$PATH
+            sudo port select --set clang mp-clang-13
+            cmake -DBUILD_OSP=OFF \
+                  -DCPACK_BINARY_DRAGNDROP=ON \
+                  -DCMAKE_BUILD_TYPE:String=Release \
+                  -DDIST_INSTALLER:string=ON \
+                  -DCMAKE_CXX_COMPILER=clang++ \
+                  -DCMAKE_C_COMPILER=clang \
+                  -DUSE_OMP=ON \
+                  ..
+            make -j2
+            make installer -j2
+            mkdir -p /tmp/workspace/installers
+            mv *.dmg /tmp/workspace/installers
+            for f in /tmp/workspace/installers/VAPOR3-*.dmg ; do mv "$f" "${f/Darwin/M1}" ; done
+          no_output_timeout: 30m
+
+      - store_artifacts:
+          path: /tmp/workspace/installers
+
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - installers
+
 
   build_ubuntu18_installer:
     docker:
@@ -769,10 +915,13 @@ jobs:
             #os="OSX:       "
             #sha=`shasum -a 256 VAPOR3*Darwin*`
             #osxSha=$os$sha$endl
+            #os="M1:       "
+            #sha=`shasum -a 256 VAPOR3*M1*`
+            #osxSha=$os$sha$endl
             #os="Windows:   "
             #sha=`shasum -a 256 VAPOR3*win64*`
             #winSha=$os$sha$endl
-            shaMessage="$title$ubuntuSha$centosSha$osxSha$winSha"
+            shaMessage="$title$ubuntuSha$centosSha$osxSha$m1Sha$winSha"
             date=`date +"%d_%m_%y"`
             echo $shaMessage > "/tmp/workspace/installers/sha256.txt"
             echo ghr -b "Weekly installers are untested an may not be stable.  Built with commit ${hash} on ${date} \(DD-MM-YY\)" -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -prerelease -c ${CIRCLE_SHA1} -recreate -c ${hash} -n ${tag} ${tag} /tmp/workspace/installers
@@ -792,6 +941,7 @@ workflows:
       #- test_clang_format
       #- build_win10_installer
       #- build_osx_installer
+      #- build_M1_installer
       #- build_ubuntu18_installer
       #- build_centos7_installer
       #- release_weekly_installers:
@@ -805,8 +955,8 @@ workflows:
         - schedule:
              cron: "05 00 * * 4" #Mountain Standard Time +6
              filters:
-               branches:
-                 only: main
+             #  branches:
+             #    only: main
       jobs:
         - build_ubuntu18_installer
         - build_centos7_installer
@@ -819,6 +969,7 @@ workflows:
               - build_ubuntu18_installer
               - build_centos7_installer
               - build_osx_installer
+              - build_M1_installer
               - build_win10_installer
               #- build_python_api_ubuntu
               #- build_python_api_osx


### PR DESCRIPTION
To support M1 processors, we need an OSX build that disables Ospray.  This PR adds an installer for M1 processors to our weekly build.  Related to #3257.