### PR TITLE
Fix height offset issues

### DIFF
--- a/lib/render/ImageRenderer.cpp
+++ b/lib/render/ImageRenderer.cpp
@@ -555,7 +555,7 @@ int ImageRenderer::_getMeshDisplacedGeo(DataMgr *dataMgr, Grid *hgtGrid, GLsizei
             float deltaZ = (float)defaultZ;
             if (hgtGrid) {
                 if (deltaZ == mv) deltaZ = defaultZ;
-                else deltaZ = hgtGrid->GetValue(x, y, 0.0) - defaultZ;
+                else deltaZ = hgtGrid->GetValue(x, y, 0.0);
             }
             z = deltaZ;
 
@@ -603,7 +603,7 @@ int ImageRenderer::_getMeshDisplacedNoGeo(DataMgr *dataMgr, Grid *hgtGrid, GLsiz
             float deltaZ = (float)defaultZ;
             if (hgtGrid) {
                 if (deltaZ == mv) deltaZ = defaultZ;
-                else deltaZ = hgtGrid->GetValue(x, y, 0.0) - defaultZ;
+                else deltaZ = hgtGrid->GetValue(x, y, 0.0);
             }
             z = deltaZ;
 

--- a/lib/vdc/DataMgrUtils.cpp
+++ b/lib/vdc/DataMgrUtils.cpp
@@ -371,7 +371,8 @@ double DataMgrUtils::Get2DRendererDefaultZ(DataMgr *dataMgr, size_t ts, int refL
     bool status = DataMgrUtils::GetExtents(dataMgr, ts, "", refLevel, lod, minExts, maxExts);
     if (!status) return (0.0);
 
-    return (minExts[2]);
+    //return (minExts[2]);
+    return (std::abs(minExts[2]) < std::abs(maxExts[2])) ? minExts[2] : maxExts[2];
 }
 
 bool DataMgrUtils::GetFirstExistingVariable(DataMgr *dataMgr, int level, int lod, int ndim, string &varname, size_t &ts)

--- a/lib/vdc/DataMgrUtils.cpp
+++ b/lib/vdc/DataMgrUtils.cpp
@@ -371,7 +371,7 @@ double DataMgrUtils::Get2DRendererDefaultZ(DataMgr *dataMgr, size_t ts, int refL
     bool status = DataMgrUtils::GetExtents(dataMgr, ts, "", refLevel, lod, minExts, maxExts);
     if (!status) return (0.0);
 
-    //return (minExts[2]);
+    // Return whichever XY plane is closest to 0 meters (typically MSL)
     return (std::abs(minExts[2]) < std::abs(maxExts[2])) ? minExts[2] : maxExts[2];
 }
 


### PR DESCRIPTION
This fixes #3592 and #2755 by setting our default Z offset for 2D renderers to the whichever XY plane within the domain is closest Z=0.  This puts the location of the 2D renderers at the top of the domain for ocean models, and the bottom of the domain for atmospheric models.