### PR TITLE
Issue3439v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1454,11 +1454,11 @@ workflows:
   build:
     jobs:
       #- clang-tidy
-      #- build_centos7
+      - build_centos7
       #- build_centos7_installer
-      #- build_ubuntu18
-      #- build_python_api_ubuntuDebug
-      #- build_python_api_ubuntu
+      - build_ubuntu18
+      - build_python_api_ubuntuDebug
+      - build_python_api_ubuntu
       #- build_python_api_centos
       #- build_python_api_osx
       #- test_clang_format
@@ -1467,7 +1467,7 @@ workflows:
       #- build_M1_installer
       #- build_ubuntu20_installer
       #- build_ubuntu22_installer
-      - build_centos7_installer
+      #- build_centos7_installer
       #- build_ubuntu20_libs
       #- build_ubuntu22_libs
       #- build_centos7_libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,15 @@ jobs:
           command: |
             cd /root/project/build
             git checkout $CIRCLE_BRANCH
-            cmake3 -DCMAKE_BUILD_TYPE:String=Release -DDIST_INSTALLER:string=ON -DUSE_OMP=ON -DTHIRD_PARTY_DIR=/usr/local/VAPOR-Deps/2019-Aug -DPython_INCLUDE_DIRS=/usr/local/VAPOR-Deps/2019-Aug/include/python3.6m -DPYTHONVERSION=3.6 ..
+            cmake3 \
+            -DCMAKE_BUILD_TYPE:String=Release \
+            -DDIST_INSTALLER:string=ON \
+            -DUSE_OMP=ON \
+            -DTHIRD_PARTY_DIR=/usr/local/VAPOR-Deps/2019-Aug \
+            -DPython_INCLUDE_DIRS=/usr/local/VAPOR-Deps/2019-Aug/include/python3.6m \
+            -DPYTHONVERSION=3.6 \
+            -DQTDIR=/usr/local/VAPOR-Deps/2019-Aug/Qt/5.13.2/gcc_64 \
+            ..
             make -j2
             make installer -j2
             for f in VAPOR3-*.sh ; do mv "$f" "${f/Linux/CentOS7}" ; done
@@ -1446,11 +1454,11 @@ workflows:
   build:
     jobs:
       #- clang-tidy
-      - build_centos7
+      #- build_centos7
       #- build_centos7_installer
-      - build_ubuntu18
-      - build_python_api_ubuntuDebug
-      - build_python_api_ubuntu
+      #- build_ubuntu18
+      #- build_python_api_ubuntuDebug
+      #- build_python_api_ubuntu
       #- build_python_api_centos
       #- build_python_api_osx
       #- test_clang_format
@@ -1459,7 +1467,7 @@ workflows:
       #- build_M1_installer
       #- build_ubuntu20_installer
       #- build_ubuntu22_installer
-      #- build_centos7_installer
+      - build_centos7_installer
       #- build_ubuntu20_libs
       #- build_ubuntu22_libs
       #- build_centos7_libs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,8 +556,27 @@ if (UNIX AND NOT APPLE)
 		        	DESTINATION ${INSTALL_LIB_DIR}
 		        	COMPONENT Dependencies
 		        	)
-                        endif ()
-                    endif ()
+                endif ()
+                file (GLOB HDF5_PLUGINS "${THIRD_PARTY_DIR}/HDF_Group/HDF5/1.12.2/lib/plugin/*.so")
+            else()
+                install (
+                    DIRECTORY ${QTDIR}/plugins/xcbglintegrations
+                    DESTINATION ${INSTALL_LIB_DIR}
+                    COMPONENT Dependencies
+                )
+                install (
+                FILES ${QTDIR}/plugins/platforms/libqxcb.so
+                DESTINATION ${INSTALL_LIB_DIR}/platforms
+                COMPONENT Dependencies
+                )
+
+                file (GLOB XCBQPA_FILES ${QTDIR}/lib/libQt5XcbQpa.*)
+                install (
+                    FILES ${XCBQPA_FILES}
+                    DESTINATION ${INSTALL_LIB_DIR}
+                    COMPONENT Dependencies
+                )
+            endif ()
 
             file (GLOB XCB_FILES ${THIRD_PARTY_LIB_DIR}/libxcb-xinput.*)
             install (
@@ -572,7 +591,8 @@ if (UNIX AND NOT APPLE)
 		    	DESTINATION ${INSTALL_LIB_DIR}
 		    	COMPONENT Dependencies
 		    	)
-        endif ()
+            file (GLOB_RECURSE HDF5_PLUGINS "${THIRD_PARTY_DIR}/share/plugins/*.so")
+        endif (DIST STREQUAL "Ubuntu")
 
 		if (BUILD_OSP)
 			file (GLOB INSTALL_OSPRAY_LIBS ${OSPRAYDIR}/lib/*.so*)
@@ -583,7 +603,6 @@ if (UNIX AND NOT APPLE)
 				)
 		endif ()
 
-        file (GLOB HDF5_PLUGINS "${THIRD_PARTY_DIR}/HDF_Group/HDF5/1.12.2/lib/plugin/*.so")
 			install (
 				FILES ${HDF5_PLUGINS}
 				DESTINATION "${INSTALL_SHARE_DIR}/plugins"


### PR DESCRIPTION
Fixes #3439 by adding a build rule specifically for CentOS, which is using the old third party libraries back from 2019.