### PR TITLE
Fix variable selector empty option and clean python api Conda build linker warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/lib/osgl/glad/include")
 if (WIN32)
 	get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
 endif ()
-if (BUILD_VDC)
+if (BUILD_VDC AND EXISTS ${PYTHONPATH}/lib-dynload)
 	link_directories (${PYTHONPATH}/lib-dynload)
 endif ()
 

--- a/apps/vaporgui/PStringDropdown.cpp
+++ b/apps/vaporgui/PStringDropdown.cpp
@@ -10,6 +10,14 @@ PStringDropdown::PStringDropdown(const std::string &tag, const std::vector<std::
 
 void PStringDropdown::SetItems(const std::vector<std::string> &items) const { _vComboBox->SetOptions(items); }
 
-void PStringDropdown::updateGUI() const { _vComboBox->SetValue(getParamsString()); }
+void PStringDropdown::updateGUI() const
+{
+    auto val = getParamsString();
+    if (val.empty())
+        val = _customBlankText;
+    _vComboBox->SetValue(val);
+}
+
+void PStringDropdown::setCustomBlankText(std::string text) { _customBlankText = text; }
 
 void PStringDropdown::dropdownTextChanged(std::string text) { setParamsString(text); }

--- a/apps/vaporgui/PStringDropdown.h
+++ b/apps/vaporgui/PStringDropdown.h
@@ -14,6 +14,7 @@ class PStringDropdown : public PLineItem {
     Q_OBJECT
 
     VComboBox *_vComboBox;
+    std::string _customBlankText;
 
 public:
     PStringDropdown(const std::string &tag, const std::vector<std::string> &items, const std::string &label = "");
@@ -22,6 +23,7 @@ public:
 
 protected:
     virtual void updateGUI() const override;
+    void setCustomBlankText(std::string text);
 
 protected slots:
     virtual void dropdownTextChanged(std::string text);

--- a/apps/vaporgui/PVariableSelector.cpp
+++ b/apps/vaporgui/PVariableSelector.cpp
@@ -8,7 +8,8 @@ typedef VAPoR::DataMgr::VarType VarType;
 
 #define NULL_TEXT "<none>"
 
-PVariableSelector::PVariableSelector(const std::string &tag, const std::string &label) : PStringDropdown(tag, {}, label) {}
+PVariableSelector::PVariableSelector(const std::string &tag, const std::string &label)
+: PStringDropdown(tag, {}, label) { setCustomBlankText(NULL_TEXT); }
 
 void PVariableSelector::updateGUI() const
 {


### PR DESCRIPTION
Fix #3556

## Before
<img width="452" alt="before" src="https://github.com/NCAR/VAPOR/assets/2772687/c386bdad-56eb-405f-aef5-130f2af0e671">


## After
<img width="452" alt="after" src="https://github.com/NCAR/VAPOR/assets/2772687/5bae0b4b-cd3d-4fb3-acb5-5e8302f9c154">
