### PR TITLE
Fix Provide the user an option to specify absolute/relative paths for datasets #3420

### DIFF
--- a/include/vapor/ControlExecutive.h
+++ b/include/vapor/ControlExecutive.h
@@ -50,6 +50,15 @@ public:
     //
     virtual void LoadState(const XmlNode *node);
 
+    class RelAndAbsPathsExistException : public std::exception {
+    public:
+        const std::string AbsolutePath;
+        const std::string RelativePath;
+        RelAndAbsPathsExistException(const std::string &absolute, const std::string &relative)
+                : AbsolutePath(absolute), RelativePath(relative) {}
+    };
+    enum class LoadStateRelAndAbsPathsExistAction { Ask, LoadAbs, LoadRel };
+
     //!	Restore the session state from a session state file
     //!
     //! This method sets the session state based on the contents of the
@@ -64,7 +73,7 @@ public:
     //! fails the session state remains unchanged
     //!
     //
-    virtual int LoadState(string stateFile);
+    virtual int LoadState(string stateFile, LoadStateRelAndAbsPathsExistAction relAndAbsPathsExistAction = LoadStateRelAndAbsPathsExistAction::LoadAbs);
 
     //! Set number of execution threads
     //!

--- a/include/vapor/FileUtils.h
+++ b/include/vapor/FileUtils.h
@@ -17,6 +17,8 @@ COMMON_API std::string HomeDir();
 COMMON_API std::string Basename(const std::string &path);
 COMMON_API std::string Dirname(const std::string &path);
 COMMON_API std::string Realpath(const std::string &path);
+COMMON_API std::string Relpath(std::string path, std::string to);
+COMMON_API std::string CommonAncestor(const std::vector<std::string> &paths);
 COMMON_API std::string Extension(const std::string &path);
 COMMON_API std::string RemoveExtension(const std::string &path);
 COMMON_API std::string POSIXPathToWindows(std::string path);
@@ -28,11 +30,13 @@ COMMON_API bool        Exists(const std::string &path);
 COMMON_API bool        IsRegularFile(const std::string &path);
 COMMON_API bool        IsDirectory(const std::string &path);
 COMMON_API bool        IsSubpath(const std::string &dir, const std::string &path);
+COMMON_API bool        AreSameFile(const std::string &pathA, const std::string &pathB);
 COMMON_API FileType    GetFileType(const std::string &path);
+COMMON_API long long   GetFileSize(const std::string &path);
 COMMON_API std::vector<std::string> ListFiles(const std::string &path);
 
 //! @code JoinPaths({"home", "a/b"}); @endcode
-COMMON_API std::string JoinPaths(const std::initializer_list<std::string> &paths);
+COMMON_API std::string JoinPaths(const std::vector<std::string> &paths);
 COMMON_API std::vector<std::string> SplitPath(std::string path);
 
 COMMON_API int MakeDir(const std::string &path);

--- a/include/vapor/GUIStateParams.h
+++ b/include/vapor/GUIStateParams.h
@@ -64,12 +64,13 @@ public:
     std::vector<string> GetOpenDataSetNames() const { return (m_openDataSets->GetNames()); }
 
     std::vector<string> GetOpenDataSetPaths(string dataSetName) const;
+    std::vector<string> GetOpenDataSetRelativePaths(string dataSetName) const;
 
     string GetOpenDataSetFormat(string dataSetName) const;
 
     void RemoveOpenDateSet(string dataSetName) { m_openDataSets->Remove(dataSetName); }
 
-    void InsertOpenDateSet(string dataSetName, string format, const std::vector<string> &paths);
+    void InsertOpenDateSet(string dataSetName, string format, const std::vector<string> &paths, const std::vector<string> &relPaths={});
 
     //! method sets the current session path
     //! \param[in] path string
@@ -153,6 +154,10 @@ public:
 
         std::vector<string> GetPaths() const { return (GetValueStringVec(m_dataSetPathsTag)); };
 
