### PR TITLE
Change notifier URL to one with an improved repository name

### DIFF
--- a/apps/vaporgui/CheckForNotices.cpp
+++ b/apps/vaporgui/CheckForNotices.cpp
@@ -91,7 +91,7 @@ void CheckForGHNotices(std::function<void(const std::vector<Notice> &)> callback
 #ifdef TESTING_API
     req.setUrl(QUrl("http://localhost:8000/list.json"));
 #else
-    req.setUrl(QUrl("https://api.github.com/repos/NCAR/VAPOR-SupportPage/contents/notices"));
+    req.setUrl(QUrl("https://api.github.com/repos/NCAR/VAPOR-LandingPage/contents/notices"));
 #endif
     manager->get(req);
 }


### PR DESCRIPTION
The repository that hosts Vapor's landing page at https://www.vapor.ucar.edu/ is named `Vapor-SupportPage `because it was previously used as a user support form years ago.  Since it is no longer used for that, it would be less confusing if it had a more descriptive name.

We also use this repository to store Vapor's notifications.  This PR updates the URL used by the notifier to direct to a repository named `VAPOR-LandingPage`, instead of `VAPOR-SupportPage`.

Once this is merged, we can change the actual repository name without breaking the notifier.