### PR TITLE
Fix CopyRegionAnnotationWidget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,7 +636,7 @@ workflows:
       #- build_python_api_ubuntuDebug
       #- build_python_api_ubuntu
       #- build_python_api_osx
-      - build_win10_installer
+      #- build_win10_installer
       #- build_macOS_installers
       #- build_appleSilicon_installer
       #- build_macOSx86_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,7 +636,7 @@ workflows:
       #- build_python_api_ubuntuDebug
       #- build_python_api_ubuntu
       #- build_python_api_osx
-      # - build_win10_installer
+      - build_win10_installer
       #- build_macOS_installers
       #- build_appleSilicon_installer
       #- build_macOSx86_installer

--- a/apps/vaporgui/CopyRegionAnnotationWidget.cpp
+++ b/apps/vaporgui/CopyRegionAnnotationWidget.cpp
@@ -71,7 +71,7 @@ void CopyRegionAnnotationWidget::copyRegion()
         VAssert(aParams);
         int timeStep = aParams->GetCurrentTimestep();
 
-        _scaleWorldCoordsToNormalized(minExtents, maxExtents, timeStep);
+        _scaleWorldCoordsToNormalized(minExtentsVec, maxExtentsVec, timeStep);
 
         aa->SetAxisOrigin(minExtentsVec);
         aa->SetMinTics(minExtentsVec);
@@ -81,18 +81,17 @@ void CopyRegionAnnotationWidget::copyRegion()
     }
 }
 
-void CopyRegionAnnotationWidget::_scaleWorldCoordsToNormalized(CoordType &minExts, CoordType &maxExts, int timeStep)
-{
+void CopyRegionAnnotationWidget::_scaleWorldCoordsToNormalized(std::vector<double> &minCoords, std::vector<double> &maxCoords, int timeStep) {
+    VAssert(minCoords.size() == maxCoords.size());
     VAPoR::CoordType    minDomainExts, maxDomainExts;
     DataStatus *        dataStatus = _controlExec->GetDataStatus();
     dataStatus->GetActiveExtents(_paramsMgr, timeStep, minDomainExts, maxDomainExts);
-    VAssert(minExts.size() == maxExts.size());
 
-    int size = minExts.size();
-    for (int i = 0; i < size; i++) {
-        double point = minExts[i] - minDomainExts[i];
-        minExts[i] = point / (maxDomainExts[i] - minDomainExts[i]);
-        point = maxExts[i] - minDomainExts[i];
-        maxExts[i] = point / (maxDomainExts[i] - minDomainExts[i]);
+    for (int i = 0; i < minCoords.size(); i++) {
+        double minPoint = minCoords[i] - minDomainExts[i];
+        double maxPoint = maxCoords[i] - minDomainExts[i];
+        double magnitude = maxDomainExts[i] - minDomainExts[i];
+        minCoords[i] = minPoint / magnitude;
+        maxCoords[i] = maxPoint / magnitude;
     }
 }

--- a/apps/vaporgui/CopyRegionAnnotationWidget.h
+++ b/apps/vaporgui/CopyRegionAnnotationWidget.h
@@ -27,7 +27,7 @@ protected slots:
     void copyRegion() override;
 
 private:
-    void _scaleWorldCoordsToNormalized(VAPoR::CoordType &minExts, VAPoR::CoordType &maxExts, int timeStep);
+    void _scaleWorldCoordsToNormalized(std::vector<double> &minExts, std::vector<double> &maxExts, int timeStep);
 
     VAPoR::ControlExec *_controlExec;
 };


### PR DESCRIPTION
Fixes #3668 

This fixes a typo that caused the issue.

However the Annotations really need a complete refactoring.  Annotations are stored in nomalized coordinates, and we are normalizing/un-normalizing these coordinates in both the GUI and Renderer libraries.  It should only be done in the Params.  The functionality of our annotations is not that different from that of a renderer.  Making it conformant with our other renderers would simplify our architecture, remove some pretty obscure legacy code, and reduce our maintenance overhead.