### PR TITLE
Restructure smoketest functions

### DIFF
--- a/test_apps/smokeTests/dataMgrTools.cpp
+++ b/test_apps/smokeTests/dataMgrTools.cpp
@@ -3,6 +3,25 @@
 #include "gridTools.h"
 #include "dataMgrTools.h"
 
+int TestDataMgr(const std::string &fileType, size_t memsize, size_t nthreads, const std::vector<std::string> &files, const std::vector<std::string> &options, bool silenceTime)
+{
+    VAPoR::DataMgr dataMgr(fileType, memsize, nthreads);
+    int            rc = dataMgr.Initialize(files, options);
+    if (rc < 0) {
+        cerr << "Failed to intialize WRF DataMGR" << endl;
+        return -1;
+    }
+
+    PrintDimensions(dataMgr);
+    PrintMeshes(dataMgr);
+    PrintVariables(dataMgr);
+    TestVariables(dataMgr, silenceTime);
+    PrintCoordVariables(dataMgr);
+    PrintTimeCoordinates(dataMgr);
+
+    return 0;
+}
+
 void PrintDimensions(const VAPoR::DataMgr &dataMgr)
 {
     vector<string> dimnames;
@@ -138,23 +157,4 @@ void TestVariables(VAPoR::DataMgr &dataMgr, bool silenceTime)
             PrintStats(rms, numMissingValues, disagreements, 0.0, silenceTime);
         }
     }
-}
-
-int TestDataMgr(const std::string &fileType, size_t memsize, size_t nthreads, const std::vector<std::string> &files, const std::vector<std::string> &options, bool silenceTime)
-{
-    VAPoR::DataMgr dataMgr(fileType, memsize, nthreads);
-    int            rc = dataMgr.Initialize(files, options);
-    if (rc < 0) {
-        cerr << "Failed to intialize WRF DataMGR" << endl;
-        return -1;
-    }
-
-    PrintDimensions(dataMgr);
-    PrintMeshes(dataMgr);
-    PrintVariables(dataMgr);
-    TestVariables(dataMgr, silenceTime);
-    PrintCoordVariables(dataMgr);
-    PrintTimeCoordinates(dataMgr);
-
-    return 0;
 }

--- a/test_apps/smokeTests/dataMgrTools.h
+++ b/test_apps/smokeTests/dataMgrTools.h
@@ -4,6 +4,8 @@
 
 #include <vapor/DataMgr.h>
 
+int TestDataMgr(const std::string &fileType, size_t memsize, size_t nthreads, const std::vector<std::string> &files, const std::vector<std::string> &options, bool silenceTime);
+
 void PrintDimensions(const VAPoR::DataMgr &dataMgr);
 
 void PrintMeshes(const VAPoR::DataMgr &dataMgr, bool verbose = false);
@@ -16,6 +18,4 @@ void PrintVariables(const VAPoR::DataMgr &dataMgr, bool verbose = false, bool te
 
 void PrintCompressionInfo(const VAPoR::DataMgr &dataMgr, const std::string &varname);
 
-void TestVariables(VAPoR::DataMgr &dataMgr);
-
-int TestDataMgr(const std::string &fileType, size_t memsize, size_t nthreads, const std::vector<std::string> &files, const std::vector<std::string> &options, bool silenceTime);
+void TestVariables(VAPoR::DataMgr &dataMgr, bool siclenceTime);

--- a/test_apps/smokeTests/gridTools.h
+++ b/test_apps/smokeTests/gridTools.h
@@ -6,9 +6,9 @@
 #include <vapor/StretchedGrid.h>
 #include <vapor/UnstructuredGrid2D.h>
 
-std::vector<float *> AllocateBlocks(const std::vector<size_t> &bs, const std::vector<size_t> &dims);
+void DeleteHeap();
 
-bool RandomizeMissingValue();
+std::vector<float *> AllocateBlocks(const std::vector<size_t> &bs, const std::vector<size_t> &dims);
 
 void MakeTriangle(VAPoR::Grid *grid, float minVal, float maxVal, bool addRandomMissingValues=true);
 
@@ -24,31 +24,28 @@ bool CompareIndexToCoords(VAPoR::Grid *grid,
                           size_t &     disagreements        // Counter for when AccessIJK() and GetValue() disagree
 );
 
-bool isNotEqual(double x, double y);
-
-// Returns the expected node count for Grid::ConstNodeIterator
-bool TestConstNodeIterator(const VAPoR::Grid *g, size_t &count, size_t &expectedCount, size_t &disagreements, double &time);
-
 // Returns the expected node count for Grid::Iterator
 bool TestIterator(VAPoR::Grid *g, size_t &count, size_t &expectedCount, size_t &disagreements, double &time);
 
 // Returns the expected node count for Grid::ConstCoordIterator
 bool TestConstCoordItr(const VAPoR::Grid *g, size_t &count, size_t &expectedCount, size_t &disagreements, double &time);
 
-void PrintGridIteratorResults(std::string &gridType, std::string itrType, size_t count, size_t expectedCount, size_t disagreements, double time, bool silenceTime);
+// Returns the expected node count for Grid::ConstNodeIterator
+bool TestConstNodeIterator(const VAPoR::Grid *g, size_t &count, size_t &expectedCount, size_t &disagreements, double &time, bool withCoordBounds);
 
 void PrintStats(double rms, size_t numMissingValues, size_t disagreements, double time, bool silenceTime);
 
-bool RunTest(VAPoR::Grid *grid, bool silenceTime);
-
 bool RunTests(VAPoR::Grid *grid, const std::vector<std::string> &tests, float minVal, float maxVal, bool silenceTime);
 
-VAPoR::StretchedGrid *MakeStretchedGrid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const std::vector<double> &minu, const std::vector<double> &maxu);
+bool RunTest(VAPoR::Grid *grid, bool silenceTime);
 
-VAPoR::UnstructuredGrid2D *MakeUnstructuredGrid2D(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const std::vector<double> &minu, const std::vector<double> &maxu);
+void PrintGridIteratorResults(std::string &gridType, std::string itrType, size_t count, size_t expectedCount, size_t disagreements, double time, bool silenceTime);
 
 VAPoR::CurvilinearGrid *MakeCurvilinearTerrainGrid(const std::vector<size_t> &bs, const std::vector<double> &minu, const std::vector<double> &maxu, const std::vector<size_t> &dims);
 
 VAPoR::LayeredGrid *MakeLayeredGrid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const std::vector<double> &minu, const std::vector<double> &maxu);
 
-void DeleteHeap();
+VAPoR::StretchedGrid *MakeStretchedGrid(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const std::vector<double> &minu, const std::vector<double> &maxu);
+
+VAPoR::UnstructuredGrid2D *MakeUnstructuredGrid2D(const std::vector<size_t> &dims, const std::vector<size_t> &bs, const std::vector<double> &minu, const std::vector<double> &maxu);
+


### PR DESCRIPTION
Fixes [#3094](https://github.com/NCAR/VAPOR/issues/3094) by re-ordering smoke test functions. Some functions were being defined before being called resulting in multiple signatures. This resulted in modifications to the the header creating new function definitions, which wouldn't be called in lieu of the source's definition.

This also re-orders the smoke test function definitions to match the order of their header declarations.
