### PR TITLE
Fix broken Ubuntu installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -932,17 +932,17 @@ workflows:
   build:
     jobs:
       #- clang-tidy
-      - build_ubuntu18
-      - build_centos7
-      - build_python_api_ubuntuDebug
-      - build_python_api_ubuntu
+      #- build_ubuntu18
+      #- build_centos7
+      #- build_python_api_ubuntuDebug
+      #- build_python_api_ubuntu
       #- build_python_api_centos
       #- build_python_api_osx
       #- test_clang_format
       #- build_win10_installer
       #- build_osx_installer
       #- build_M1_installer
-      #- build_ubuntu18_installer
+      - build_ubuntu18_installer
       #- build_centos7_installer
       #- release_weekly_installers:
       #    requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -932,17 +932,17 @@ workflows:
   build:
     jobs:
       #- clang-tidy
-      #- build_ubuntu18
-      #- build_centos7
-      #- build_python_api_ubuntuDebug
-      #- build_python_api_ubuntu
+      - build_ubuntu18
+      - build_centos7
+      - build_python_api_ubuntuDebug
+      - build_python_api_ubuntu
       #- build_python_api_centos
       #- build_python_api_osx
       #- test_clang_format
       #- build_win10_installer
       #- build_osx_installer
       #- build_M1_installer
-      - build_ubuntu18_installer
+      #- build_ubuntu18_installer
       #- build_centos7_installer
       #- release_weekly_installers:
       #    requires:

--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -388,6 +388,7 @@ if (APPLE)
 elseif (UNIX AND NOT APPLE)
 	target_link_libraries (vapor quadmath)
 	target_compile_options(vapor PRIVATE -Wno-conversion-null)
+    target_link_options(vapor PRIVATE "LINKER:--no-as-needed")
 endif ()
 
 OpenMPInstall (


### PR DESCRIPTION
Fixes #3280 and #3278.

After #3109 was merged, vaporgui stopped linking to the library Qt5::DBus during compile time on Ubuntu.  This caused our Linux build script _gen_linux_shared_libs.pl_, which runs _ld_ on our executables, to miss miss DBus as a requirement.  DBus was therefore not included it as a dependency for the installer.

Strangely, CentOS was not affected by the changes in #3109, and does include DBus as a dependency.  Upgrading CentOS's gnu compiler and linker still include DBus as a dependency.

The only solution I've found is to add the `--no-as-needed` flag to the CMake linker.  Backing out the changes to CMakeLists.txt files relevant to vaporgui in #3109 have not gotten Ubuntu to link to DBus either.  Upgrading to Qt 5.15.2 has no affect either.

The following files can be used on Ubuntu or CentOS systems to demonstrate the problem.  Unzip the attached zip that contains the CMakeLists.txt and main.cpp files and run `cmake .. && make && ld main` from the `build` directory.  On CentOS you will see that DBus is included, while it's excluded on Ubuntu.

[dbus.zip](https://github.com/NCAR/VAPOR/files/10108292/dbus.zip)
