### PR TITLE
Fix #3350

### DIFF
--- a/apps/pythonapi/vapor/link.py
+++ b/apps/pythonapi/vapor/link.py
@@ -24,6 +24,16 @@ class Link:
         # print("- include", path)
         return cppyy.include(path)
 
+    @staticmethod
+    def FixModuleOwnership(Class):
+        """
+        Classes that directly inherit from CPPYY C++ classes have an incorrect __module__ attr
+        """
+        import inspect
+        callerModule = inspect.getmodule(inspect.stack()[1][0])
+        Class.__module__ = callerModule.__name__
+        return Class
+
     def __getattr__(self, name):
         return getattr(cppyy.gbl, name)
 

--- a/apps/pythonapi/vapor/session.py
+++ b/apps/pythonapi/vapor/session.py
@@ -10,6 +10,7 @@ import PIL.Image
 link.include('vapor/Session.h')
 link.include('vapor/RenderManager.h')
 
+@link.FixModuleOwnership
 class Session(link.Session):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
CPPYY messes with some internal python behaviors and causing Python's inspect module to incorrectly mark the Session class as not part of the session module.