### PR TITLE
Fix for Dockerfile smell DL3009

### DIFF
--- a/share/docker/ubuntu18/Dockerfile
+++ b/share/docker/ubuntu18/Dockerfile
@@ -20,7 +20,9 @@ RUN apt-get update \
     && apt-get install -y libglib2.0-0 \
     && apt-get install -y libdbus-1-3 \
     && apt-get install -y valgrind \
-    && apt-get install -y clang-tidy 
+    && apt-get install -y clang-tidy \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Acquire 3rd party libraries
 #


### PR DESCRIPTION
Hi!
The Dockerfile placed at "share/docker/ubuntu18/Dockerfile" contains the best practice violation [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3009 occurs when the apt tool is used to install packages without wiping the cache and source lists.
This pull request proposes a fix for that smell generated by my fixing tool. The generated patch has been manually verified before opening the pull request.
To fix this smell, specifically, the instructions to clean up the apt cache and remove the /var/lib/apt/lists have been added. This helps keep the image size down.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance