### PR TITLE
Fixes for windows installers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -827,7 +827,7 @@ workflows:
       #- build_macOS_installers
       # - build_appleSilicon_installer
       # - build_macOSx86_installer
-      - build_linux_installer
+      # - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs
       #- build_macOSx86_libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ commands:
             # clang
             # If we run selfupdate on every run, we will update clang on minor revisions, taking 1+ hours to build
             # Therefore, skip selfupdate until we know we want a newer version of clang
-            #(sudo yes || true) | sudo /opt/local/bin/port install clang-17 +universal
+            (sudo yes || true) | sudo /opt/local/bin/port install clang-17 +universal
             sudo /opt/local/bin/port select --set clang mp-clang-17
             /opt/local/bin/clang++ -v > clangVersion.txt
           no_output_timeout: 45m
@@ -827,14 +827,14 @@ workflows:
       #- build_python_api_ubuntuDebug
       #- build_python_api_ubuntu
       #- build_python_api_osx
-      - build_win10_installer
+      # - build_win10_installer
       #- build_macOS_installers
-      # - build_appleSilicon_installer
+      - build_appleSilicon_installer
       # - build_macOSx86_installer
       # - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs
-      #- build_macOSx86_libs
+      # - build_macOSx86_libs
       #- build_AppleSilicon_libs
       #- build_suse_libs
       #- build_windows_libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
     parameters:
       branch:
         type: string
-        default: 3.9.3firstRound
+        default: $CIRCLE_BRANCH
       beforeCompile:
         type: string
         default: ""
@@ -199,7 +199,7 @@ jobs:
             Copy-Item site_files\* -Destination .
             mkdir build
             cd build
-            git checkout 3.9.3firstRound
+            git checkout $CIRCLE_BRANCH
             & 'C:\\Program Files\\CMake\\bin\\cmake.exe' -S C:\Users\circleci\project -B C:\Users\circleci\project\build -DDIST_INSTALLER:string=ON -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_OSP=OFF -G 'Visual Studio 16 2019' -A x64
             msbuild C:\Users\circleci\project\build\PACKAGE.vcxproj /p:Configuration=Release /p:Platform=x64
             mkdir -p C:\Users\circleci\project\tmp\workspace\installers
@@ -290,7 +290,7 @@ jobs:
           command: |
             git clone https://github.com/NCAR/VAPOR.git /root/VAPOR
             cd /root/VAPOR
-            git checkout 3.9.3firstRound
+            git checkout $CIRCLE_BRANCH
             apt install -y libomp-dev
             cmake . \
             -DCMAKE_BUILD_TYPE:String=Release \
@@ -849,7 +849,7 @@ workflows:
              cron: "0 16 * * 3" #Time is GMT
              filters:
                branches:
-                 only: 3.9.3firstRound
+                 only: $CIRCLE_BRANCH
       jobs:
         - build_linux_installer
         - build_appleSilicon_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
             Copy-Item site_files\* -Destination .
             mkdir build
             cd build
-            git checkout $CIRCLE_BRANCH
+            git checkout main
             & 'C:\\Program Files\\CMake\\bin\\cmake.exe' -S C:\Users\circleci\project -B C:\Users\circleci\project\build -DDIST_INSTALLER:string=ON -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_OSP=OFF -G 'Visual Studio 16 2019' -A x64
             msbuild C:\Users\circleci\project\build\PACKAGE.vcxproj /p:Configuration=Release /p:Platform=x64
             mkdir -p C:\Users\circleci\project\tmp\workspace\installers
@@ -286,7 +286,7 @@ jobs:
           command: |
             git clone https://github.com/NCAR/VAPOR.git /root/VAPOR
             cd /root/VAPOR
-            git checkout $CIRCLE_BRANCH
+            git checkout main
             apt install -y libomp-dev
             cmake . \
             -DCMAKE_BUILD_TYPE:String=Release \
@@ -825,9 +825,9 @@ workflows:
       #- build_python_api_osx
       - build_win10_installer
       #- build_macOS_installers
-      - build_appleSilicon_installer
-      - build_macOSx86_installer
-      - build_linux_installer
+      # - build_appleSilicon_installer
+      # - build_macOSx86_installer
+      # - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs
       #- build_macOSx86_libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
     parameters:
       branch:
         type: string
-        default: main
+        default: codesigning-vapor
       beforeCompile:
         type: string
         default: ""
@@ -823,10 +823,10 @@ workflows:
       #- build_python_api_ubuntuDebug
       #- build_python_api_ubuntu
       #- build_python_api_osx
-      - build_win10_installer
+      # - build_win10_installer
       #- build_macOS_installers
       # - build_appleSilicon_installer
-      # - build_macOSx86_installer
+      - build_macOSx86_installer
       # - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs
@@ -845,7 +845,7 @@ workflows:
              cron: "0 16 * * 3" #Time is GMT
              filters:
                branches:
-                 only: main
+                 only: codesigning-vapor
       jobs:
         - build_linux_installer
         - build_appleSilicon_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
     parameters:
       branch:
         type: string
-        default: codesigning-vapor
+        default: $CIRCLE_BRANCH
       beforeCompile:
         type: string
         default: ""
@@ -199,7 +199,7 @@ jobs:
             Copy-Item site_files\* -Destination .
             mkdir build
             cd build
-            git checkout main
+            git checkout codesigning-vapor
             & 'C:\\Program Files\\CMake\\bin\\cmake.exe' -S C:\Users\circleci\project -B C:\Users\circleci\project\build -DDIST_INSTALLER:string=ON -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_OSP=OFF -G 'Visual Studio 16 2019' -A x64
             msbuild C:\Users\circleci\project\build\PACKAGE.vcxproj /p:Configuration=Release /p:Platform=x64
             mkdir -p C:\Users\circleci\project\tmp\workspace\installers
@@ -286,7 +286,7 @@ jobs:
           command: |
             git clone https://github.com/NCAR/VAPOR.git /root/VAPOR
             cd /root/VAPOR
-            git checkout main
+            git checkout codesigning-vapor
             apt install -y libomp-dev
             cmake . \
             -DCMAKE_BUILD_TYPE:String=Release \
@@ -823,10 +823,10 @@ workflows:
       #- build_python_api_ubuntuDebug
       #- build_python_api_ubuntu
       #- build_python_api_osx
-      # - build_win10_installer
+      - build_win10_installer
       #- build_macOS_installers
       # - build_appleSilicon_installer
-      - build_macOSx86_installer
+      # - build_macOSx86_installer
       # - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
     parameters:
       branch:
         type: string
-        default: $CIRCLE_BRANCH
+        default: 3.9.3firstRound
       beforeCompile:
         type: string
         default: ""
@@ -199,7 +199,7 @@ jobs:
             Copy-Item site_files\* -Destination .
             mkdir build
             cd build
-            git checkout codesigning-vapor
+            git checkout 3.9.3firstRound
             & 'C:\\Program Files\\CMake\\bin\\cmake.exe' -S C:\Users\circleci\project -B C:\Users\circleci\project\build -DDIST_INSTALLER:string=ON -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_OSP=OFF -G 'Visual Studio 16 2019' -A x64
             msbuild C:\Users\circleci\project\build\PACKAGE.vcxproj /p:Configuration=Release /p:Platform=x64
             mkdir -p C:\Users\circleci\project\tmp\workspace\installers
@@ -286,7 +286,7 @@ jobs:
           command: |
             git clone https://github.com/NCAR/VAPOR.git /root/VAPOR
             cd /root/VAPOR
-            git checkout codesigning-vapor
+            git checkout 3.9.3firstRound
             apt install -y libomp-dev
             cmake . \
             -DCMAKE_BUILD_TYPE:String=Release \
@@ -827,7 +827,7 @@ workflows:
       #- build_macOS_installers
       # - build_appleSilicon_installer
       # - build_macOSx86_installer
-      # - build_linux_installer
+      - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs
       #- build_macOSx86_libs
@@ -845,7 +845,7 @@ workflows:
              cron: "0 16 * * 3" #Time is GMT
              filters:
                branches:
-                 only: codesigning-vapor
+                 only: 3.9.3firstRound
       jobs:
         - build_linux_installer
         - build_appleSilicon_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,6 +204,10 @@ jobs:
             msbuild C:\Users\circleci\project\build\PACKAGE.vcxproj /p:Configuration=Release /p:Platform=x64
             mkdir -p C:\Users\circleci\project\tmp\workspace\installers
             Copy-Item C:\Users\circleci\project\build\*.exe -Destination C:\Users\circleci\project\tmp\workspace\installers
+            if (!(Test-Path -Path C:\Users\circleci\project\tmp\workspace\installers\*.exe)) {
+              Write-Error "Build failed: No installers found"
+              exit 1
+            }
           no_output_timeout: 45m
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -827,11 +827,11 @@ workflows:
       #- build_python_api_ubuntuDebug
       #- build_python_api_ubuntu
       #- build_python_api_osx
-      - build_win10_installer
+      # - build_win10_installer
       #- build_macOS_installers
       # - build_appleSilicon_installer
       # - build_macOSx86_installer
-      # - build_linux_installer
+      - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs
       # - build_macOSx86_libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -827,11 +827,11 @@ workflows:
       #- build_python_api_ubuntuDebug
       #- build_python_api_ubuntu
       #- build_python_api_osx
-      # - build_win10_installer
+      - build_win10_installer
       #- build_macOS_installers
       # - build_appleSilicon_installer
       # - build_macOSx86_installer
-      - build_linux_installer
+      # - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs
       # - build_macOSx86_libs
@@ -849,7 +849,7 @@ workflows:
              cron: "0 16 * * 3" #Time is GMT
              filters:
                branches:
