### PR TITLE
Make sha256.txt more readable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -675,7 +675,7 @@ workflows:
              cron: "0 14 * * 6" #Time is GMT
              filters:
                branches:
-                 only: issue3300
+                 only: main
       jobs:
         - build_linux_installer
         - build_appleSilicon_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -675,7 +675,7 @@ workflows:
              cron: "0 14 * * 6" #Time is GMT
              filters:
                branches:
-                 only: main
+                 only: issue3300
       jobs:
         - build_linux_installer
         - build_appleSilicon_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,7 +672,7 @@ workflows:
   weekly:
       triggers:
         - schedule:
-             cron: "30 20 * * 4" #Time is GMT
+             cron: "0 22 * * 4" #Time is GMT
              filters:
                branches:
                  only: issue3300 #main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,7 +672,7 @@ workflows:
   weekly:
       triggers:
         - schedule:
-             cron: "0 18 * * 4" #Time is GMT
+             cron: "30 20 * * 4" #Time is GMT
              filters:
                branches:
                  only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,8 +476,8 @@ jobs:
             winSha=$os$sha$endl
             shaMessage="$title$linuxSha$osxSha$siliconSha$winSha"
             date=`date +"%d_%m_%y"`
-            echo $shaMessage
-            echo $shaMessage > "/tmp/workspace/installers/sha256.txt" 
+            echo "$shaMessage"
+            echo "$shaMessage" > "/tmp/workspace/installers/sha256.txt" 
             echo ghr -b "Weekly installers are untested an may not be stable.  Built with commit ${hash} on ${date} \(DD-MM-YY\)" -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -prerelease -c ${CIRCLE_SHA1} -recreate -c ${hash} -n ${tag} ${tag} /tmp/workspace/installers
             ghr -b "Weekly installers are untested an may not be stable.  Built with commit ${hash} on ${date} \(DD-MM-YY\)" -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -prerelease -c ${CIRCLE_SHA1} -recreate -c ${hash} -n ${tag} ${tag} /tmp/workspace/installers
 
@@ -675,7 +675,7 @@ workflows:
              cron: "30 20 * * 4" #Time is GMT
              filters:
                branches:
-                 only: main
+                 only: issue3300 #main
       jobs:
         - build_linux_installer
         - build_appleSilicon_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,10 +672,10 @@ workflows:
   weekly:
       triggers:
         - schedule:
-             cron: "0 22 * * 4" #Time is GMT
+             cron: "0 22 * * 5" #Time is GMT
              filters:
                branches:
-                 only: issue3300 #main
+                 only: main
       jobs:
         - build_linux_installer
         - build_appleSilicon_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
             make installer
             for f in VAPOR3-* ; do mv "$f" "<<parameters.moveToCommand>>" ; done
             mkdir -p /tmp/workspace/installers
-            find VAPOR* -maxdepth 1 -type f -exec mv {} /tmp/workspace/installers \;
+            find VAPOR* -maxdepth 1 -type f \( -name "*.AppImage" -o -name "*.exe" -o -name "*.dmg" \) -exec mv {} /tmp/workspace/installers \;
             ls /tmp/workspace/installers
           no_output_timeout: 30m
       - store_artifacts:
@@ -672,7 +672,7 @@ workflows:
   weekly:
       triggers:
         - schedule:
-             cron: "0 22 * * 5" #Time is GMT
+             cron: "0 14 * * 6" #Time is GMT
              filters:
                branches:
                  only: main


### PR DESCRIPTION
#3300 was fixed, but the sha256.txt file was missing carriage returns so it wasn't very readable.  The current file for our weekly installer reads as follows:

```
sha 256
AppImage:  19756c66a0bee9205df4c88d5785919b6143278a0f663044ac3689cb8a2e720b  VAPOR-3.10.0-x86_64-w34.AppImage
OSX:       0b215345c6dde25d388f046930b664ce11933de60f170e9784f6cef96d07b51a  VAPOR3-3.10.0-macOSx86-w34.dmg
AppleSilicon:       a7a371c8a61e9df425d24bd3fd176aa5a98fdcbbf320248700d436075d954338  VAPOR3-3.10.0-AppleSilicon-w34.dmg
Windows:   6eba4b27b75a3b8426f2aec6efc58f69c3b3f9881708fa82a450e21d0f5caeeb  VAPOR3-3.10.0-win64-w34.exe
```

