### PR TITLE
Error check and dump metadata function

### DIFF
--- a/apps/pythonapi/vapor/dataset.py
+++ b/apps/pythonapi/vapor/dataset.py
@@ -71,8 +71,8 @@ class Dataset(SmartWrapper, wrap=link.VAPoR.DataMgr):
             print(f"  {var}")
             print(f"    Dimensionality:", self.GetVarGeometryDim(var))
             print(f"    Coordinates:", self.GetVarCoordVars(var, True))
-            print(f"    Num Timesteps:", self.GetNumTimeSteps(var))
             print(f"    Data Range:", self.GetDataRange(var))
+            print(f"    Num Timesteps:", self.GetNumTimeSteps(var))
 
     @staticmethod
     def GetDatasetTypes():

--- a/apps/pythonapi/vapor/dataset.py
+++ b/apps/pythonapi/vapor/dataset.py
@@ -47,9 +47,34 @@ class Dataset(SmartWrapper, wrap=link.VAPoR.DataMgr):
 
     def GetName(self):
         return str(self.id)
+    
+    def __str__(self):
+        output = []
+        # Dataset Name
+        output.append(f"Dataset: {self.GetName()}")
+        # Dimensions
+        output.append("Dimensions:")
+        for dim in self.GetDimensionNames():
+            output.append(f"  {dim}: {self.GetDimensionLength(dim, 0)}")
+        # Coordinates
+        coord_var_names = self.GetCoordVarNames()
+        if len(coord_var_names) > 0:
+            output.append(f"Coordinate Variable Names: {coord_var_names}")
+        # Variables
+        output.append("Data Variables:")
+        for var in self.GetDataVarNames():
+            output.extend([
+                f"  {var}",
+                f"    Dimensionality: {self.GetVarGeometryDim(var)}",
+                f"    Number of Timesteps: {self.GetNumTimeSteps(var)}",
+                f"    Coordinates: {self.GetVarCoordVars(var, True)}",
+                f"    Data Range: {self.GetDataRange(var)}"
+            ])
+
+        return "\n".join(output)
 
     def __repr__(self):
-        return f'Dataset("{self.GetName()}")'
+        return self.__str__()
 
     def GetTransform(self):
         pm = self.ses.ce.GetParamsMgr()
@@ -61,18 +86,6 @@ class Dataset(SmartWrapper, wrap=link.VAPoR.DataMgr):
         c_range = link.std.vector[link.double]()
         self._wrappedInstance.GetDataRange(atTimestep, varname, 0, 0, c_range)
         return list(c_range)
-
-    def DumpVarMetadata(self):
-        """
-        Prints metadata associated with each variable in dataset
-        """
-        print("Data Variables:")
-        for var in self.GetDataVarNames():
-            print(f"  {var}")
-            print(f"    Dimensionality:", self.GetVarGeometryDim(var))
-            print(f"    Coordinates:", self.GetVarCoordVars(var, True))
-            print(f"    Data Range:", self.GetDataRange(var))
-            print(f"    Num Timesteps:", self.GetNumTimeSteps(var))
 
     @staticmethod
     def GetDatasetTypes():

--- a/apps/pythonapi/vapor/dataset.py
+++ b/apps/pythonapi/vapor/dataset.py
@@ -69,9 +69,9 @@ class Dataset(SmartWrapper, wrap=link.VAPoR.DataMgr):
         print("Data Variables:")
         for var in self.GetDataVarNames():
             print(f"  {var}")
-            print(f"    Time Varying:", bool(self.IsTimeVarying(var)))
             print(f"    Dimensionality:", self.GetVarGeometryDim(var))
             print(f"    Coordinates:", self.GetVarCoordVars(var, True))
+            print(f"    Num Timesteps:", self.GetNumTimeSteps(var))
             print(f"    Data Range:", self.GetDataRange(var))
 
     @staticmethod

--- a/apps/pythonapi/vapor/dataset.py
+++ b/apps/pythonapi/vapor/dataset.py
@@ -62,6 +62,14 @@ class Dataset(SmartWrapper, wrap=link.VAPoR.DataMgr):
         self._wrappedInstance.GetDataRange(atTimestep, varname, 0, 0, c_range)
         return list(c_range)
 
+    def DumpMetadata(self):
+        print("Data Variables:")
+        for var in self.GetDataVarNames():
+            print(f"  {var}")
+            print(f"    Time Varying:", bool(self.IsTimeVarying(var)))
+            print(f"    Dimensionality:", self.GetVarGeometryDim(var))
+            print(f"    Coordinates:", self.GetVarCoordVars(var, True))
+            print(f"    Data Range:", self.GetDataRange(var))
 
     @staticmethod
     def GetDatasetTypes():

--- a/apps/pythonapi/vapor/dataset.py
+++ b/apps/pythonapi/vapor/dataset.py
@@ -62,7 +62,10 @@ class Dataset(SmartWrapper, wrap=link.VAPoR.DataMgr):
         self._wrappedInstance.GetDataRange(atTimestep, varname, 0, 0, c_range)
         return list(c_range)
 
-    def DumpMetadata(self):
+    def DumpVarMetadata(self):
+        """
+        Prints metadata associated with each variable in dataset
+        """
         print("Data Variables:")
         for var in self.GetDataVarNames():
             print(f"  {var}")

--- a/apps/pythonapi/vapor/transferfunction.py
+++ b/apps/pythonapi/vapor/transferfunction.py
@@ -60,6 +60,8 @@ class TransferFunction(ParamsWrapper, wrap=link.VAPoR.MapperFunction):
         return list(flatten(l))
 
     def __rgbToHsv(self, rgb):
+        if len(rgb) != 3:
+            raise ValueError("colors must be a list of tuples of length three")
         return [*self._params.rgbToHsv(rgb)]
 
     def SetOpacityNormalizedControlPoints(self, cp: list[tuple[float, float]]):

--- a/apps/pythonapi/vapor/transferfunction.py
+++ b/apps/pythonapi/vapor/transferfunction.py
@@ -61,7 +61,7 @@ class TransferFunction(ParamsWrapper, wrap=link.VAPoR.MapperFunction):
 
     def __rgbToHsv(self, rgb):
         if len(rgb) != 3:
-            raise ValueError("colors must be a list of tuples of length three")
+            raise ValueError("rgb list must have 3 values")
         return [*self._params.rgbToHsv(rgb)]
 
     def SetOpacityNormalizedControlPoints(self, cp: list[tuple[float, float]]):


### PR DESCRIPTION
I thought I'd open a small PR to test run making changes to the Python api. I've made two changes:
1. When RGB colors are converted to HSV, make a check to verify the list is of length 3. I think this stops the kernel from crashing when using incorrect inputs with `SetColorRGBList`
2. Added a `DumpVarMetadata` function for datasets. Some of the examples printed out the metadata manually, and I thought it would be nice to have it integrated into the package. 

I've tested it out and I think it's working as intended, but let me know if there's anything else I should watch out for!