-                 only: $CIRCLE_BRANCH
+                 only: main
       jobs:
         - build_linux_installer
         - build_appleSilicon_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ commands:
             # clang
             # If we run selfupdate on every run, we will update clang on minor revisions, taking 1+ hours to build
             # Therefore, skip selfupdate until we know we want a newer version of clang
-            (sudo yes || true) | sudo /opt/local/bin/port install clang-17 +universal
+            # (sudo yes || true) | sudo /opt/local/bin/port install clang-17 +universal
             sudo /opt/local/bin/port select --set clang mp-clang-17
             /opt/local/bin/clang++ -v > clangVersion.txt
           no_output_timeout: 45m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
     parameters:
       branch:
         type: string
-        default: $CIRCLE_BRANCH
+        default: main
       beforeCompile:
         type: string
         default: ""
@@ -823,10 +823,10 @@ workflows:
       #- build_python_api_ubuntuDebug
       #- build_python_api_ubuntu
       #- build_python_api_osx
-      #- build_win10_installer
+      - build_win10_installer
       #- build_macOS_installers
-      #- build_appleSilicon_installer
-      #- build_macOSx86_installer
+      - build_appleSilicon_installer
+      - build_macOSx86_installer
       - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,9 +829,9 @@ workflows:
       #- build_python_api_osx
       # - build_win10_installer
       #- build_macOS_installers
-      - build_appleSilicon_installer
+      # - build_appleSilicon_installer
       # - build_macOSx86_installer
-      # - build_linux_installer
+      - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs
       # - build_macOSx86_libs

--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -11,7 +11,7 @@
 #include "ErrorReporter.h"
 #include "CheckForUpdate.h"
 #include <QLabel>
-#if !defined(OPENSSL_WINDOWS)
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 #include "vapor/STLUtils.h"

--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -133,11 +133,13 @@ AppSettingsMenu::AppSettingsMenu(QWidget *parent) : QDialog(parent), Updateable(
         new PButton("Restore defaults", [](VAPoR::ParamsBase *p) { dynamic_cast<SettingsParams *>(p)->Init(); }),
     });
 
-    char hostname[1024];
-    hostname[1023] = '\0';
-    gethostname(hostname, 1023);
-    if (STLUtils::BeginsWith(hostname, "casper"))
-        startupSettings->Add(new PCheckboxHLI<SettingsParams>("Check for VGL on Casper", &SettingsParams::GetCasperCheckForVGL, &SettingsParams::SetCasperCheckForVGL));
+    #ifndef _WIN32
+        char hostname[1024];
+        hostname[1023] = '\0';
+        gethostname(hostname, 1023);
+        if (STLUtils::BeginsWith(hostname, "casper"))
+            startupSettings->Add(new PCheckboxHLI<SettingsParams>("Check for VGL on Casper", &SettingsParams::GetCasperCheckForVGL, &SettingsParams::SetCasperCheckForVGL));
+    #endif
 
     setLayout(new QVBoxLayout);
     layout()->addWidget(_settings);

--- a/apps/vaporgui/AppSettingsMenu.cpp
+++ b/apps/vaporgui/AppSettingsMenu.cpp
@@ -11,7 +11,9 @@
 #include "ErrorReporter.h"
 #include "CheckForUpdate.h"
 #include <QLabel>
+#if !defined(OPENSSL_WINDOWS)
 #include <unistd.h>
+#endif
 #include "vapor/STLUtils.h"
 
 class PUpdateChecker : public PWidget {

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -34,7 +34,9 @@
 #include <iostream>
 #include <functional>
 #include <cmath>
+#if !defined(OPENSSL_WINDOWS)
 #include <unistd.h>
+#endif
 
 #include <QDesktopWidget>
 #include <QDockWidget>

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -34,9 +34,9 @@
 #include <iostream>
 #include <functional>
 #include <cmath>
-#ifndef _WIN32
+
 #include <unistd.h>
-#endif
+
 
 #include <QDesktopWidget>
 #include <QDockWidget>

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -34,7 +34,7 @@
 #include <iostream>
 #include <functional>
 #include <cmath>
-#if !defined(OPENSSL_WINDOWS)
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -34,9 +34,9 @@
 #include <iostream>
 #include <functional>
 #include <cmath>
-
+#ifndef _WIN32
 #include <unistd.h>
-
+#endif
 
 #include <QDesktopWidget>
 #include <QDockWidget>


### PR DESCRIPTION
This PR addresses two issues:

1. It looks like `unistd.h` isn't compatible with windows, but I think it's an easy fix. There were two files throwing errors and I added a quick check to each of them to make sure the incompatible lines don't run for Windows machines. This seems to do the trick as far as I can tell, but let me know if there is a better way!
```
#ifndef _WIN32
#include <unistd.h>
#endif
```

2. Adds a check to config.yml that throws an error if the windows installer doesn't build properly. Otherwise CricleCI will tell us that the job succeeds even when the build fails.