### PR TITLE
fix 3306 - Problems with ZFP compression on OSX

### DIFF
--- a/include/vapor/SetHDF5PluginPath.h
+++ b/include/vapor/SetHDF5PluginPath.h
@@ -5,7 +5,7 @@
 
 namespace VAPoR {
 void SetHDF5PluginPath() {
-    int rc;
+    int rc=0;
     std::string plugins = "HDF5_PLUGIN_PATH=" + Wasp::GetSharePath("plugins");
     #ifdef WIN32
         rc=_putenv(plugins.c_str());

--- a/include/vapor/SetHDF5PluginPath.h
+++ b/include/vapor/SetHDF5PluginPath.h
@@ -3,20 +3,16 @@
 #include "vapor/MyBase.h"
 #include "vapor/ResourcePath.h"
 
-#ifndef WIN32
-    #include <H5PLpublic.h>
-#endif
-
 namespace VAPoR {
 void SetHDF5PluginPath() {
-    string plugins = Wasp::GetSharePath("plugins");
-
-    #ifndef WIN32
-        H5PLreplace(plugins.c_str(), 0);
+    int rc;
+    std::string plugins = "HDF5_PLUGIN_PATH=" + Wasp::GetSharePath("plugins");
+    #ifdef WIN32
+        rc=_putenv(plugins.c_str());
     #else
-        plugins = "HDF5_PLUGIN_PATH=" + plugins;
-        int rc=_putenv(plugins.c_str());
-        if (rc != 0) Wasp::MyBase::SetErrMsg("Unable to set environtment variable %s", plugins.c_str());
+        rc = setenv("HDF5_PLUGIN_PATH", Wasp::GetSharePath("plugins").c_str(), 1);
     #endif
+
+    if (rc != 0) Wasp::MyBase::SetErrMsg("Unable to set environtment variable s", plugins.c_str());
 }
 };    // namespace VAPoR


### PR DESCRIPTION
Fixes #3306 ZFP issues by bypassing the use of H5PLreplace() in favor of just setting the HDF5_PLUGIN_PATH environment variable in the current process.