### PR TITLE
Use DataMgrUtils instead of CE

### DIFF
--- a/lib/render/ImageRenderer.cpp
+++ b/lib/render/ImageRenderer.cpp
@@ -33,8 +33,7 @@ namespace {
 //
 void conform(GLfloat *verts, int nx, int ny)
 {
-    VAssert(nx >= 2);
-    VAssert(ny >= 2);
+    if (nx<2 || ny<2) return;
 
     // x values
     //

--- a/lib/render/Renderer.cpp
+++ b/lib/render/Renderer.cpp
@@ -26,6 +26,7 @@
 
 #include <vapor/glutil.h>    // Must be included first!!!
 #include <vapor/Renderer.h>
+#include <vapor/TwoDDataRenderer.h>
 #include <vapor/DataMgrUtils.h>
 #include "vapor/GLManager.h"
 #include "vapor/FontManager.h"
@@ -120,6 +121,11 @@ int Renderer::paintGL(bool fast)
 
     mm->MatrixModeModelView();
     mm->PushMatrix();
+
+    if (dynamic_cast<TwoDDataRenderer*>(this) != nullptr) {
+        float zOffset = GetDefaultZ(_dataMgr, GetActiveParams()->GetCurrentTimestep());
+        _glManager->matrixManager->Translate(0, 0, zOffset);
+    }
     ApplyTransform(_glManager, GetDatasetTransform(), rParams->GetTransform());
 
     int rc = _paintGL(fast);

--- a/lib/render/TwoDRenderer.cpp
+++ b/lib/render/TwoDRenderer.cpp
@@ -82,9 +82,6 @@ int TwoDRenderer::_initializeGL()
 
 int TwoDRenderer::_paintGL(bool)
 {
-    float zOffset = GetDefaultZ(_dataMgr, GetActiveParams()->GetCurrentTimestep());
-    _glManager->matrixManager->Translate(0, 0, zOffset);
-    
     // Get the 2D texture
     //
     _texture = GetTexture(_dataMgr, _texWidth, _texHeight, _texInternalFormat, _texFormat, _texType, _texelSize, _gridAligned);
@@ -105,7 +102,6 @@ int TwoDRenderer::_paintGL(bool)
 
         _texCoords = (GLfloat *)_sb_texCoords.Alloc(_meshWidth * _meshHeight * 2 * sizeof(*_texCoords));
         _computeTexCoords(_texCoords, _meshWidth, _meshHeight);
-
         _renderMeshUnAligned();
     } else {
         VAssert(_meshWidth == _texWidth);

--- a/lib/render/TwoDRenderer.cpp
+++ b/lib/render/TwoDRenderer.cpp
@@ -97,8 +97,7 @@ int TwoDRenderer::_paintGL(bool)
 
     if (!_gridAligned) {
         VAssert(_structuredMesh);
-        VAssert(_meshWidth >= 2);
-        VAssert(_meshHeight >= 2);
+        if (_meshWidth<2 || _meshHeight<2) return 0; // If mesh with or height is too small for a texture, harmlessly return
 
         _texCoords = (GLfloat *)_sb_texCoords.Alloc(_meshWidth * _meshHeight * 2 * sizeof(*_texCoords));
         _computeTexCoords(_texCoords, _meshWidth, _meshHeight);
@@ -281,8 +280,7 @@ void TwoDRenderer::ComputeNormals(const GLfloat *verts, GLsizei w, GLsizei h, GL
 
 void TwoDRenderer::_computeTexCoords(GLfloat *tcoords, size_t w, size_t h) const
 {
-    VAssert(_meshWidth >= 2);
-    VAssert(_meshHeight >= 2);
+    if (_meshWidth<2 || _meshHeight<2) return;
 
     double deltax = 1.0 / (_meshWidth - 1);
     double deltay = 1.0 / (_meshHeight - 1);


### PR DESCRIPTION
@stasj, I looked into using RenderParams to query a random 3D variable but there does not seem to be a way to do this.  The RenderParams gets instantiated with a dimensionality, and has no evident way to query variables outside of their given dimension.  The only path forward I found was to use DataMgrUtils, shown here.

Also, the CE method used in PR #3584 does in fact find the domain extents by taking the union of all variables in the dataset.  Not taking the union of the extents could break the PRegionSelector if we don't land on a variable that encloses the entire domain, which could happen.  WRF can contain soil and fire grids that lie outside or within the meteorological grids that we typically deal with.  

Feel free to pick whichever solution you like.

Fixes #3575 and #3583.