### PR TITLE
Fix separate widget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -497,6 +497,7 @@ jobs:
             cd /root/project/conda
             conda install -y conda-build
             conda config --add channels conda-forge
+            conda config --add channels ncar-vapor
             conda build .
             mkdir /usr/local/conda-bld/linux-64/tarBallDir
             mv /usr/local/conda-bld/linux-64/*.tar.bz2 /usr/local/conda-bld/linux-64/tarBallDir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,6 +495,7 @@ jobs:
           name: conda build .
           command: |
             cd /root/project/conda
+            conda update -n base -c defaults conda
             conda install -y conda-build
             conda config --add channels conda-forge
             conda config --add channels ncar-vapor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,6 +527,8 @@ jobs:
       - run:
           name: build conda installer
           command: |
+            conda update -n base -c defaults conda
+            conda config --add channels ncar-vapor
             conda config --add channels conda-forge
             conda install -y conda-build
             cd /root/project/conda


### PR DESCRIPTION
Fixes the builds for the PythonAPI by adding the anaconda ncar-vapor channel to the environment.