### PR TITLE
Issue3162 v1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -932,15 +932,15 @@ workflows:
   build:
     jobs:
       #- clang-tidy
-      - build_ubuntu18
-      - build_centos7
-      - build_python_api_ubuntuDebug
-      - build_python_api_ubuntu
+      #- build_ubuntu18
+      #- build_centos7
+      #- build_python_api_ubuntuDebug
+      #- build_python_api_ubuntu
       #- build_python_api_centos
       #- build_python_api_osx
       #- test_clang_format
       #- build_win10_installer
-      #- build_osx_installer
+      - build_osx_installer
       #- build_M1_installer
       #- build_ubuntu18_installer
       #- build_centos7_installer

--- a/apps/vaporgui/PVariableSelector.cpp
+++ b/apps/vaporgui/PVariableSelector.cpp
@@ -1,4 +1,5 @@
 #include "PVariableSelector.h"
+#include "PCheckbox.h"
 #include <vapor/RenderParams.h>
 #include <assert.h>
 
@@ -49,11 +50,22 @@ void PVariableSelector::dropdownTextChanged(std::string text)
 
 PScalarVariableSelector::PScalarVariableSelector() : PVariableSelector(RenderParams::_variableNameTag, "Variable Name") {}
 PColorMapVariableSelector::PColorMapVariableSelector() : PVariableSelector(RenderParams::_colorMapVariableNameTag, "Color mapped variable") {}
-PHeightVariableSelector::PHeightVariableSelector() : PVariableSelector2D(RenderParams::_heightVariableNameTag, "Height variable")
-{
-    AddNullOption();
-    OnlyShowForDim(2);
-}
 PXFieldVariableSelector::PXFieldVariableSelector() : PVariableSelector(RenderParams::_xFieldVariableNameTag, "X Field") { AddNullOption(); }
 PYFieldVariableSelector::PYFieldVariableSelector() : PVariableSelector(RenderParams::_yFieldVariableNameTag, "Y Field") { AddNullOption(); }
 PZFieldVariableSelector::PZFieldVariableSelector() : PVariableSelector(RenderParams::_zFieldVariableNameTag, "Z Field") { AddNullOption(); }
+
+PHeightVariableSelector::PHeightVariableSelector() : PGroup() {
+    Add((new PVariableSelector2D(RenderParams::_heightVariableNameTag, "Height variable"))->AddNullOption());
+    Add(new PCheckbox(RenderParams::AddHeightToBottomTag, "Add height values to bottom of domain"));
+    OnlyShowForDim(2);
+}
+
+PHeightVariableSelector* PHeightVariableSelector::OnlyShowForDim(int dim) {
+    _onlyShowForDim = dim;
+    return this;
+}
+
+bool PHeightVariableSelector::isShown() const {
+    if (_onlyShowForDim > 0) return getParams<RenderParams>()->GetRenderDim() == _onlyShowForDim;
+    return true;
+}

--- a/apps/vaporgui/PVariableSelector.h
+++ b/apps/vaporgui/PVariableSelector.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "PStringDropdown.h"
+#include "PGroup.h"
 
 //! \class PVariableSelector
 //! \author Stas Jaroszynski
@@ -76,9 +77,12 @@ class PColorMapVariableSelector : public PVariableSelector {
 public:
     PColorMapVariableSelector();
 };
