### PR TITLE
Moving domain and python particles support

### DIFF
--- a/apps/pythonapi/vapor/camera.py
+++ b/apps/pythonapi/vapor/camera.py
@@ -56,3 +56,20 @@ class Camera():
     def SetUp       (self, v:Vec3): NavigationUtils.SetCameraUp(self.ce, v)
     def SetTarget   (self, v:Vec3): NavigationUtils.SetCameraTarget(self.ce, v)
 
+    def __GUIStateParams(self) -> link.GUIStateParams:
+        pm = self.ce.GetParamsMgr()
+        gsp = pm.GetParams(link.GUIStateParams.GetClassType())
+        return gsp
+
+
+    def TrackMovingDomain(self, on=True):
+        """Camera should follows the moving domain"""
+        gsp = self.__GUIStateParams()
+        gsp.SetValueLong(gsp.MovingDomainTrackCameraTag, "", on)
+        print(f"{gsp.MovingDomainTrackCameraTag} = {bool(gsp.GetValueLong(gsp.MovingDomainTrackCameraTag, 0))}")
+
+    def TrackMovingDomainRenderRegions(self, on=True):
+        """Renderer regions will be tracked relative to the moving domain"""
+        gsp = self.__GUIStateParams()
+        gsp.SetValueLong(gsp.MovingDomainTrackRenderRegionsTag, "", on)
+

--- a/apps/pythonapi/vapor/dataset.py
+++ b/apps/pythonapi/vapor/dataset.py
@@ -15,6 +15,7 @@ WRF = "wrf"
 CF = "cf"
 MPAS = "mpas"
 BOV = "bov"
+DCP = "dcp"
 UGRID = "ugrid"
 PYTHON = "ram"
 

--- a/apps/pythonapi/vapor/renderer.py
+++ b/apps/pythonapi/vapor/renderer.py
@@ -259,6 +259,23 @@ class FlowRenderer(Renderer, wrap=link.VAPoR.FlowParams):
         return BoundingBox(self._params.GetIntegrationBox())
 
 
+link.include('vapor/ParticleRenderer.h')
+link.include('vapor/ParticleParams.h')
+class ParticleRenderer(Renderer, wrap=link.VAPoR.ParticleParams):
+    _tags = ParamsTagWrapperList("""
+        long StrideTag
+        
+        long ShowDirectionTag
+        double RenderRadiusScalarTag
+        double DirectionScaleTag
+        
+        double PhongAmbientTag
+        double PhongDiffuseTag
+        double PhongSpecularTag
+        double PhongShininessTag
+    """)
+
+
 link.include('vapor/WireFrameRenderer.h')
 link.include('vapor/WireFrameParams.h')
 class WireFrameRenderer(Renderer, wrap=link.VAPoR.WireFrameParams):

--- a/apps/vaporgui/AnimationController.cpp
+++ b/apps/vaporgui/AnimationController.cpp
@@ -2,13 +2,18 @@
 #include <vapor/ControlExecutive.h>
 #include <vapor/AnimationParams.h>
 #include <vapor/NavigationUtils.h>
+#include <vapor/GUIStateParams.h>
 
 using namespace VAPoR;
 
 AnimationController::AnimationController(VAPoR::ControlExec *ce) : _controlExec(ce), _myTimer(new QTimer(this)) {}
 
+using glm::vec3;
 
-void AnimationController::setCurrentTimestep(size_t ts) const { NavigationUtils::SetTimestep(_controlExec, ts); }
+void AnimationController::setCurrentTimestep(size_t ts) const {
+    NavigationUtils::SetTimestep(_controlExec, ts);
+}
+
 
 // Insert values from params into tab panel
 //

--- a/apps/vaporgui/AnimationController.h
+++ b/apps/vaporgui/AnimationController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QTimer>
+#include <glm/fwd.hpp>
 
 class AnimationParams;
 namespace VAPoR {

--- a/apps/vaporgui/PRegionSelector.cpp
+++ b/apps/vaporgui/PRegionSelector.cpp
@@ -16,6 +16,7 @@ PRegionSelector::PRegionSelector(const std::string &label) : PSection(label)
 PRegionSelector1D::PRegionSelector1D(int dim) : PLineItem("", dim == 0 ? "X" : dim == 1 ? "Y" : "Z", _slider = new QRangeSliderTextCombo), _dim(dim)
 {
     QObject::connect(_slider, &QRangeSliderTextCombo::ValueChanged, this, &PRegionSelector1D::sliderValueChanged);
+    _slider->AllowCustomRange();
 }
 
 void PRegionSelector1D::updateGUI() const

--- a/apps/vaporgui/PWidget.cpp
+++ b/apps/vaporgui/PWidget.cpp
@@ -32,12 +32,10 @@ void PWidget::Update(VAPoR::ParamsBase *params, VAPoR::ParamsMgr *paramsMgr, VAP
         return;
     }
 
-    if (_enableBasedOnParam) {
-        int value = params->GetValueLong(_enableBasedOnParamTag, 0);
-        setEnabled(value == _enableBasedOnParamValue);
-    } else {
-        setEnabled(true);
-    }
+    bool enabled = isEnabled();
+    if (enabled && _enableBasedOnParam)
+        enabled = params->GetValueLong(_enableBasedOnParamTag, 0) == _enableBasedOnParamValue;
+    setEnabled(enabled);
 
     updateGUI();
 }

