### PR TITLE
Make VAPOR version number more prominent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -638,9 +638,9 @@ workflows:
       #- build_python_api_osx
       #- build_win10_installer
       #- build_macOS_installers
-      - build_appleSilicon_installer
+      #- build_appleSilicon_installer
       #- build_macOSx86_installer
-      #- build_linux_installer
+      - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs
       # - build_macOSx86_libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -638,9 +638,9 @@ workflows:
       #- build_python_api_osx
       #- build_win10_installer
       #- build_macOS_installers
-      #- build_appleSilicon_installer
+      - build_appleSilicon_installer
       #- build_macOSx86_installer
-      - build_linux_installer
+      #- build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs
       # - build_macOSx86_libs

--- a/apps/vaporgui/main.cpp
+++ b/apps/vaporgui/main.cpp
@@ -26,6 +26,7 @@
 #include <QMessageBox>
 #include <QFontDatabase>
 #include "BannerGUI.h"
+#include <vapor/Version.h>
 #include <vapor/CMakeConfig.h>
 #include <vapor/ResourcePath.h>
 #include <vapor/OptionParser.h>
@@ -199,7 +200,10 @@ int           main(int argc, char **argv)
     const char *useFont = std::getenv("USE_SYSTEM_FONT");
     if (!useFont) { mw->setFont(f); }
 
-    mw->setWindowTitle("VAPOR User Interface");
+    string title = "VAPOR" + Version::GetFullVersionString();
+    //mw->setWindowTitle("VAPOR" + Version::GetFullVersionString().c_str());
+    mw->setWindowTitle(title.c_str());
+    //mw->setWindowTitle("VAPOR User Interface");
     mw->show();
     // Disable banner in debug build
 #ifdef NDEBUG

--- a/apps/vaporgui/main.cpp
+++ b/apps/vaporgui/main.cpp
@@ -200,7 +200,7 @@ int           main(int argc, char **argv)
     const char *useFont = std::getenv("USE_SYSTEM_FONT");
     if (!useFont) { mw->setFont(f); }
 
-    string title = "VAPOR " + Version::GetFullVersionString();
+    string title = "VAPOR " + Version::GetVersionString() + " (" + Version::GetBuildHash() + ")";
     mw->setWindowTitle(title.c_str());
     mw->show();
     // Disable banner in debug build

--- a/apps/vaporgui/main.cpp
+++ b/apps/vaporgui/main.cpp
@@ -200,10 +200,8 @@ int           main(int argc, char **argv)
     const char *useFont = std::getenv("USE_SYSTEM_FONT");
     if (!useFont) { mw->setFont(f); }
 
-    string title = "VAPOR" + Version::GetFullVersionString();
-    //mw->setWindowTitle("VAPOR" + Version::GetFullVersionString().c_str());
+    string title = "VAPOR " + Version::GetFullVersionString();
     mw->setWindowTitle(title.c_str());
-    //mw->setWindowTitle("VAPOR User Interface");
     mw->show();
     // Disable banner in debug build
 #ifdef NDEBUG


### PR DESCRIPTION
This fixes #3604 by replacing VAPOR's previous title with VAPOR's version number and commit hash.

![Screen Shot 2024-10-22 at 9 22 40 AM](https://github.com/user-attachments/assets/c35ad5f8-1b5f-4776-a74b-a424775c628a)
