### PR TITLE
Fix Deleting a Python variable plotted in a renderer causes Vapor to crash #3293

### DIFF
--- a/lib/common/VAssert.cpp
+++ b/lib/common/VAssert.cpp
@@ -16,6 +16,6 @@ void Wasp::_VAssertFailed(const char *expr, const char *path, const unsigned int
 #ifdef NDEBUG
     exit(1);
 #else
-    raise(SIGTERM);
+    raise(SIGINT);
 #endif
 }

--- a/lib/osgl/CMakeLists.txt
+++ b/lib/osgl/CMakeLists.txt
@@ -110,7 +110,10 @@ install (
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 	COMPONENT Libraries
     )
-if (NOT WIN32)
+
+set (BUILD_OSGL_TESTS OFF)
+
+if (NOT WIN32 AND BUILD_OSGL_TESTS)
     file (GLOB TESTS ./test_*.cpp)
     foreach (TEST ${TESTS})
         get_filename_component(TEST_NAME "${TEST}" NAME_WE)

--- a/lib/render/TwoDDataRenderer.cpp
+++ b/lib/render/TwoDDataRenderer.cpp
@@ -635,8 +635,8 @@ int TwoDDataRenderer::_getMeshStructuredPlane(DataMgr *dataMgr, const Structured
 int TwoDDataRenderer::_getOrientation(DataMgr *dataMgr, string varname)
 {
     vector<string> coordvars;
-    bool           ok = dataMgr->GetVarCoordVars(varname, true, coordvars);
-    VAssert(ok);
+    bool ok = dataMgr->GetVarCoordVars(varname, true, coordvars);
+    if (!ok) return -1;
     VAssert(coordvars.size() == 2);
 
     vector<int> axes;    // order list of coordinate axes


### PR DESCRIPTION
Fix #3293