--- a/apps/vaporgui/PWidget.h
+++ b/apps/vaporgui/PWidget.h
@@ -68,6 +68,7 @@ protected:
     virtual bool requireParamsMgr() const { return false; }
     virtual bool requireDataMgr() const { return false; }
     virtual bool isShown() const { return true; }
+    virtual bool isEnabled() const { return true; }
 
     const std::string &getTag() const;
     VAPoR::ParamsBase *getParams() const;

--- a/apps/vaporgui/ViewpointTab.h
+++ b/apps/vaporgui/ViewpointTab.h
@@ -11,6 +11,7 @@ class ViewpointTab : public QWidget, public EventRouter {
     Q_OBJECT
 
     PWidget *_pg = nullptr;
+    PWidget *_movingDomainSection = nullptr;
 
 public:
     ViewpointTab(VAPoR::ControlExec *ce);

--- a/include/vapor/DataMgr.h
+++ b/include/vapor/DataMgr.h
@@ -294,6 +294,9 @@ public:
     //
     string GetTimeCoordVarName() const;
 
+    bool HasTimeVaryingCoordinates() const;
+    bool HasMovingDomain() const;
+
     //! Return an ordered list of a data variable's coordinate names
     //!
     //! Returns a list of a coordinate variable names for the variable

--- a/include/vapor/FlowParams.h
+++ b/include/vapor/FlowParams.h
@@ -363,7 +363,7 @@ public:
 
     //! Specifies the Phong Shininess lighting coefficient (https://en.wikipedia.org/wiki/Phong_reflection_model).
     //! Applies data of type: double.
-    //! Typical values: 0.0 to 1.0.
+    //! Typical values: 0.0 to 100.0.
     //! Valid values: DBL_MIN to DBL_MAX.
     static const std::string PhongShininessTag;
 

--- a/include/vapor/GUIStateParams.h
+++ b/include/vapor/GUIStateParams.h
@@ -210,6 +210,8 @@ public:
     static const string m_openDataSetsTag;
     static const string _flowDimensionalityTag;
     static const string BookmarksTag;
+    static const string MovingDomainTrackCameraTag;
+    static const string MovingDomainTrackRenderRegionsTag;
 
 private:
     MouseModeParams *m_mouseModeParams;

--- a/include/vapor/NavigationUtils.h
+++ b/include/vapor/NavigationUtils.h
@@ -52,4 +52,11 @@ public:
     static VAPoR::ViewpointParams *GetActiveViewpointParams(ControlExec *ce);
     static GUIStateParams *        GetGUIStateParams(ControlExec *ce);
     static AnimationParams *       GetAnimationParams(ControlExec *ce);
+
+private:
+    static void propagateTimestep(ControlExec *ce, size_t ts);
+    static void handleMovingDomainAdjustments(ControlExec *ce, size_t ts_from, size_t ts_to);
+    static glm::vec3 getDomainMovementBetweenTimesteps(ControlExec *ce, std::string dataset, size_t from, size_t to);
+    static void movingDomainTrackCamera(ControlExec *ce, size_t from, size_t to);
+    static void movingDomainTrackRenderRegions(ControlExec *ce, size_t from, size_t to);
 };

--- a/include/vapor/ParticleParams.h
+++ b/include/vapor/ParticleParams.h
@@ -23,17 +23,39 @@ private:
     void _init();
 
 public:
+    //! Show direction/velocity of particles.
+    //! The field variables must be set to the particles velocity vector components
+    //! (this is likely done automatically if using DCP).
     static const std::string ShowDirectionTag;
+
+    //! Scale the length of particles velocity vector
     static const std::string DirectionScaleTag;
+
+    //! Load every nth particle. Useful for improving performance
     static const std::string StrideTag;
+
+    //! Scale the rendered particle size
     static const std::string RenderRadiusScalarTag;
+
     static const std::string RenderRadiusBaseTag;
     static const std::string RenderLegacyTag;
 
     static const std::string LightingEnabledTag;
+
+    //! Specifies the Phong Ambient lighting coefficient (https://en.wikipedia.org/wiki/Phong_reflection_model).
+    //! Typical values: 0.0 to 1.0.
     static const std::string PhongAmbientTag;
+
+    //! Specifies the Phong Diffuse lighting coefficient (https://en.wikipedia.org/wiki/Phong_reflection_model).
+    //! Typical values: 0.0 to 1.0.
     static const std::string PhongDiffuseTag;
+
+    //! Specifies the Phong Specular lighting coefficient (https://en.wikipedia.org/wiki/Phong_reflection_model).
+    //! Typical values: 0.0 to 1.0.
     static const std::string PhongSpecularTag;
