### PR TITLE
Add missing setters/getters to python API

### DIFF
--- a/apps/pythonapi/vapor/renderer.py
+++ b/apps/pythonapi/vapor/renderer.py
@@ -52,6 +52,8 @@ class Renderer(ParamsWrapper, wrap=RenderParams):
     
     SetUseSingleColor
     UseSingleColor
+    GetConstantOpacity
+    SetConstantOpacity
     
     GetTransform
     ResetUserExtentsToDataExents


### PR DESCRIPTION
Fixes #3343

The TwoDData, Slice, and Image renderers make use of the _constantOpacityTag, which is why it was in RenderParams, not the ImageParams subclass.  However these classes make use of it through setters and getters, not direct tag reference like the GUI does.

Instead of exposing _constantOpacityTag, this PR just exposes the setters and getters which are already documented.