### PR TITLE
Fix Issue3768 - VAPOR freezes after rendering

### DIFF
--- a/apps/vaporgui/AnimationController.cpp
+++ b/apps/vaporgui/AnimationController.cpp
@@ -135,6 +135,7 @@ void AnimationController::setPlay(int direction)
         // Done animating. Disable timer and send notification
         //
         disconnect(_myTimer, 0, 0, 0);
+        _myTimer->stop();
         GUIStateParams* gsp = NavigationUtils::GetGUIStateParams(_controlExec);
     
         string windowName = gsp->GetActiveVizName();

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -984,9 +984,7 @@ bool MainForm::eventFilter(QObject *obj, QEvent *event)
         _paramsWidgetDemo->Update(GetStateParams(), _paramsMgr);
 #endif
 
-        // When _animationCapture==true, we will render from the AnimationController's
-        // AnimationDrawSignal, not a ParamsChangeEvent.
-        if (_animationCapture == false) Render(false,true);
+        Render(true);
 
         return true;
     }

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -886,12 +886,12 @@ void MainForm::_setAnimationOnOff(bool on)
 {
     if (on) {
         enableAnimationWidgets(false);
-        _App->removeEventFilter(this);
+        // _App->removeEventFilter(this);
     } else {
         _playForwardAction->setChecked(false);
         _playBackwardAction->setChecked(false);
         enableAnimationWidgets(true);
-        _App->installEventFilter(this);
+        // _App->installEventFilter(this);
     }
 }
 
@@ -968,7 +968,9 @@ bool MainForm::eventFilter(QObject *obj, QEvent *event)
         updateUI();
         setUpdatesEnabled(true);
 
-        Render(false, true);
+        // When _animationCapture==true, we will render from the AnimationController's
+        // AnimationDrawSignal, not a ParamsChangeEvent.
+        if (_animationCapture == false) Render(false,true);        
 
         QApplication::restoreOverrideCursor();
         return true;
@@ -982,7 +984,9 @@ bool MainForm::eventFilter(QObject *obj, QEvent *event)
         _paramsWidgetDemo->Update(GetStateParams(), _paramsMgr);
 #endif
 
-        Render(true);
+        // When _animationCapture==true, we will render from the AnimationController's
+        // AnimationDrawSignal, not a ParamsChangeEvent.
+        if (_animationCapture == false) Render(false,true);
 
         return true;
     }


### PR DESCRIPTION
Calling install/removeEventFilter when turning animation on or off was leaving the GUI in an unresponsive state.  This was recently done to prevent Render() from being called multiple times during an animation (#3744).  I've removed this logic and am only making a Render() call in a ParamsChangeEvent when animation is turned off.  Render() now gets issued during an AnimationDrawSignal emission during animation, not through the eventFilter.

The AnimationController's timer is also stopped when animation is complete.  Previously, it was issuing timer events to the application when not being used.