+        void SetRelativePaths(const std::vector<string> &paths) { SetValueStringVec(m_dataSetRelativePathsTag, "Data set relative paths", paths); }
+        std::vector<string> GetRelativePaths() const { return (GetValueStringVec(m_dataSetRelativePathsTag)); };
+        bool HasRelativePaths() const { return !GetRelativePaths().empty(); };
+
         void SetFormat(string format) { SetValueString(m_dataSetFormatTag, "Data set format", format); }
 
         string GetFormat() const { return (GetValueString(m_dataSetFormatTag, "vdc")); }
@@ -161,6 +166,7 @@ public:
 
     private:
         static const string m_dataSetPathsTag;
+        static const string m_dataSetRelativePathsTag;
         static const string m_dataSetFormatTag;
     };
 

--- a/include/vapor/STLUtils.h
+++ b/include/vapor/STLUtils.h
@@ -12,6 +12,8 @@ template<typename T> bool Contains(const std::vector<T> &toSearch, const T &obje
 
 template<typename T> void AppendTo(std::vector<T> &a, const std::vector<T> &b) { a.insert(a.end(), b.begin(), b.end()); }
 
+template<typename T> std::vector<T> Slice(const std::vector<T> &a, int from, int to = -1) { return std::vector<T>(a.begin() + from, to < 0 ? a.end() : a.begin() + to); }
+
 template<typename T> vector<T> Filter(const std::vector<T> &v, std::function<bool(const T&)> f) {
     vector<T> v2;
     std::copy_if(v.begin(), v.end(), std::back_inserter(v2), f);

--- a/lib/params/GUIStateParams.cpp
+++ b/lib/params/GUIStateParams.cpp
@@ -47,6 +47,7 @@ const string GUIStateParams::BookmarksTag = "BookmarksTag";
 const string GUIStateParams::MovingDomainTrackCameraTag = "MovingDomainTrackCameraTag";
 const string GUIStateParams::MovingDomainTrackRenderRegionsTag = "MovingDomainTrackRenderRegionsTag";
 const string GUIStateParams::DataSetParam::m_dataSetPathsTag = "DataSetPathsTag";
+const string GUIStateParams::DataSetParam::m_dataSetRelativePathsTag = "DataSetRelativePathsTag";
 const string GUIStateParams::DataSetParam::m_dataSetFormatTag = "DataSetFormatTag";
 
 //
@@ -250,6 +251,13 @@ vector<string> GUIStateParams::GetOpenDataSetPaths(string dataSetName) const
     return (paths);
 }
 
+vector<string> GUIStateParams::GetOpenDataSetRelativePaths(string dataSetName) const
+{
+    DataSetParam *dsParams = (DataSetParam *)m_openDataSets->GetParams(dataSetName);
+    if (!dsParams) { return (vector<string>()); }
+    return dsParams->GetRelativePaths();
+}
+
 string GUIStateParams::GetOpenDataSetFormat(string dataSetName) const
 {
     DataSetParam *dsParams = (DataSetParam *)m_openDataSets->GetParams(dataSetName);
@@ -259,13 +267,16 @@ string GUIStateParams::GetOpenDataSetFormat(string dataSetName) const
     return (dsParams->GetFormat());
 }
 
-void GUIStateParams::InsertOpenDateSet(string dataSetName, string format, const vector<string> &paths)
+void GUIStateParams::InsertOpenDateSet(string dataSetName, string format, const vector<string> &paths, const vector<string> &relPaths)
 {
     m_openDataSets->Remove(dataSetName);
 
     DataSetParam dsParam(_ssave);
     dsParam.SetPaths(paths);
     dsParam.SetFormat(format);
+
+    if (relPaths.size() == paths.size())
+        dsParam.SetRelativePaths(relPaths);
 
     m_openDataSets->Insert(&dsParam, dataSetName);
 }


### PR DESCRIPTION
Fix #3420

Always saves both absolute dataset paths and relative to the session file. If data exists at both locations and is different, user is prompted to pick one:

<img width="483" alt="s" src="https://github.com/NCAR/VAPOR/assets/2772687/94ce0622-f0e3-4cf1-a2e1-8d3062316949">
