### PR TITLE
Python API Flow output incomplete #3448

### DIFF
--- a/apps/pythonapi/examples/flow_example.py
+++ b/apps/pythonapi/examples/flow_example.py
@@ -123,3 +123,21 @@ with open("flow_seeds.txt", "w") as f:
 ren.SetSeedGenMode(ren.FlowSeedMode.LIST)
 ren.SetSeedInputFilename("flow_seeds.txt")
 ses.Show()
+
+# %% [md]
+#
+# ### Outputting Flow Lines
+#
+# The advected flow lines can be saved to a .csv file
+#
+# %%
+ren.SetFlowlineOutputFilename("flow_output.csv") # Needs to be set once per renderer
+ren.SetFlowOutputMoreVariables([U, V]) # Optionally specify additional variables to sample at each point
+
+ren.SetNeedFlowlineOutput(True) # Needs to be called before each render call that should output the computed flow in a .csv file
+_ = ses.RenderToImage() # This returns a PIL image variable that is not displayed by default and can be ignored if only saving flow output
+
+# %%
+import pandas as pd
+pd.read_csv("flow_output.csv", sep=",").head(10)
+

--- a/apps/pythonapi/vapor/renderer.py
+++ b/apps/pythonapi/vapor/renderer.py
@@ -209,7 +209,10 @@ class FlowRenderer(Renderer, wrap=link.VAPoR.FlowParams):
         SetSeedInputFilename
         GetFlowlineOutputFilename
         SetFlowlineOutputFilename
+        GetNeedFlowlineOutput
+        SetNeedFlowlineOutput
         GetFlowOutputMoreVariables
+        SetFlowOutputMoreVariables
         GetPeriodic
         SetPeriodic
         GetGridNumOfSeeds

--- a/include/vapor/FlowParams.h
+++ b/include/vapor/FlowParams.h
@@ -151,6 +151,10 @@ public:
     //! \retval std::vector<std::string> - A vector containing the variables being written to the specified output file name.
     std::vector<std::string> GetFlowOutputMoreVariables() const;
 
+    //! One or more variable to be sampled along flowlines and written to an output file.
+    //! \param[in] std::vector<std::string> - A vector containing the variables being written to the specified output file name.
+    void SetFlowOutputMoreVariables(std::vector<std::string> vars);
+
     //! Inquires whether the current flow advection scheme is periodic.
     //! \details IE - Do pathlines or streamlines continue on the opposite side of the domain when the exit it?  Similar to when PAC-MAN exits the right side of the screen, and re-enters on the left.\n
     //! Note: this result vector could be of size 2 or 3.

--- a/lib/params/FlowParams.cpp
+++ b/lib/params/FlowParams.cpp
@@ -202,6 +202,7 @@ std::string FlowParams::GetFlowlineOutputFilename() const { return GetValueStrin
 void        FlowParams::SetFlowlineOutputFilename(const std::string &name) { SetValueString(_flowlineOutputFilenameTag, "filename for output flow lines", name); }
 
 std::vector<std::string> FlowParams::GetFlowOutputMoreVariables() const { return GetValueStringVec(_flowOutputMoreVariablesTag); }
+void FlowParams::SetFlowOutputMoreVariables(std::vector<std::string> vars) { SetValueStringVec(_flowOutputMoreVariablesTag, "", vars); }
 
 int FlowParams::GetFlowDirection() const { return GetValueLong(_flowDirectionTag, (int)FlowDir::FORWARD); }
 


### PR DESCRIPTION
Adds support for outputting flow data with the python API.
Adds documentation and examples.

<img width="643" alt="ss2" src="https://github.com/NCAR/VAPOR/assets/2772687/9fed133d-ff24-473e-8861-53654c324bb9">

Fix #3448