+
+    //! Specifies the Phong Shininess lighting coefficient (https://en.wikipedia.org/wiki/Phong_reflection_model).
+    //! Typical values: 0.0 to 100.0.
     static const std::string PhongShininessTag;
 };
 

--- a/lib/params/GUIStateParams.cpp
+++ b/lib/params/GUIStateParams.cpp
@@ -314,7 +314,11 @@ BookmarkParams *GUIStateParams::GetBookmark(int i) const
     return (BookmarkParams *)_bookmarks->GetParams(_bookmarks->GetNames()[i]);
 }
 
-void GUIStateParams::_init() { SetActiveVizName(""); }
+void GUIStateParams::_init() {
+    SetActiveVizName("");
+    SetValueLong(MovingDomainTrackCameraTag, "", true);
+    SetValueLong(MovingDomainTrackRenderRegionsTag, "", true);
+}
 
 void GUIStateParams::ActiveRenderer::SetActiveRenderer(string vizWin, string renderType, string renderInst)
 {

--- a/lib/params/GUIStateParams.cpp
+++ b/lib/params/GUIStateParams.cpp
@@ -44,6 +44,8 @@ const string GUIStateParams::m_proj4StringTag = "Proj4StringTag";
 const string GUIStateParams::m_openDataSetsTag = "OpenDataSetsTag";
 const string GUIStateParams::_flowDimensionalityTag = "_flowDimensionalityTag";
 const string GUIStateParams::BookmarksTag = "BookmarksTag";
+const string GUIStateParams::MovingDomainTrackCameraTag = "MovingDomainTrackCameraTag";
+const string GUIStateParams::MovingDomainTrackRenderRegionsTag = "MovingDomainTrackRenderRegionsTag";
 const string GUIStateParams::DataSetParam::m_dataSetPathsTag = "DataSetPathsTag";
 const string GUIStateParams::DataSetParam::m_dataSetFormatTag = "DataSetFormatTag";
 

--- a/lib/render/NavigationUtils.cpp
+++ b/lib/render/NavigationUtils.cpp
@@ -279,7 +279,7 @@ void NavigationUtils::LookAt(ControlExec *ce, const vector<double> &position, co
 void NavigationUtils::SetTimestep(ControlExec *ce, size_t ts)
 {
     AnimationParams *aParams = GetAnimationParams(ce);
-    int ots = aParams->GetCurrentTimestep();
+    size_t ots = aParams->GetCurrentTimestep();
 
     propagateTimestep(ce, ts);
 

--- a/lib/vapi/Session.cpp
+++ b/lib/vapi/Session.cpp
@@ -160,6 +160,7 @@ int Session::Render(String imagePath, bool fast)
 }
 
 void Session::SetTimestep(int ts) { NavigationUtils::SetTimestep(_controlExec, ts); }
+int Session::GetTimesteps() const { return _controlExec->GetDataStatus()->getMaxTimestep() + 1; }
 
 
 void Session::SetWaspMyBaseErrMsgFilePtrToSTDERR()

--- a/lib/vapi/Session.h
+++ b/lib/vapi/Session.h
@@ -33,6 +33,7 @@ public:
 
     int  Render(String imagePath, bool fast=false);
     void SetTimestep(int ts);
+    int GetTimesteps() const;
     
     static void SetWaspMyBaseErrMsgFilePtrToSTDERR();
     

--- a/lib/vdc/DataMgr.cpp
+++ b/lib/vdc/DataMgr.cpp
@@ -787,6 +787,21 @@ string DataMgr::GetTimeCoordVarName() const
     return ("");
 }
 
+bool DataMgr::HasTimeVaryingCoordinates() const
+{
+    const auto time = GetTimeCoordVarName();
+    for (const auto &v : GetCoordVarNames()) {
+        if (v == time) continue;
+        if (IsTimeVarying(v)) return true;
+    }
+    return false;
+}
+
+bool DataMgr::HasMovingDomain() const
+{
+    return HasTimeVaryingCoordinates();
+}
+
 bool DataMgr::GetVarCoordVars(string varname, bool spatial, std::vector<string> &coord_vars) const
 {
     VAssert(_dc);

--- a/lib/vdc/NetCDFCollection.cpp
+++ b/lib/vdc/NetCDFCollection.cpp
@@ -173,6 +173,8 @@ long NetCDFCollection::GetDimLengthAtTime(string name, long ts)
         for (int i = 0; i < it->second.size(); i++) {
             if (it->second[i] == realTime) {
                 filePath = it->first;
+                if (filePath == "constant")
+                    continue;
                 goto SEARCH_FINISHED;
             }
         }


### PR DESCRIPTION
- Adds support for rendering particle datasets using the Python API
- Adds support for moving domains
    - Adds ability for camera to automatically track a moving domain
    - Adds ability for renderer extents to track a moving domain
    - These can be independently toggled under the viewpoint tab in the GUI and in the Camera class in the Python API
- Adds ability to query dataset timestep information using the Python API
- Fixes renderer domains unable to be expanded past current dataset bounds
- Fixes bug where datasets with time-varying dimensions would fail to load if they were opened using unprefixed filenames


Fix #433