### PR TITLE
Improve particle renderer performance 12,500x

### DIFF
--- a/include/vapor/ParticleRenderer.h
+++ b/include/vapor/ParticleRenderer.h
@@ -72,9 +72,7 @@ private:
         float      value;
     };
 
-    std::vector<Vertex> _particles;
-
-    std::vector<int> _streamSizes;
+    size_t _particlesCount;
 
     unsigned int _VAO = 0;
     unsigned int _VBO = 0;
@@ -99,8 +97,6 @@ private:
     int  _renderParticlesHelper();
     void _prepareColormap();
     glm::vec3 _getScales();
-    bool _clipOriginToBox( const glm::vec3 &p1);
-    void _clipEndpointToBox( const glm::vec3 &p1, glm::vec3 &p2 ) const;
 };
 
 };    // namespace VAPoR

--- a/share/shaders/ParticleDirection.frag
+++ b/share/shaders/ParticleDirection.frag
@@ -1,0 +1,66 @@
+// Basic fragment shader. Maps the fValue onto a color using the LUT then applies Phong lighting.
+#version 330 core
+
+uniform bool constantColorEnabled = false;
+uniform vec3 constantColor = vec3(1.0f);
+uniform vec3 lightDir = vec3(0, 0, -1);
+uniform bool lightingEnabled = true;
+
+uniform sampler1D LUT;
+uniform vec2 mapRange;
+uniform vec3 scales;
+
+in float fValue;
+in vec3  fNormal;
+out vec4 fragment;
+
+uniform float phongAmbient;
+uniform float phongDiffuse;
+uniform float phongSpecular;
+uniform float phongShininess;
+float PhongLighting(vec3 normal, vec3 viewDir)
+{
+	if (!lightingEnabled)
+		return 1.0;
+    
+    vec3 lightDir = viewDir;
+
+    float diffuse = abs(dot(normal, -lightDir)) * phongDiffuse;
+
+    float specularStrength = phongSpecular;
+    vec3 reflectDir = reflect(lightDir, normal);
+    float spec = pow(abs(dot(viewDir, reflectDir)), phongShininess);
+    float specular = specularStrength * spec;
+
+    return max(phongAmbient + diffuse + specular, phongAmbient);
+}
+
+void main() {
+    // fragment = vec4(1,0,1,1);
+    //fragment = texture(LUT, (fValue - mapRange.x) / (mapRange.y - mapRange.x));
+    //return;
+
+    vec4 color;
+    if (constantColorEnabled)
+        color = vec4(constantColor, 1.0f);
+    else
+        color = texture(LUT, (fValue - mapRange.x) / (mapRange.y - mapRange.x));
+
+    if (lightingEnabled) {
+		vec3 normal;
+		if (gl_FrontFacing)
+			normal = -fNormal;
+		else 
+			normal = fNormal;
+
+		vec3 ld = normalize(lightDir * scales);
+        // float diffuse = max(dot(normal, ld), 0.0);
+        // color.rgb *= max(diffuse, 0.2f);
+        color.rgb *= PhongLighting(normal, ld);
+    }
+
+    fragment = color;
+    
+    if (color.a < 0.05) discard;
+}
+

--- a/share/shaders/ParticleDirection.geom
+++ b/share/shaders/ParticleDirection.geom
@@ -1,0 +1,95 @@
+// This shader generates tubes between every pair of vertices in a line. 
+// The tube is generated as a triangle strip. This geometry is generated at the origin
+// and transformed with a simple affine transformation using basis vectors.
+// 
+// EmitWorld(vec3 v) projects v and emits it.
+// CylinderVert(v, ...) is a helper function that generates a point on a circle
+// given the parameters and passes it to EmitWorld.
+
+#version 330 core
+
+#include FlowInclude.geom
+
+#define REFINEMENT 7
+
+layout (points) in;
+layout (triangle_strip, max_vertices = 16) out; // 7 * 2 + 2
+//layout (line_strip, max_vertices = 64) out; // 7 * 2 + 2
+//layout (points, max_vertices = 64) out; // 7 * 2 + 2
+
+
+in  vec3 gNorm[];
+in  float gValue[];
+out float fValue;
+out vec3 fNormal;
+
+
+uniform mat4 P;
+uniform mat4 MV;
+uniform vec3 scales;
+uniform float radius = 0.05;
+uniform float dirScale = 0.05;
+
+void EmitWorld(const vec3 v);
+void CylinderVert(const vec3 v, const vec3 d, const float value);
+
+
+void main()
+{
+    //fValue = gValue[0];
+    //EmitWorld(gl_in[0].gl_Position.xyz);
+    //EmitWorld(gl_in[0].gl_Position.xyz + gNorm[0] * dirScale);
+    //EndPrimitive();
+    //return;
+
+    vec3 V[2];
+    V[0] = gl_in[0].gl_Position.xyz;
+
+    vec3 N = gNorm[0];
+    V[1] = V[0] + N * dirScale;
+
+    vec3 up = vec3(0, 0, 1);
+    bool parallelToUpChanged = false;
+    if (1 - dot(N, up) < FLT_EPSILON)
+        parallelToUpChanged = true;
+
+    if (parallelToUpChanged)
+        up = vec3(1, 0, 0);
+
+    vec3 XH;
+    vec3 YH;
+    XH = normalize(cross(N, up));
+    YH = normalize(cross(XH, N));
+
+    vec2 fade = CalculateFade();
+
+    //fNormal = vec3(1,0,0); fValue = 1; EmitWorld(gl_in[0].gl_Position.xyz); EmitWorld(gl_in[1].gl_Position.xyz); EndPrimitive(); return;
+
+    for (int i = 0; i < REFINEMENT + 1; i++) {
+        float t = float(i)/float(REFINEMENT) * 2.f * PI;
+        vec3 D;
+        D = XH*cos(t) + YH*sin(t);
+
+        CylinderVert(V[0], D, gValue[0]);
+        CylinderVert(V[1], D, gValue[0]);
+    }
+    EndPrimitive();
+} 
+
+
+void EmitWorld(const vec3 v)
+{
+    gl_Position = P * MV * vec4(v, 1.0f);
+    EmitVertex();
+}
+
+
+void CylinderVert(const vec3 v, const vec3 d, const float value)
+{
+    fNormal = d;
+    fValue = value;
+    vec3 offset = d*radius;
+    offset /= scales;
+    EmitWorld(v + offset);
+}
+

