### PR TITLE
change default interpolation order

### DIFF
--- a/include/vapor/Grid.h
+++ b/include/vapor/Grid.h
@@ -1281,7 +1281,7 @@ private:
     size_t               _topologyDimension = 0;
     float                _missingValue = std::numeric_limits<float>::infinity();
     bool                 _hasMissing = false;
-    int                  _interpolationOrder = 0;    // Order of interpolation
+    int                  _interpolationOrder = 1;    // Order of interpolation
     long                 _nodeIDOffset = 0;
     long                 _cellIDOffset = 0;
     mutable CoordType    _minuCache = {{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()}};

--- a/include/vapor/StructuredGrid.h
+++ b/include/vapor/StructuredGrid.h
@@ -20,7 +20,7 @@ namespace VAPoR {
 //! This abstract base class defines a 2D or 3D structured
 //! grid: a tessellation
 //! of Euculidean space by quadrilaterals (2D) or hexahdrons (3D). Each
-//! grid point can be addressed by an index(i,j,k), where \a i, \p a
+//! grid point can be addressed by an index(i,j,k), where \a i, \p j
 //! and \a k range from 0 to \a dim - 1, where \a dim is the dimension of the
 //! \a I, \a J, or \a K axis, respectively. Moreover, each grid point
 //! has a coordinate in a user-defined coordinate system.

--- a/lib/vdc/Grid.cpp
+++ b/lib/vdc/Grid.cpp
@@ -106,7 +106,7 @@ void Grid::_grid(const DimsType &dims, const DimsType &bs, const std::vector<flo
     _topologyDimension = topology_dimension;
     _missingValue = INFINITY;
     _hasMissing = false;
-    _interpolationOrder = 0;
+    _interpolationOrder = 1;
     _nodeIDOffset = 0;
     _cellIDOffset = 0;
     _minAbs = {0, 0, 0};


### PR DESCRIPTION
The [comment of class Grid](https://github.com/NCAR/VAPOR/blob/1099388f6e22fbdae25badf3243002c0791d82a5/include/vapor/Grid.h#L433) indicates that the default interpolation order should be 1, or trilinear. As a result, this PR sets the default value to be 1 really.