### PR TITLE
Relative dataset path support

### DIFF
--- a/include/vapor/FileUtils.h
+++ b/include/vapor/FileUtils.h
@@ -16,6 +16,7 @@ COMMON_API std::string ReadFileToString(const std::string &path);
 COMMON_API std::string HomeDir();
 COMMON_API std::string Basename(const std::string &path);
 COMMON_API std::string Dirname(const std::string &path);
+COMMON_API std::string Realpath(const std::string &path);
 COMMON_API std::string Extension(const std::string &path);
 COMMON_API std::string RemoveExtension(const std::string &path);
 COMMON_API std::string POSIXPathToWindows(std::string path);
@@ -26,11 +27,13 @@ COMMON_API bool        IsPathAbsolute(const std::string &path);
 COMMON_API bool        Exists(const std::string &path);
 COMMON_API bool        IsRegularFile(const std::string &path);
 COMMON_API bool        IsDirectory(const std::string &path);
+COMMON_API bool        IsSubpath(const std::string &dir, const std::string &path);
 COMMON_API FileType    GetFileType(const std::string &path);
 COMMON_API std::vector<std::string> ListFiles(const std::string &path);
 
 //! @code JoinPaths({"home", "a/b"}); @endcode
-COMMON_API std::string JoinPaths(std::initializer_list<std::string> paths);
+COMMON_API std::string JoinPaths(const std::initializer_list<std::string> &paths);
+COMMON_API std::vector<std::string> SplitPath(std::string path);
 
 COMMON_API int MakeDir(const std::string &path);
 

--- a/include/vapor/STLUtils.h
+++ b/include/vapor/STLUtils.h
@@ -18,9 +18,13 @@ template<typename T> vector<T> Filter(const std::vector<T> &v, std::function<boo
     return v2;
 }
 
+template<typename T> bool BeginsWith(const T &str, const T &match) {
+    return str.size() >= match.size() && equal(match.begin(), match.end(), str.begin());
+}
+COMMON_API bool BeginsWith(const std::string &str, const std::string &match);
+
 COMMON_API bool Contains(const std::string &toSearch, const std::string &query);
 COMMON_API bool ContainsIgnoreCase(const std::string &toSearch, const std::string &query);
-COMMON_API bool BeginsWith(const std::string &str, const std::string &match);
 COMMON_API bool EndsWith(const std::string &str, const std::string &match);
 COMMON_API std::string ToLower(std::string str);
 COMMON_API std::vector<std::string> Split(std::string str, const std::string &delimeter);

--- a/lib/common/STLUtils.cpp
+++ b/lib/common/STLUtils.cpp
@@ -7,9 +7,9 @@ bool STLUtils::Contains(const std::string &toSearch, const std::string &query) {
 
 bool STLUtils::ContainsIgnoreCase(const std::string &toSearch, const std::string &query) { return Contains(ToLower(toSearch), ToLower(query)); }
 
-bool STLUtils::BeginsWith(const std::string &str, const std::string &match) { return str.size() >= match.size() && equal(match.begin(), match.end(), str.begin()); }
-
 bool STLUtils::EndsWith(const std::string &str, const std::string &match) { return str.size() >= match.size() && equal(match.begin(), match.end(), str.end() - match.size()); }
+
+bool STLUtils::BeginsWith(const std::string &str, const std::string &match) { return STLUtils::BeginsWith<string>(str, match); }
 
 std::string STLUtils::ToLower(std::string str)
 {


### PR DESCRIPTION
- Adds support for loading/saving dataset paths relative to session files
- When saving a session file, vapor now checks if all of the open datasets are contained within the directory containing the session file. If so, it will save dataset paths as relative to the session file. Otherwise it will use absolute paths.

Expected behavior when sharing sessions:
- Sharing session pointing to data on shared HPC drive in /glade will be absolute.
- Sharing a folder containing data and session will be relative.

Fix #3399
Fix #3389