### PR TITLE
Re-enable OSPRay clipping volumes

### DIFF
--- a/lib/render/VolumeOSPRay.cpp
+++ b/lib/render/VolumeOSPRay.cpp
@@ -208,7 +208,7 @@ int VolumeOSPRay::LoadData(const Grid *grid)
         ospSetObjectAsData(group, "geometry", OSP_GEOMETRIC_MODEL, _ospIsoModel);
     else
         ospSetObjectAsData(group, "volume", OSP_VOLUMETRIC_MODEL, _ospVolumeModel);
-    if (p->GetValueLong("osp_enable_clipping", false)) ospSetObjectAsData(group, "clippingGeometry", OSP_GEOMETRIC_MODEL, clipModel);
+    if (p->GetValueLong("osp_enable_clipping", true)) ospSetObjectAsData(group, "clippingGeometry", OSP_GEOMETRIC_MODEL, clipModel);
     //    ospSetObjectAsData(group, "geometry", OSP_GEOMETRIC_MODEL, clipModel);
     ospCommit(group);
     ospRelease(clipModel);

--- a/lib/render/VolumeRenderer.cpp
+++ b/lib/render/VolumeRenderer.cpp
@@ -111,7 +111,7 @@ int VolumeRenderer::_paintGL(bool fast)
     CheckCache(_cache.osp_force_regular, p->GetValueLong("osp_force_regular", 0));
     CheckCache(_cache.osp_test_volume, p->GetValueLong("osp_test_volume", 0));
     CheckCache(_cache.osp_decompose, p->GetValueLong("osp_decompose", 0));
-    CheckCache(_cache.osp_enable_clipping, p->GetValueLong("osp_enable_clipping", 0));
+    CheckCache(_cache.osp_enable_clipping, p->GetValueLong("osp_enable_clipping", 1));
 
     if (_initializeAlgorithm() < 0) return -1;
     if (_loadData() < 0) return -1;


### PR DESCRIPTION
This feature was broken at the time of adding OSPRay support so it was disabled but it appears to be fixed in the current version of OSPRay.