### PR TITLE
fix broken windows build

### DIFF
--- a/apps/vaporgui/VRouter.cpp
+++ b/apps/vaporgui/VRouter.cpp
@@ -1,6 +1,11 @@
 #include "VRouter.h"
 #include "vapor/STLUtils.h"
 
+VRouter::VRouter() 
+: VContainer(_stack = new QStackedWidget)
+{
+}
+
 VRouter::VRouter(AbstractWidgetGroup<VRouter, QWidget>::List children)
 : VContainer(_stack = new QStackedWidget)
 {

--- a/apps/vaporgui/VRouter.h
+++ b/apps/vaporgui/VRouter.h
@@ -11,7 +11,8 @@ class VRouter : public VContainer, public AbstractWidgetGroup<VRouter, QWidget> 
     QWidget *_emptyWidget = nullptr;
 
 public:
-    VRouter(List children = {});
+	VRouter();
+	VRouter(List children);
     VRouter *Add(QWidget *w) override;
 
     void Show(QWidget *w);

--- a/lib/common/FileUtils.cpp
+++ b/lib/common/FileUtils.cpp
@@ -97,7 +97,7 @@ std::string FileUtils::Realpath(const std::string &path)
 {
 #ifdef WIN32
     char real[_MAX_PATH];
-    if(_fullpath(real, path, _MAX_PATH))
+    if(_fullpath(real, path.c_str(), _MAX_PATH))
         return string(real);
     return path;
 #else


### PR DESCRIPTION
Fixes #3432 which reported our broken windows build which was due to Visual Studio not supporting implicit casts from std::string to const char* in FileUtils.cpp, and [error C2512](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c2512?view=msvc-170) in the VRouter class.