### PR TITLE
Fix Vapor crashes when variable names have invalid XML characters #3633

### DIFF
--- a/include/vapor/XmlNode.h
+++ b/include/vapor/XmlNode.h
@@ -501,7 +501,8 @@ public:
     // I don't know how to export an operator<< !
     static ostream &streamOut(ostream &os, const XmlNode &node);
 
-    static bool IsValidXMLElement(string s);
+    static bool IsValidXMLElement(const string &s, int *badIdx=nullptr);
+    static string SanitizeXMLTag(string s);
 
 private:
     static vector<long>   _emptyLongVec;    // empty elements

--- a/lib/params/XmlNode.cpp
+++ b/lib/params/XmlNode.cpp
@@ -77,16 +77,32 @@ string escapeStr(string s)
 }
 };    // namespace
 
-bool XmlNode::IsValidXMLElement(string s)
+bool XmlNode::IsValidXMLElement(const string &s, int *badIdx)
 {
+    int _;
+    badIdx = badIdx?badIdx:&_;
+    *badIdx = 0;
+
     if (s.empty()) return (false);
     if (!(std::isalpha(s[0]) || s[0] == '_')) return (false);
     for (string::const_iterator itr = s.begin(); itr != s.end(); ++itr) {
         if (!(std::isalnum(*itr) || std::isdigit(*itr) || *itr == '-' || *itr == '_' || *itr == '.')) { return (false); }
         if (isspace(*itr)) return (false);
+        ++*badIdx;
     }
 
+    *badIdx = -1;
     return (true);
+}
+
+string XmlNode::SanitizeXMLTag(string s)
+{
+    assert(!s.empty());
+    int i;
+    while (!IsValidXMLElement(s, &i)) {
+        s = s.substr(0, i) + "_" + to_string((int)s[i]) + "_" + s.substr(i+1);
+    }
+    return s;
 }
 
 XmlNode::XmlNode(const string &tag, const map<string, string> &attrs, size_t numChildrenHint)

--- a/lib/params/XmlNode.cpp
+++ b/lib/params/XmlNode.cpp
@@ -97,7 +97,8 @@ bool XmlNode::IsValidXMLElement(const string &s, int *badIdx)
 
 string XmlNode::SanitizeXMLTag(string s)
 {
-    assert(!s.empty());
+    if(s.empty())
+        return "__empty__";
     int i;
     while (!IsValidXMLElement(s, &i)) {
         s = s.substr(0, i) + "_" + to_string((int)s[i]) + "_" + s.substr(i+1);

--- a/lib/vdc/NetCDFCFCollection.cpp
+++ b/lib/vdc/NetCDFCFCollection.cpp
@@ -43,6 +43,14 @@ NetCDFCFCollection::~NetCDFCFCollection()
 
 }
 
+static bool IsNameCFCompliant(const string &name, bool strict=true) {
+    if (!isalpha(name[0]) || (!strict && name[0] == '_')) return false;
+    for (int i = 1; i < name.size(); i++)
+        if (!(isalnum(name[i]) || name[i] == '_' || (!strict && (name[i] == '_' || name[i] == '.' || name[i] == '-'))))
+            return false;
+    return true;
+}
+
 int NetCDFCFCollection::_Initialize(const vector<string> &files)
 {
     // Look for time coordinate variables. Must be 1D and have same
@@ -76,6 +84,13 @@ int NetCDFCFCollection::_Initialize(const vector<string> &files)
     //
     int rc = NetCDFCollection::Initialize(files, tv, tv);
     if (rc < 0) return (-1);
+
+    for (const auto &v : GetVariableNames(-1, false)) {
+        if (!IsNameCFCompliant(v, false)) {
+            SetErrMsg("Variable name \"%s\" is not compliant with NetCDF-CF", v.c_str());
+            return -1;
+        }
+    }
 
     return (0);
 }

--- a/lib/vdc/NetCDFCollection.cpp
+++ b/lib/vdc/NetCDFCollection.cpp
@@ -249,7 +249,7 @@ vector<string> NetCDFCollection::GetVariableNames(int ndims, bool spatial) const
         const TimeVaryingVar &tvvars = p->second;
         int                   myndims = tvvars.GetSpatialDims().size();
         if (!spatial && tvvars.GetTimeVarying()) { myndims++; }
-        if (myndims == ndims) { names.push_back(p->first); }
+        if (myndims == ndims || ndims == -1) { names.push_back(p->first); }
     }
 
     return (names);


### PR DESCRIPTION
Support for variables with invalid XML characters cannot be added without major refactoring. The dataset in question is not CF complaint as the spec does not allow the characters used (CF Conventions § 2.3. Naming Conventions).

I added a check for CF-compliant names in the data loader.

Fix #3633