--- a/share/shaders/ParticleDirection.vert
+++ b/share/shaders/ParticleDirection.vert
@@ -1,0 +1,14 @@
+#version 330 core
+
+layout (location = 0) in vec3 vPos;
+layout (location = 1) in vec3 vNorm;
+layout (location = 2) in float vValue;
+
+out vec3 gNorm;
+out float gValue;
+
+void main() {
+    gValue = vValue;
+    gNorm = vNorm;
+    gl_Position = vec4(vPos, 1.0f);
+}

--- a/share/shaders/ParticlePoint.frag
+++ b/share/shaders/ParticlePoint.frag
@@ -1,0 +1,55 @@
+// Maps the fValue onto a color using the LUT then applies Phong lighting.
+// Using the texture coordinates of the billboard it caclulates the bounds and normals of a sphere
+// which is then used for the lighting calculation.
+
+#version 330 core
+
+#define PI (3.1415926)
+
+uniform bool constantColorEnabled = false;
+uniform vec3 constantColor = vec3(1.0f);
+uniform vec3 lightDir = vec3(0, 0, -1);
+uniform bool lightingEnabled = true;
+
+uniform sampler1D LUT;
+uniform vec2 mapRange;
+uniform vec3 scales;
+
+in float fValue;
+in  vec2 fC;
+out vec4 fragment;
+
+uniform float phongAmbient;
+uniform float phongDiffuse;
+uniform float phongSpecular;
+uniform float phongShininess;
+float PhongLighting(float theta)
+{
+	if (!lightingEnabled)
+		return 1.0;
+
+	float ct = cos(theta);
+    float diffuse = ct * phongDiffuse;
+    float specular = phongSpecular * pow(ct, phongShininess);
+    return max(phongAmbient + diffuse + specular, phongAmbient);
+}
+
+void main() {
+    vec4 color;
+    if (constantColorEnabled)
+        color = vec4(constantColor, 1.0f);
+    else
+        color = texture(LUT, (fValue - mapRange.x) / (mapRange.y - mapRange.x));
+
+	float a = length(fC); // Length of a right angle triangle with a hypontenuse going from the origin to the sphere surface.
+	float t = acos(a); // Angle of triangle
+	float t2 = PI/2.0 - t; // Reflected angle
+
+	if (a > 1)
+		discard;
+
+	color.rgb *= PhongLighting(t2);
+    fragment = color;
+    
+    if (color.a < 0.05) discard;
+}

--- a/share/shaders/ParticlePoint.geom
+++ b/share/shaders/ParticlePoint.geom
@@ -1,0 +1,52 @@
+// This generates a billboard with a width and height equal to the diameter the sphere
+
+#version 330 core
+
+#define REFINEMENT 10
+
+layout (points) in;
+layout (triangle_strip, max_vertices = 4) out;
+
+
+in  float gValue[];
+out float fValue;
+out vec2 fC;
+
+
+uniform mat4 P;
+uniform mat4 MV;
+uniform vec3 cameraPos;
+uniform vec3 scales;
+uniform float radius = 0.05;
+
+
+void EmitWorld(const vec3 v);
+
+
+void main()
+{
+    fValue = gValue[0];
+    vec3 o = gl_in[0].gl_Position.xyz;
+
+	// Plane perpendicular to camera normal
+	vec3 up = vec3(0.0, 0.0, 1.0);
+	vec3 toCamera = normalize(cameraPos - o);
+	vec3 xh = normalize(cross(up, toCamera));
+	vec3 yh = normalize(cross(toCamera, xh));
+	xh /= scales;
+	yh /= scales;
+
+	// Billboard
+	fC = vec2(-1.0, -1.0); EmitWorld(o + radius * (-xh + -yh));
+	fC = vec2( 1.0, -1.0); EmitWorld(o + radius * ( xh + -yh));
+	fC = vec2(-1.0,  1.0); EmitWorld(o + radius * (-xh +  yh));
+	fC = vec2( 1.0,  1.0); EmitWorld(o + radius * ( xh +  yh));
+	EndPrimitive();
+} 
+
+
+void EmitWorld(const vec3 v)
+{
+    gl_Position = P * MV * vec4(v, 1.0f);
+    EmitVertex();
+}

--- a/share/shaders/ParticlePoint.vert
+++ b/share/shaders/ParticlePoint.vert
@@ -1,0 +1,11 @@
+#version 330 core
+
+layout (location = 0) in vec3 vPos;
+layout (location = 1) in float vValue;
+
+out float gValue;
+
+void main() {
+    gValue = vValue;
+    gl_Position = vec4(vPos, 1.0f);
+}


### PR DESCRIPTION
This PR makes the particle renderer over 12,500 times faster. Below Vapor is rendering over 20,000,000 particles in realtime. This PR also drastically decreases both its CPU and GPU RAM requirements.

![performance](https://github.com/NCAR/VAPOR/assets/2772687/5c296b32-f57b-49ce-876e-4176e23ef1fb)