-class PHeightVariableSelector : public PVariableSelector2D {
+class PHeightVariableSelector : public PGroup {
+    bool isShown() const override;
+    int _onlyShowForDim = -1;
 public:
     PHeightVariableSelector();
+    PHeightVariableSelector* OnlyShowForDim(int dim);
 };
 class PXFieldVariableSelector : public PVariableSelector {
 public:

--- a/include/vapor/BarbRenderer.h
+++ b/include/vapor/BarbRenderer.h
@@ -153,6 +153,7 @@ private:
         float          colorSamples[10][3];
         float          alphaSamples[10];
         bool           needToRecalc;
+        bool           addHeightToBottom;
     } _cacheParams;
 
     bool _isCacheDirty() const;

--- a/include/vapor/ImageRenderer.h
+++ b/include/vapor/ImageRenderer.h
@@ -44,6 +44,7 @@ private:
     string         _cacheHgtVar;
     int            _cacheGeoreferenced;
     vector<double> _cacheBoxExtentsTex;
+    bool           _cacheAddHeightToBottom;
     SmartBuf       _sb_verts;
     SmartBuf       _sb_normals;
     SmartBuf       _sb_indices;

--- a/include/vapor/RenderParams.h
+++ b/include/vapor/RenderParams.h
@@ -497,6 +497,7 @@ public:
     static const string CustomHistogramDataTag;
     static const string CustomHistogramRangeTag;
     static const string LightingEnabledTag;
+    static const string AddHeightToBottomTag;
 
     //! If a renderer supports rotation about a point of origin (IE - Slice and Contour),
     //! this tag identifies the parameter for the origin's

--- a/include/vapor/SetHDF5PluginPath.h
+++ b/include/vapor/SetHDF5PluginPath.h
@@ -12,8 +12,7 @@ void SetHDF5PluginPath() {
     string plugins = Wasp::GetSharePath("plugins");
 
     #ifndef WIN32
-        std::cout << "retVal: " << H5PLreplace(plugins.c_str(), 0) << std::endl;
-        std::cout << plugins << std::endl;
+        H5PLreplace(plugins.c_str(), 0);
     #else
         plugins = "HDF5_PLUGIN_PATH=" + plugins;
         int rc=_putenv(plugins.c_str());

--- a/include/vapor/SetHDF5PluginPath.h
+++ b/include/vapor/SetHDF5PluginPath.h
@@ -12,7 +12,8 @@ void SetHDF5PluginPath() {
     string plugins = Wasp::GetSharePath("plugins");
 
     #ifndef WIN32
-        H5PLreplace(plugins.c_str(), 0);
+        std::cout << "retVal: " << H5PLreplace(plugins.c_str(), 0) << std::endl;
+        std::cout << plugins << std::endl;
     #else
         plugins = "HDF5_PLUGIN_PATH=" + plugins;
         int rc=_putenv(plugins.c_str());

--- a/include/vapor/TwoDDataRenderer.h
+++ b/include/vapor/TwoDDataRenderer.h
@@ -52,8 +52,8 @@ private:
     class _grid_state_c {
     public:
         _grid_state_c() = default;
-        _grid_state_c(size_t numRefLevels, int refLevel, int lod, string hgtVar, string meshName, size_t ts, vector<double> minExts, vector<double> maxExts)
-        : _numRefLevels(numRefLevels), _refLevel(refLevel), _lod(lod), _hgtVar(hgtVar), _meshName(meshName), _ts(ts), _minExts(minExts), _maxExts(maxExts)
+        _grid_state_c(size_t numRefLevels, int refLevel, int lod, string hgtVar, string meshName, size_t ts, vector<double> minExts, vector<double> maxExts, bool addHeightToBottom)
+        : _numRefLevels(numRefLevels), _refLevel(refLevel), _lod(lod), _hgtVar(hgtVar), _meshName(meshName), _ts(ts), _minExts(minExts), _maxExts(maxExts), _addHeightToBottom(addHeightToBottom)
         {
         }
 
@@ -65,12 +65,13 @@ private:
             _ts = 0;
             _minExts.clear();
             _maxExts.clear();
+            _addHeightToBottom = false;
         }
 
         bool operator==(const _grid_state_c &rhs) const
         {
             return (_numRefLevels == rhs._numRefLevels && _refLevel == rhs._refLevel && _lod == rhs._lod && _hgtVar == rhs._hgtVar && _meshName == rhs._meshName && _ts == rhs._ts
-                    && _minExts == rhs._minExts && _maxExts == rhs._maxExts);
+                    && _minExts == rhs._minExts && _maxExts == rhs._maxExts && _addHeightToBottom == rhs._addHeightToBottom);
         }
         bool operator!=(const _grid_state_c &rhs) const { return (!(*this == rhs)); }
 
@@ -83,6 +84,7 @@ private:
         size_t         _ts;
         vector<double> _minExts;
         vector<double> _maxExts;
+        bool           _addHeightToBottom;
     };
 
     class _tex_state_c {

--- a/include/vapor/WireFrameRenderer.h
+++ b/include/vapor/WireFrameRenderer.h
@@ -59,6 +59,7 @@ private:
         int                 level;
         int                 lod;
         std::vector<double> boxMin, boxMax;
+        bool                addHeightToBottom;
 
     } _cacheParams;
 

--- a/lib/params/RenderParams.cpp
+++ b/lib/params/RenderParams.cpp
@@ -67,6 +67,7 @@ const string RenderParams::SlicePlaneNormalYTag = "SlicePlaneNormalYTag";
 const string RenderParams::SlicePlaneNormalZTag = "SlicePlaneNormalZTag";
 const string RenderParams::SlicePlaneOrientationModeTag = "SlicePlaneOrientationModeTag";
 const string RenderParams::LightingEnabledTag = "LightingEnabled";
+const string RenderParams::AddHeightToBottomTag = "AddHeightToBottom";
 
 #define REQUIRED_SAMPLE_SIZE 1000000
 

--- a/lib/render/BarbRenderer.cpp
+++ b/lib/render/BarbRenderer.cpp
@@ -110,6 +110,7 @@ void BarbRenderer::_saveCacheParams()
     _cacheParams.grid = p->GetGrid();
     _cacheParams.needToRecalc = p->GetNeedToRecalculateScales();
     _cacheParams.useSingleColor = p->UseSingleColor();
+    _cacheParams.addHeightToBottom = p->GetValueLong(RenderParams::AddHeightToBottomTag, false);
     p->GetBox()->GetExtents(_cacheParams.boxMin, _cacheParams.boxMax);
 }
 
@@ -126,6 +127,7 @@ bool BarbRenderer::_isCacheDirty() const
     if (_cacheParams.grid != p->GetGrid()) return true;
     if (_cacheParams.needToRecalc != p->GetNeedToRecalculateScales()) return true;
     if (_cacheParams.useSingleColor != p->UseSingleColor()) return true;
+    if (_cacheParams.addHeightToBottom != p->GetValueLong(RenderParams::AddHeightToBottomTag, false)) return true;
 
     vector<double> min, max, contourValues;
     p->GetBox()->GetExtents(min, max);
@@ -601,6 +603,9 @@ float BarbRenderer::_getHeightOffset(Grid *heightVar, float xCoord, float yCoord
         missing = true;
         offset = 0.f;
     }
+    BarbParams* p = (BarbParams *)GetActiveParams();
+    if (!p->GetValueLong(RenderParams::AddHeightToBottomTag, false))
+        offset -= GetDefaultZ(_dataMgr, p->GetCurrentTimestep());
     return offset;
 }
 


### PR DESCRIPTION
This PR adds a checkbox that adds the minimum Z extent to 2D renderers using a height variable.  Is there a use case for this???

This is the alternative to PR #3272, which simply represents height variables as an absolute coordinate.  I think that's what we want, not this.

![](https://user-images.githubusercontent.com/9522770/200904695-02a105de-5bbb-4bfe-9f9a-6cdc0acedd89.gif)
