### PR TITLE
Issue3778 - Separate MainForm from LeftPanel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,8 +653,8 @@ workflows:
       #- build_python_api_osx
       - build_win10_installer
       # - build_macOS_installers
-      # - build_appleSilicon_installer
-      # - build_macOSx86_installer
+      - build_appleSilicon_installer
+      - build_macOSx86_installer
       - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,8 +653,8 @@ workflows:
       #- build_python_api_osx
       - build_win10_installer
       # - build_macOS_installers
-      - build_appleSilicon_installer
-      - build_macOSx86_installer
+      # - build_appleSilicon_installer
+      # - build_macOSx86_installer
       - build_linux_installer
       #- build_suse_installer
       #- build_ubuntu20_libs

--- a/apps/vaporgui/AnimationController.cpp
+++ b/apps/vaporgui/AnimationController.cpp
@@ -5,8 +5,6 @@
 #include <vapor/NavigationUtils.h>
 
 #include <QAction>
-#include <QFileDialog>
-#include <QDir>
 
 using namespace VAPoR;
 

--- a/apps/vaporgui/AnimationController.cpp
+++ b/apps/vaporgui/AnimationController.cpp
@@ -5,6 +5,8 @@
 #include <vapor/NavigationUtils.h>
 
 #include <QAction>
+#include <QFileDialog>
+#include <QDir>
 
 using namespace VAPoR;
 

--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -277,6 +277,8 @@ set (SRCS
     AnimationController.h
     CaptureController.cpp
     CaptureController.h
+    DatasetImporter.cpp
+    DatasetImporter.h
     CheckForNotices.cpp
     CheckForNotices.h
     NoticeBoard.cpp

--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -275,6 +275,8 @@ set (SRCS
     PTotalTimestepsDisplay.h
     AnimationController.cpp
     AnimationController.h
+    CaptureController.cpp
+    CaptureController.h
     CheckForNotices.cpp
     CheckForNotices.h
     NoticeBoard.cpp

--- a/apps/vaporgui/CMakeLists.txt
+++ b/apps/vaporgui/CMakeLists.txt
@@ -279,6 +279,7 @@ set (SRCS
     CaptureController.h
     DatasetImporter.cpp
     DatasetImporter.h
+    DatasetExistsAction.h
     CheckForNotices.cpp
     CheckForNotices.h
     NoticeBoard.cpp

--- a/apps/vaporgui/CaptureController.cpp
+++ b/apps/vaporgui/CaptureController.cpp
@@ -13,8 +13,9 @@
 #include <QFileDialog>
 
 #include <sstream>
+#include <iomanip>
 
-CaptureController::CaptureController(VAPoR::ControlExec *ce) : _ce(ce), _pm(_ce->GetParamsMgr()) {}
+CaptureController::CaptureController(VAPoR::ControlExec *ce) : _ce(ce) {}
 
 bool CaptureController::EnableAnimationCapture(std::string filePath) {
     if (filePath.empty()) {
@@ -22,8 +23,9 @@ bool CaptureController::EnableAnimationCapture(std::string filePath) {
         if (filePath.empty()) return false;
     }
 
-    GUIStateParams *p = (GUIStateParams*)_pm->GetParams(GUIStateParams::GetClassType());
-    string          vizName = p->GetActiveVizName();
+    //GUIStateParams *p = (GUIStateParams*)_pm->GetParams(GUIStateParams::GetClassType());
+    GUIStateParams* gsp = _ce->GetParams<GUIStateParams>();
+    string vizName = gsp->GetActiveVizName();
     int rc = _ce->EnableAnimationCapture(vizName, true, filePath);
 
     if (rc < 0) {
@@ -37,7 +39,7 @@ void CaptureController::CaptureSingleImage() {
     std::string filePath = _getFileName();
     if (filePath.empty()) return;
 
-    GUIStateParams *gsp = (GUIStateParams*)_pm->GetParams(GUIStateParams::GetClassType());
+    GUIStateParams *gsp = gsp = _ce->GetParams<GUIStateParams>();
     int rc = _ce->EnableImageCapture(filePath, gsp->GetActiveVizName());
     if (rc < 0) MSG_ERR("Error capturing image");
 }
@@ -56,7 +58,7 @@ void CaptureController::EndAnimationCapture() const {
     //if (vizName != _capturingAnimationVizName) { MSG_WARN("Terminating capture in non-active visualizer"); }
     //if (_controlExec->EnableAnimationCapture(_capturingAnimationVizName, false)) MSG_WARN("Image Capture Warning;\nCurrent active visualizer is not capturing images");
     
-    GUIStateParams *gsp = (GUIStateParams*)_pm->GetParams(GUIStateParams::GetClassType());
+    GUIStateParams *gsp = gsp = _ce->GetParams<GUIStateParams>();
     string vizName = gsp->GetActiveVizName();
     if (_ce->EnableAnimationCapture(vizName, false)) MSG_WARN("Image Capture Warning;\nCurrent active visualizer is not capturing images");
 }
@@ -65,7 +67,8 @@ std::string CaptureController::_getFileName() {
     _showCitationReminder();
 
     std::string filter, defaultSuffix;
-    AnimationParams* ap = (AnimationParams*)_pm->GetParams(AnimationParams::GetClassType());
+    //AnimationParams* ap = (AnimationParams*)_pm->GetParams(AnimationParams::GetClassType());
+    AnimationParams* ap = _ce->GetParams<AnimationParams>();
     if (ap->GetValueLong(AnimationParams::CaptureTypeTag, 0) == 0) { // .tiff
          filter = "TIFF (*.tif)";
          defaultSuffix =  "tif";

--- a/apps/vaporgui/CaptureController.cpp
+++ b/apps/vaporgui/CaptureController.cpp
@@ -15,11 +15,14 @@
 #include <sstream>
 #include <iomanip>
 
-CaptureController::CaptureController(VAPoR::ControlExec *ce) : _ce(ce) {}
+CaptureController::CaptureController(VAPoR::ControlExec *ce) : _ce(ce) {
+    std::cout << "nullptr? " << (_ce==nullptr) << std::endl;
+}
 
 bool CaptureController::EnableAnimationCapture(std::string filePath) {
     if (filePath.empty()) {
         filePath = _getFileName();
+        std::cout << "nullptr2? " << (_ce==nullptr) << std::endl;
         if (filePath.empty()) return false;
     }
 
@@ -67,7 +70,8 @@ std::string CaptureController::_getFileName() {
     _showCitationReminder();
 
     std::string filter, defaultSuffix;
-    //AnimationParams* ap = (AnimationParams*)_pm->GetParams(AnimationParams::GetClassType());
+    //AnimationParams* ap = (AnimationParams*)_ce->GetParamsMgr()->GetParams(AnimationParams::GetClassType());
+    std::cout << "nullptr3? " << (_ce==nullptr) << std::endl;
     AnimationParams* ap = _ce->GetParams<AnimationParams>();
     if (ap->GetValueLong(AnimationParams::CaptureTypeTag, 0) == 0) { // .tiff
          filter = "TIFF (*.tif)";

--- a/apps/vaporgui/CaptureController.cpp
+++ b/apps/vaporgui/CaptureController.cpp
@@ -1,0 +1,140 @@
+#include "CaptureController.h"
+#include "CitationReminder.h"
+#include "ErrorReporter.h"
+
+#include "vapor/ControlExecutive.h"
+#include "vapor/AnimationParams.h"
+#include "vapor/GUIStateParams.h"
+#include "vapor/FileUtils.h"
+#include "vapor/STLUtils.h"
+
+#include <QFileInfo>
+#include <QMessageBox>
+#include <QFileDialog>
+
+#include <sstream>
+
+CaptureController::CaptureController(VAPoR::ControlExec *ce) : _ce(ce), _pm(_ce->GetParamsMgr()) {}
+
+bool CaptureController::EnableAnimationCapture(std::string filePath) {
+    if (filePath.empty()) {
+        filePath = _getFileName();
+        if (filePath.empty()) return false;
+    }
+
+    GUIStateParams *p = (GUIStateParams*)_pm->GetParams(GUIStateParams::GetClassType());
+    string          vizName = p->GetActiveVizName();
+    int rc = _ce->EnableAnimationCapture(vizName, true, filePath);
+
+    if (rc < 0) {
+        MSG_ERR("Error capturing image");
+        return false;
+    }
+    return true;
+}
+
+void CaptureController::CaptureSingleImage() {
+    std::string filePath = _getFileName();
+    if (filePath.empty()) return;
+
+    GUIStateParams *gsp = (GUIStateParams*)_pm->GetParams(GUIStateParams::GetClassType());
+    int rc = _ce->EnableImageCapture(filePath, gsp->GetActiveVizName());
+    if (rc < 0) MSG_ERR("Error capturing image");
+}
+
+// Signal AnimationController to start through connection in MainForm
+void CaptureController::StartAnimationCapture() const {
+    emit animationCaptureStarted(); 
+}
+
+void CaptureController::EndAnimationCapture() const {
+    //// Turn off capture mode for the current active visualizer (if it is on!)
+    //if (_capturingAnimationVizName.empty()) return;
+    //GUIStateParams *p = GetStateParams();
+    //GUIStateParams *gsp = (GUIStateParams*)_pm->GetParams(GUIStateParams::GetClassType());
+    //string          vizName = gsp->GetActiveVizName();
+    //if (vizName != _capturingAnimationVizName) { MSG_WARN("Terminating capture in non-active visualizer"); }
+    //if (_controlExec->EnableAnimationCapture(_capturingAnimationVizName, false)) MSG_WARN("Image Capture Warning;\nCurrent active visualizer is not capturing images");
+    
+    GUIStateParams *gsp = (GUIStateParams*)_pm->GetParams(GUIStateParams::GetClassType());
+    string vizName = gsp->GetActiveVizName();
+    if (_ce->EnableAnimationCapture(vizName, false)) MSG_WARN("Image Capture Warning;\nCurrent active visualizer is not capturing images");
+}
+
+std::string CaptureController::_getFileName() {
+    _showCitationReminder();
+
+    std::string filter, defaultSuffix;
+    AnimationParams* ap = (AnimationParams*)_pm->GetParams(AnimationParams::GetClassType());
+    if (ap->GetValueLong(AnimationParams::CaptureTypeTag, 0) == 0) { // .tiff
+         filter = "TIFF (*.tif)";
+         defaultSuffix =  "tif";
+    }
+    else {                                                           // .png
+         filter = "PNG (*.png)";
+         defaultSuffix = "png";
+    }
+
+    // DontConfirmOverwrite because we do this manually after modifying the user's input
+    // in the case of capturing time series.  DontUseNativeDialog becuase DontConfirmOverwrite will
+    // not work on MacOS without it.
+    std::string defaultPath = ap->GetValueString(AnimationParams::CaptureFileDirTag, FileUtils::HomeDir());
+    std::string fileName = QFileDialog::getSaveFileName(
+        nullptr, 
+        "Select Filename", 
+        QString::fromStdString(defaultPath), 
+        QString::fromStdString(filter),
+        nullptr,
+        (QFileDialog::DontConfirmOverwrite | QFileDialog::DontUseNativeDialog)
+        ).toStdString();
+    if (fileName.empty()) return "";
+
+    // Qt does not always append the filetype to the selection from the QFileDialog, so manually add it if this happens
+    if (fileName.find(defaultSuffix) == std::string::npos) fileName = fileName + "." + defaultSuffix;
+
+    // Add zero padding if we are capturing TimeSeries
+    auto captureMode = ap->GetValueLong(AnimationParams::CaptureModeTag, AnimationParams::SingleImage);
+    if (captureMode == AnimationParams::TimeSeries) {
+        std::ostringstream oss;
+        oss << FileUtils::RemoveExtension(FileUtils::Basename(fileName));
+        oss << std::setw(5) << std::setfill('0');
+        oss << "." << FileUtils::Extension(fileName);
+        fileName = FileUtils::JoinPaths({FileUtils::Dirname(fileName), oss.str()});
+    }
+
+    // Warn user about overwriting file
+    if (FileUtils::Exists(fileName)) {
+        QMessageBox::StandardButton overwrite;
+        overwrite = QMessageBox::question(
+            nullptr,
+            "File exists",
+            QString::fromStdString(FileUtils::Basename(fileName) + " exists.\nDo you want to overwrite?"),
+            QMessageBox::Yes | QMessageBox::No
+        );
+        if (overwrite == QMessageBox::No) return "";
+    }
+
+    ap->SetValueString(AnimationParams::CaptureFileDirTag, "Capture animation file directory", FileUtils::Dirname(fileName));
+
+    if (captureMode == AnimationParams::SingleImage) {
+        ap->SetValueString(AnimationParams::CaptureFileNameTag, "Capture animation file name", FileUtils::Basename(fileName));
+        ap->SetValueString(AnimationParams::CaptureFileTimeTag, "Capture file time", STLUtils::GetCurrentDateTimestamp());
+    }
+    else {
+        ap->SetValueString(AnimationParams::CaptureTimeSeriesFileNameTag, "Capture animation file name", FileUtils::Basename(fileName));
+        ap->SetValueString(AnimationParams::CaptureTimeSeriesTimeTag, "Capture file time", STLUtils::GetCurrentDateTimestamp());
+    }
+
+    return fileName;
+}
+
+void CaptureController::_showCitationReminder() {
+    // Disable citation reminder in Debug build
+#ifndef NDEBUG
+    return;
+#endif
+    if (!_askForCitation) return;
+    _askForCitation = false;
+    CitationReminder::Show();
+}
+

--- a/apps/vaporgui/CaptureController.cpp
+++ b/apps/vaporgui/CaptureController.cpp
@@ -15,9 +15,7 @@
 #include <sstream>
 #include <iomanip>
 
-CaptureController::CaptureController(VAPoR::ControlExec *ce) : _ce(ce) {
-    std::cout << "nullptr? " << (_ce==nullptr) << std::endl;
-}
+CaptureController::CaptureController(VAPoR::ControlExec *ce) : _ce(ce) {}
 
 bool CaptureController::EnableAnimationCapture(std::string filePath) {
     if (filePath.empty()) {
@@ -26,7 +24,6 @@ bool CaptureController::EnableAnimationCapture(std::string filePath) {
         if (filePath.empty()) return false;
     }
 
-    //GUIStateParams *p = (GUIStateParams*)_pm->GetParams(GUIStateParams::GetClassType());
     GUIStateParams* gsp = _ce->GetParams<GUIStateParams>();
     string vizName = gsp->GetActiveVizName();
     int rc = _ce->EnableAnimationCapture(vizName, true, filePath);
@@ -70,21 +67,21 @@ std::string CaptureController::_getFileName() {
     _showCitationReminder();
 
     std::string filter, defaultSuffix;
-    //AnimationParams* ap = (AnimationParams*)_ce->GetParamsMgr()->GetParams(AnimationParams::GetClassType());
-    std::cout << "nullptr3? " << (_ce==nullptr) << std::endl;
     AnimationParams* ap = _ce->GetParams<AnimationParams>();
-    if (ap->GetValueLong(AnimationParams::CaptureTypeTag, 0) == 0) { // .tiff
+    if (ap->GetValueLong(AnimationParams::CaptureTypeTag, 0) == 0) {
          filter = "TIFF (*.tif)";
          defaultSuffix =  "tif";
     }
-    else {                                                           // .png
+    else {
          filter = "PNG (*.png)";
          defaultSuffix = "png";
     }
 
-    // DontConfirmOverwrite because we do this manually after modifying the user's input
-    // in the case of capturing time series.  DontUseNativeDialog becuase DontConfirmOverwrite will
-    // not work on MacOS without it.
+    // - For this QFileDialog, QFileDialog::DontConfirmOverwrite is needed because we do file overwrite confirmation 
+    //   manually after modifying the user's input filename for capturing time series
+    // 
+    // - QFileDialog::DontUseNativeDialog is needed becuase QFileDialog::DontConfirmOverwrite will not work on MacOS without it
+    //
     std::string defaultPath = ap->GetValueString(AnimationParams::CaptureFileDirTag, FileUtils::HomeDir());
     std::string fileName = QFileDialog::getSaveFileName(
         nullptr, 

--- a/apps/vaporgui/CaptureController.h
+++ b/apps/vaporgui/CaptureController.h
@@ -3,9 +3,10 @@
 #include <QObject>
 
 class AnimationParams;
+
 namespace VAPoR {
-class ControlExec;
-class ParamsMgr;
+    class ControlExec;
+    class ParamsMgr;
 }
 
 //! \class CaptureController

--- a/apps/vaporgui/CaptureController.h
+++ b/apps/vaporgui/CaptureController.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QTimer>
-#include <glm/fwd.hpp>
+#include <QObject>
 
 class AnimationParams;
 namespace VAPoR {
@@ -16,7 +15,6 @@ class ParamsMgr;
 class CaptureController : public QObject {
     Q_OBJECT
     VAPoR::ControlExec *_ce;
-    VAPoR::ParamsMgr   *_pm;
 
     void _showCitationReminder();
     std::string _getFileName();

--- a/apps/vaporgui/CaptureController.h
+++ b/apps/vaporgui/CaptureController.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QTimer>
+#include <glm/fwd.hpp>
+
+class AnimationParams;
+namespace VAPoR {
+class ControlExec;
+class ParamsMgr;
+}
+
+//! \class CaptureController
+//! \brief Decouples image capture logic that was previously in MainForm so it can be
+//! performed outside of the MainForm
+
+class CaptureController : public QObject {
+    Q_OBJECT
+    VAPoR::ControlExec *_ce;
+    VAPoR::ParamsMgr   *_pm;
+
+    void _showCitationReminder();
+    std::string _getFileName();
+
+    bool _askForCitation = true;
+
+public:
+    CaptureController(VAPoR::ControlExec *ce);
+    void CaptureSingleImage();
+    bool EnableAnimationCapture(std::string baseFile = "");
+    void StartAnimationCapture() const;
+    void EndAnimationCapture() const;
+
+signals:
+    void animationCaptureStarted() const;
+};

--- a/apps/vaporgui/DatasetExistsAction.h
+++ b/apps/vaporgui/DatasetExistsAction.h
@@ -1,0 +1,3 @@
+#pragma once
+
+enum class DatasetExistsAction {Prompt, AddNew, ReplaceFirst};

--- a/apps/vaporgui/DatasetImporter.cpp
+++ b/apps/vaporgui/DatasetImporter.cpp
@@ -1,0 +1,149 @@
+#include "DatasetImporter.h"
+#include "ErrorReporter.h"
+#include "DatasetTypeLookup.h"
+
+#include "vapor/ControlExecutive.h"
+#include "vapor/DataStatus.h"
+#include "vapor/GUIStateParams.h"
+#include "vapor/AnimationParams.h"
+#include "vapor/SettingsParams.h"
+#include "vapor/NavigationUtils.h"
+#include "vapor/FileUtils.h"
+
+#include <QFileInfo>
+#include <QFileDialog>
+#include <QInputDialog>
+
+DatasetImporter::DatasetImporter(VAPoR::ControlExec *ce) : _ce(ce), _pm(_ce->GetParamsMgr()) {}
+
+void DatasetImporter::ImportDataset(const std::vector<string> &files, string format, DatasetExistsAction existsAction, string name) {
+    _pm->BeginSaveStateGroup("Import Dataset");
+    //if (name.empty()) name = _getDataSetName(files[0], existsAction);
+    int rc = _ce->OpenData(files, name, format);
+    if (rc < 0) {
+        _pm->EndSaveStateGroup();
+        MSG_ERR("Failed to load data");
+        return;
+    }
+
+    auto gsp = _ce->GetParams<GUIStateParams>();
+    gsp->InsertOpenDataSet(name, format, files);
+
+    VAPoR::DataStatus *ds = _ce->GetDataStatus();
+    AnimationParams* ap = (AnimationParams*)_pm->GetParams(AnimationParams::GetClassType());
+    ap->SetEndTimestep(ds->GetTimeCoordinates().size() - 1);
+
+    //if (_sessionNewFlag) {
+        NavigationUtils::ViewAll(_ce);
+        NavigationUtils::SetHomeViewpoint(_ce);
+        gsp->SetProjectionString(ds->GetMapProjection());
+    //}
+
+    //_sessionNewFlag = false;
+    _pm->EndSaveStateGroup();
+
+    //_leftPanel->GoToRendererTab();
+}
+
+void DatasetImporter::showImportDatasetGUI(string format) {
+    static vector<pair<string, string>> prompts = GetDatasets();
+
+    string defaultPath;
+    GUIStateParams *gsp = _ce->GetParams<GUIStateParams>();
+    auto openDatasets = gsp->GetOpenDataSetNames();
+    if (!openDatasets.empty())
+        defaultPath = gsp->GetOpenDataSetPaths(openDatasets.back())[0];
+    else
+        defaultPath = _ce->GetParams<SettingsParams>()->GetMetadataDir();
+        //defaultPath = GetSettingsParams()->GetMetadataDir();
+
+    auto files = _getUserFileSelection(DatasetTypeDescriptiveName(format), defaultPath, "", format!="vdc");
+    if (files.empty()) return;
+
+    ImportDataset(files, format, DatasetExistsAction::Prompt);
+}
+
+std::vector<std::string> DatasetImporter::_getUserFileSelection(std::string prompt, std::string dir, std::string filter, bool multi) {
+    QString qPrompt(prompt.c_str());
+    QString qDir(dir.c_str());
+    QString qFilter(filter.c_str());
+
+    vector<string> files;
+    if (multi) {
+        QStringList           fileNames = QFileDialog::getOpenFileNames(nullptr, qPrompt, qDir, qFilter);
+        QStringList           list = fileNames;
+        QStringList::Iterator it = list.begin();
+        while (it != list.end()) {
+            if (!it->isNull()) {
+                if (checkQStringContainsNonASCIICharacter(*it) < 0)
+                    return {};
+                files.push_back((*it).toStdString());
+            }
+            ++it;
+        }
+    } else {
+        QString fileName = QFileDialog::getOpenFileName(nullptr, qPrompt, qDir, qFilter);
+        if (!fileName.isNull()) {
+            if (checkQStringContainsNonASCIICharacter(fileName) < 0)
+                return {};
+            files.push_back(fileName.toStdString());
+        }
+    }
+
+    for (int i = 0; i < files.size(); i++) {
+        QFileInfo fInfo(files[i].c_str());
+        if (!fInfo.isReadable() || !fInfo.isFile()) {
+            MyBase::SetErrMsg("File %s not readable", files[i].c_str());
+            MSG_ERR("Invalid file selection");
+            return {};
+        }
+    }
+    return (files);
+}
+
+string DatasetImporter::_getDataSetName(string file, DatasetExistsAction existsAction) {
+    vector<string> names = _pm->GetDataMgrNames();
+    //if (names.empty() || existsAction == AddNew)
+    //    return ControlExec::MakeStringConformant(FileUtils::Basename(file));
+    //else if (existsAction == ReplaceFirst)
+    //    return names[0];
+
+    string newSession = "New Dataset";
+
+    QStringList items;
+    items << tr(newSession.c_str());
+    for (int i = 0; i < names.size(); i++)
+        items << tr(names[i].c_str());
+
+    bool    ok;
+    QString item = QInputDialog::getItem(nullptr, tr("Load Data"), tr("Load as new dataset or replace existing"), items, 0, false, &ok);
+    if (!ok || item.isEmpty())
+        return "";
+
+    string dataSetName = item.toStdString();
+
+    if (dataSetName == newSession)
+        dataSetName = ControlExec::MakeStringConformant(FileUtils::Basename(file));
+
+    return dataSetName;
+}
+
+int DatasetImporter::checkQStringContainsNonASCIICharacter(const QString &s)
+{
+    if (doesQStringContainNonASCIICharacter(s)) {
+#ifdef WIN32
+        MyBase::SetErrMsg("Windows will convert a colon (common in WRF timestamps) to a non-ASCII dot character. This needs to be renamed.\n");
+#endif
+        MyBase::SetErrMsg("Vapor does not support paths with non-ASCII characters.\n");
+        MSG_ERR("Non ASCII Character in path");
+        return -1;
+    }
+    return 0;
+}
+
+bool DatasetImporter::doesQStringContainNonASCIICharacter(const QString &s)
+{
+    for (int i = 0; i < s.length(); i++)
+        if (s.at(i).unicode() > 127) return true;
+    return false;
+}

--- a/apps/vaporgui/DatasetImporter.cpp
+++ b/apps/vaporgui/DatasetImporter.cpp
@@ -16,14 +16,16 @@
 
 DatasetImporter::DatasetImporter(VAPoR::ControlExec *ce) : _ce(ce), _pm(_ce->GetParamsMgr()) {}
 
-void DatasetImporter::ImportDataset(const std::vector<string> &files, string format, DatasetExistsAction existsAction, string name) {
+bool DatasetImporter::ImportDataset(const std::vector<string> &files, string format, DatasetExistsAction existsAction, string name) {
+    std::cout << "DatasetImporter::ImportDataset" << std::endl;
     _pm->BeginSaveStateGroup("Import Dataset");
-    //if (name.empty()) name = _getDataSetName(files[0], existsAction);
+    if (name.empty()) name = _getDataSetName(files[0], existsAction);
     int rc = _ce->OpenData(files, name, format);
     if (rc < 0) {
         _pm->EndSaveStateGroup();
         MSG_ERR("Failed to load data");
-        return;
+        std::cout << "failed" << std::endl;
+        return false;
     }
 
     auto gsp = _ce->GetParams<GUIStateParams>();
@@ -33,80 +35,31 @@ void DatasetImporter::ImportDataset(const std::vector<string> &files, string for
     AnimationParams* ap = (AnimationParams*)_pm->GetParams(AnimationParams::GetClassType());
     ap->SetEndTimestep(ds->GetTimeCoordinates().size() - 1);
 
-    //if (_sessionNewFlag) {
+    if (_sessionNewFlag) {
         NavigationUtils::ViewAll(_ce);
         NavigationUtils::SetHomeViewpoint(_ce);
         gsp->SetProjectionString(ds->GetMapProjection());
-    //}
+    }
 
-    //_sessionNewFlag = false;
     _pm->EndSaveStateGroup();
 
-    //_leftPanel->GoToRendererTab();
+    std::cout << "name, format, files " << name << " " << format << " " << files.size() << std::endl;
+    emit datasetImported();
+    std::cout << "emitted" << std::endl;
+
+    return true;
 }
 
-void DatasetImporter::showImportDatasetGUI(string format) {
-    static vector<pair<string, string>> prompts = GetDatasets();
-
-    string defaultPath;
-    GUIStateParams *gsp = _ce->GetParams<GUIStateParams>();
-    auto openDatasets = gsp->GetOpenDataSetNames();
-    if (!openDatasets.empty())
-        defaultPath = gsp->GetOpenDataSetPaths(openDatasets.back())[0];
-    else
-        defaultPath = _ce->GetParams<SettingsParams>()->GetMetadataDir();
-        //defaultPath = GetSettingsParams()->GetMetadataDir();
-
-    auto files = _getUserFileSelection(DatasetTypeDescriptiveName(format), defaultPath, "", format!="vdc");
-    if (files.empty()) return;
-
-    ImportDataset(files, format, DatasetExistsAction::Prompt);
-}
-
-std::vector<std::string> DatasetImporter::_getUserFileSelection(std::string prompt, std::string dir, std::string filter, bool multi) {
-    QString qPrompt(prompt.c_str());
-    QString qDir(dir.c_str());
-    QString qFilter(filter.c_str());
-
-    vector<string> files;
-    if (multi) {
-        QStringList           fileNames = QFileDialog::getOpenFileNames(nullptr, qPrompt, qDir, qFilter);
-        QStringList           list = fileNames;
-        QStringList::Iterator it = list.begin();
-        while (it != list.end()) {
-            if (!it->isNull()) {
-                if (checkQStringContainsNonASCIICharacter(*it) < 0)
-                    return {};
-                files.push_back((*it).toStdString());
-            }
-            ++it;
-        }
-    } else {
-        QString fileName = QFileDialog::getOpenFileName(nullptr, qPrompt, qDir, qFilter);
-        if (!fileName.isNull()) {
-            if (checkQStringContainsNonASCIICharacter(fileName) < 0)
-                return {};
-            files.push_back(fileName.toStdString());
-        }
-    }
-
-    for (int i = 0; i < files.size(); i++) {
-        QFileInfo fInfo(files[i].c_str());
-        if (!fInfo.isReadable() || !fInfo.isFile()) {
-            MyBase::SetErrMsg("File %s not readable", files[i].c_str());
-            MSG_ERR("Invalid file selection");
-            return {};
-        }
-    }
-    return (files);
-}
+void DatasetImporter::SetSessionNewFlag(bool flag) { 
+    _sessionNewFlag = flag; 
+};
 
 string DatasetImporter::_getDataSetName(string file, DatasetExistsAction existsAction) {
     vector<string> names = _pm->GetDataMgrNames();
-    //if (names.empty() || existsAction == AddNew)
-    //    return ControlExec::MakeStringConformant(FileUtils::Basename(file));
-    //else if (existsAction == ReplaceFirst)
-    //    return names[0];
+    if (names.empty() || existsAction == DatasetExistsAction::AddNew)
+        return ControlExec::MakeStringConformant(FileUtils::Basename(file));
+    else if (existsAction == DatasetExistsAction::ReplaceFirst)
+        return names[0];
 
     string newSession = "New Dataset";
 
@@ -125,25 +78,6 @@ string DatasetImporter::_getDataSetName(string file, DatasetExistsAction existsA
     if (dataSetName == newSession)
         dataSetName = ControlExec::MakeStringConformant(FileUtils::Basename(file));
 
+    std::cout << "datasetName " << dataSetName << std::endl;
     return dataSetName;
-}
-
-int DatasetImporter::checkQStringContainsNonASCIICharacter(const QString &s)
-{
-    if (doesQStringContainNonASCIICharacter(s)) {
-#ifdef WIN32
-        MyBase::SetErrMsg("Windows will convert a colon (common in WRF timestamps) to a non-ASCII dot character. This needs to be renamed.\n");
-#endif
-        MyBase::SetErrMsg("Vapor does not support paths with non-ASCII characters.\n");
-        MSG_ERR("Non ASCII Character in path");
-        return -1;
-    }
-    return 0;
-}
-
-bool DatasetImporter::doesQStringContainNonASCIICharacter(const QString &s)
-{
-    for (int i = 0; i < s.length(); i++)
-        if (s.at(i).unicode() > 127) return true;
-    return false;
 }

--- a/apps/vaporgui/DatasetImporter.h
+++ b/apps/vaporgui/DatasetImporter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "DatasetExistsAction.h"
 #include <QObject>
 
 namespace VAPoR {
@@ -15,18 +16,20 @@ class DatasetImporter : public QObject {
     Q_OBJECT
     VAPoR::ControlExec *_ce;
     VAPoR::ParamsMgr   *_pm;
+    bool _sessionNewFlag = true;
 
-    enum DatasetExistsAction { Prompt, AddNew, ReplaceFirst };
-
-    void showImportDatasetGUI(std::string format);
     std::string _getDataSetName(std::string file, DatasetExistsAction existsAction);
-    std::vector<std::string> _getUserFileSelection(std::string prompt, std::string dir, std::string filter, bool multi);
-    int checkQStringContainsNonASCIICharacter(const QString &s);
-    bool doesQStringContainNonASCIICharacter(const QString &s);
 
 public:
     DatasetImporter(VAPoR::ControlExec *ce);
-    void ImportDataset(const std::vector<std::string> &files, std::string format, DatasetExistsAction existsAction, std::string name = "");
+    bool ImportDataset(
+        const std::vector<std::string> &files, 
+        std::string format, 
+        DatasetExistsAction existsAction = DatasetExistsAction::Prompt, 
+        std::string name = ""
+    );
+    void SetSessionNewFlag(bool flag);
 
 signals:
+    void datasetImported();
 };

--- a/apps/vaporgui/DatasetImporter.h
+++ b/apps/vaporgui/DatasetImporter.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QObject>
+
+namespace VAPoR {
+class ControlExec;
+class ParamsMgr;
+}
+
+//! \class DatasetImporter
+//! \brief Decouples dataset import logic that was previously in MainForm so it can be
+//! performed outside of the MainForm
+
+class DatasetImporter : public QObject {
+    Q_OBJECT
+    VAPoR::ControlExec *_ce;
+    VAPoR::ParamsMgr   *_pm;
+
+    enum DatasetExistsAction { Prompt, AddNew, ReplaceFirst };
+
+    void showImportDatasetGUI(std::string format);
+    std::string _getDataSetName(std::string file, DatasetExistsAction existsAction);
+    std::vector<std::string> _getUserFileSelection(std::string prompt, std::string dir, std::string filter, bool multi);
+    int checkQStringContainsNonASCIICharacter(const QString &s);
+    bool doesQStringContainNonASCIICharacter(const QString &s);
+
+public:
+    DatasetImporter(VAPoR::ControlExec *ce);
+    void ImportDataset(const std::vector<std::string> &files, std::string format, DatasetExistsAction existsAction, std::string name = "");
+
+signals:
+};

--- a/apps/vaporgui/ExportTab.cpp
+++ b/apps/vaporgui/ExportTab.cpp
@@ -12,10 +12,10 @@
 #include <vapor/AnimationParams.h>
 #include <QLayout>
 
-ExportTab::ExportTab(ControlExec *ce, CaptureController *cc, MainForm *mf) : _ce(ce)
+ExportTab::ExportTab(ControlExec *ce, CaptureController *cc) : _ce(ce)
 {
     _pg = new PGroup({
-        new PCaptureWidget(_ce, cc, mf),
+        new PCaptureWidget(_ce, cc),
         new POutputResolutionSection(_ce),
         new PCameraControlsSection(_ce),
         _movingDomainSection = new PMovingDomainSettings(_ce),

--- a/apps/vaporgui/ExportTab.cpp
+++ b/apps/vaporgui/ExportTab.cpp
@@ -1,4 +1,5 @@
 #include "ExportTab.h"
+#include "CaptureController.h"
 #include "PCheckbox.h"
 #include "PIntegerInput.h"
 #include "PSliderEdit.h"
@@ -11,10 +12,10 @@
 #include <vapor/AnimationParams.h>
 #include <QLayout>
 
-ExportTab::ExportTab(ControlExec *ce, MainForm *mf) : _ce(ce)
+ExportTab::ExportTab(ControlExec *ce, CaptureController *cc, MainForm *mf) : _ce(ce)
 {
     _pg = new PGroup({
-        new PCaptureWidget(_ce, mf),
+        new PCaptureWidget(_ce, cc, mf),
         new POutputResolutionSection(_ce),
         new PCameraControlsSection(_ce),
         _movingDomainSection = new PMovingDomainSettings(_ce),

--- a/apps/vaporgui/ExportTab.h
+++ b/apps/vaporgui/ExportTab.h
@@ -6,6 +6,7 @@
 #include "VGroup.h"
 
 class MainForm;
+class CaptureController;
 
 class ExportTab : public VGroup, public Updatable {
     Q_OBJECT
@@ -15,6 +16,6 @@ class ExportTab : public VGroup, public Updatable {
     PWidget *_movingDomainSection = nullptr;
 
 public:
-    ExportTab(VAPoR::ControlExec *ce, MainForm *mf);
+    ExportTab(VAPoR::ControlExec *ce, CaptureController *cc, MainForm *mf);
     void Update() override;
 };

--- a/apps/vaporgui/ExportTab.h
+++ b/apps/vaporgui/ExportTab.h
@@ -5,7 +5,6 @@
 #include "Updatable.h"
 #include "VGroup.h"
 
-class MainForm;
 class CaptureController;
 
 class ExportTab : public VGroup, public Updatable {
@@ -16,6 +15,6 @@ class ExportTab : public VGroup, public Updatable {
     PWidget *_movingDomainSection = nullptr;
 
 public:
-    ExportTab(VAPoR::ControlExec *ce, CaptureController *cc, MainForm *mf);
+    ExportTab(VAPoR::ControlExec *ce, CaptureController *cc);
     void Update() override;
 };

--- a/apps/vaporgui/ImportTab.cpp
+++ b/apps/vaporgui/ImportTab.cpp
@@ -3,7 +3,7 @@
 #include "PProjectionStringWidget.h"
 #include "VHyperlink.h"
 #include "VSection.h"
-#include "MainForm.h"
+#include "DatasetImporter.h"
 
 #include <vapor/GUIStateParams.h>
 #include <vapor/ControlExecutive.h>
@@ -11,12 +11,12 @@
 
 using namespace VAPoR;
 
-ImportTab::ImportTab(VAPoR::ControlExec *ce, MainForm *mf) : _ce(ce)
+ImportTab::ImportTab(VAPoR::ControlExec *ce, DatasetImporter *di) : _ce(ce)
 {
     QVBoxLayout *l = new QVBoxLayout;
     l->setContentsMargins(0, 0, 0, 0);
 
-    l->addWidget(new VSectionGroup("Import Data", {_importer = new PImportDataWidget(_ce, mf)}));
+    l->addWidget(new VSectionGroup("Import Data", {_importer = new PImportDataWidget(_ce, di)}));
 
     VSectionGroup *sg = new VSectionGroup("Tips", {
         new VHyperlink(

--- a/apps/vaporgui/ImportTab.h
+++ b/apps/vaporgui/ImportTab.h
@@ -5,7 +5,7 @@
 
 class PImportDataWidget;
 class PProjectionStringWidget;
-class MainForm;
+class DatasetImporter;
 
 class ImportTab : public QWidget, public Updatable {
     Q_OBJECT
@@ -15,6 +15,6 @@ class ImportTab : public QWidget, public Updatable {
     PProjectionStringWidget *_projectionWidget;
 
 public:
-    ImportTab(VAPoR::ControlExec *ce, MainForm *mf);
+    ImportTab(VAPoR::ControlExec *ce, DatasetImporter *di);
     void Update() override;
 };

--- a/apps/vaporgui/LeftPanel.cpp
+++ b/apps/vaporgui/LeftPanel.cpp
@@ -1,5 +1,5 @@
 #include "LeftPanel.h"
-#include "MainForm.h"
+#include "DatasetImporter.h"
 #include "RenderersPanel.h"
 #include "ImportTab.h"
 #include "ExportTab.h"
@@ -9,7 +9,7 @@
 
 #include <QScrollArea>
 
-LeftPanel::LeftPanel(ControlExec *ce, CaptureController *cc, MainForm *mf) : _ce(ce)
+LeftPanel::LeftPanel(ControlExec *ce, CaptureController *cc, DatasetImporter *di)
 {
     auto add = [this](auto &&w, auto &&t) constexpr {
         QScrollArea *scrollArea = new QScrollArea;
@@ -20,7 +20,7 @@ LeftPanel::LeftPanel(ControlExec *ce, CaptureController *cc, MainForm *mf) : _ce
         _uTabs.push_back(w);
     };
    
-    _importTab = new ImportTab(_ce, mf); 
+    _importTab = new ImportTab(ce, di); 
     add(_importTab, "Import");
     add(new RenderersPanel(ce), "Render");
     add(new AnnotationEventRouter(ce), "Annotate");

--- a/apps/vaporgui/LeftPanel.cpp
+++ b/apps/vaporgui/LeftPanel.cpp
@@ -24,7 +24,7 @@ LeftPanel::LeftPanel(ControlExec *ce, CaptureController *cc, MainForm *mf) : _ce
     add(_importTab, "Import");
     add(new RenderersPanel(ce), "Render");
     add(new AnnotationEventRouter(ce), "Annotate");
-    add(new ExportTab(ce, cc, mf), "Export");
+    add(new ExportTab(ce, cc), "Export");
 
     for (int i=1 ; i<count(); ++i) setTabEnabled(i, false);
     setTabEnabled(0,true);

--- a/apps/vaporgui/LeftPanel.cpp
+++ b/apps/vaporgui/LeftPanel.cpp
@@ -9,7 +9,7 @@
 
 #include <QScrollArea>
 
-LeftPanel::LeftPanel(ControlExec *ce, MainForm *mf) : _ce(ce)
+LeftPanel::LeftPanel(ControlExec *ce, CaptureController *cc, MainForm *mf) : _ce(ce)
 {
     auto add = [this](auto &&w, auto &&t) constexpr {
         QScrollArea *scrollArea = new QScrollArea;
@@ -24,7 +24,7 @@ LeftPanel::LeftPanel(ControlExec *ce, MainForm *mf) : _ce(ce)
     add(_importTab, "Import");
     add(new RenderersPanel(ce), "Render");
     add(new AnnotationEventRouter(ce), "Annotate");
-    add(new ExportTab(ce, mf), "Export");
+    add(new ExportTab(ce, cc, mf), "Export");
 
     for (int i=1 ; i<count(); ++i) setTabEnabled(i, false);
     setTabEnabled(0,true);

--- a/apps/vaporgui/LeftPanel.h
+++ b/apps/vaporgui/LeftPanel.h
@@ -6,6 +6,7 @@
 
 class ImportTab;
 class MainForm;
+class CaptureController;
 
 class LeftPanel : public QTabWidget, public Updatable {
     Q_OBJECT
@@ -14,7 +15,7 @@ class LeftPanel : public QTabWidget, public Updatable {
     ImportTab* _importTab;
 
 public:
-    LeftPanel(ControlExec *ce, MainForm* mf);
+    LeftPanel(ControlExec *ce, CaptureController *cc, MainForm* mf);
     void Update() override;
     void GoToRendererTab();
     void ConfigureEnabledState(bool enabled);

--- a/apps/vaporgui/LeftPanel.h
+++ b/apps/vaporgui/LeftPanel.h
@@ -5,17 +5,16 @@
 #include <common.h>
 
 class ImportTab;
-class MainForm;
+class DatasetImporter;
 class CaptureController;
 
 class LeftPanel : public QTabWidget, public Updatable {
     Q_OBJECT
-    ControlExec *_ce;
     std::vector<Updatable *> _uTabs;
     ImportTab* _importTab;
 
 public:
-    LeftPanel(ControlExec *ce, CaptureController *cc, MainForm* mf);
+    LeftPanel(ControlExec *ce, CaptureController *cc, DatasetImporter *di);
     void Update() override;
     void GoToRendererTab();
     void ConfigureEnabledState(bool enabled);

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -94,7 +94,6 @@ MainForm *MainForm::_instance = nullptr;
 
 MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, string filesType, QWidget *parent) : QMainWindow(parent)
 {
-    std::cout << "sanity test" << std::endl;
     _App = app;
     _sessionNewFlag = true;
     _begForCitation = true;
@@ -171,7 +170,6 @@ MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, s
     connect(_datasetImporter, &DatasetImporter::datasetImported, [this](){
         _sessionNewFlag=false;
         _leftPanel->GoToRendererTab();
-        std::cout << "slot done" << std::endl;
     });
     
     _leftPanel = new LeftPanel(_controlExec, _captureController, _datasetImporter);
@@ -240,11 +238,8 @@ MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, s
             fmt = filesType;
         }
 
-        if (!fmt.empty()) {
-            std::cout << "MainForm->_datasetImporter->ImportDataset" << std::endl;
+        if (!fmt.empty())
             _datasetImporter->ImportDataset(paths, fmt, DatasetExistsAction::ReplaceFirst);
-        }
-            //ImportDataset(paths, fmt, ReplaceFirst);
     }
 
     app->installEventFilter(this);
@@ -283,7 +278,6 @@ int MainForm::RenderAndExit(int start, int end, const std::string &baseFile, int
     auto vpp = _paramsMgr->GetViewpointParams(GetStateParams()->GetActiveVizName());
 
     _paramsMgr->BeginSaveStateGroup("test");
-    //StartAnimCapture(baseFileWithTS);
     ap->SetStartTimestep(start);
     ap->SetEndTimestep(end);
 
@@ -291,7 +285,6 @@ int MainForm::RenderAndExit(int start, int end, const std::string &baseFile, int
     vpp->SetValueLong(vpp->CustomFramebufferWidthTag, "", width);
     vpp->SetValueLong(vpp->CustomFramebufferHeightTag, "", height);
 
-    //_animationController->AnimationPlayForward();
     if (_captureController->EnableAnimationCapture(baseFileWithTS)) {
         GUIStateParams *p = (GUIStateParams*)_paramsMgr->GetParams(GUIStateParams::GetClassType());
         _capturingAnimationVizName = p->GetActiveVizName();
@@ -303,7 +296,6 @@ int MainForm::RenderAndExit(int start, int end, const std::string &baseFile, int
 
     connect(_animationController, &AnimationController::AnimationOnOffSignal, this, [this]() {
         _captureController->EndAnimationCapture();
-        //endAnimCapture();
         _animationCapture = false;
         _capturingAnimationVizName = "";
         close();

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -65,6 +65,7 @@
 #include "NcarCasperUtils.h"
 #include "ViewpointToolbar.h"
 #include "DatasetTypeLookup.h"
+#include "CaptureController.h"
 
 #include <QStyle>
 #include <vapor/Progress.h>
@@ -156,11 +157,13 @@ MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, s
         Render(false, true);
     });
 
-    _leftPanel = new LeftPanel(_controlExec, this);
+    _captureController = new CaptureController(_controlExec);
+    connect(_captureController, SIGNAL(animationCaptureStarted()), _animationController, SLOT(AnimationPlayForward()));
+
+    _leftPanel = new LeftPanel(_controlExec, _captureController, this);
     const int dpi = qApp->desktop()->logicalDpiX();
     _leftPanel->setMinimumWidth(dpi > 96 ? 675 : 460);
     _leftPanel->setMinimumHeight(500);
-    //_dependOnLoadedData_insert(_leftPanel);
     _updatableElements.insert(_leftPanel);
 
     _status = new ProgressStatusBar;
@@ -1056,7 +1059,6 @@ void MainForm::enableAnimationWidgets(bool on)
         _playForwardAction->setEnabled(false);
     }
 }
-
 
 void MainForm::CaptureSingleImage(string filter, string defaultSuffix)
 {

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -66,6 +66,7 @@
 #include "ViewpointToolbar.h"
 #include "DatasetTypeLookup.h"
 #include "CaptureController.h"
+#include "DatasetImporter.h"
 
 #include <QStyle>
 #include <vapor/Progress.h>
@@ -164,6 +165,8 @@ MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, s
         _animationController->AnimationPlayForward();
     });
 
+    _datasetImporter = new DatasetImporter(_controlExec);
+    
     _leftPanel = new LeftPanel(_controlExec, _captureController, this);
     const int dpi = qApp->desktop()->logicalDpiX();
     _leftPanel->setMinimumWidth(dpi > 96 ? 675 : 460);
@@ -279,13 +282,11 @@ int MainForm::RenderAndExit(int start, int end, const std::string &baseFile, int
     vpp->SetValueLong(vpp->CustomFramebufferHeightTag, "", height);
 
     //_animationController->AnimationPlayForward();
-    GUIStateParams *p = (GUIStateParams*)_paramsMgr->GetParams(GUIStateParams::GetClassType());
-    _capturingAnimationVizName = p->GetActiveVizName();
-    _animationCapture = true;
-    if (_captureController->EnableAnimationCapture(baseFileWithTS)) _captureController->StartAnimationCapture();
-    else {
-        _animationCapture = false;
-        _capturingAnimationVizName = "";
+    if (_captureController->EnableAnimationCapture(baseFileWithTS)) {
+        GUIStateParams *p = (GUIStateParams*)_paramsMgr->GetParams(GUIStateParams::GetClassType());
+        _capturingAnimationVizName = p->GetActiveVizName();
+        _animationCapture = true;
+        _captureController->StartAnimationCapture();
     }
     
     _paramsMgr->EndSaveStateGroup();

--- a/apps/vaporgui/MainForm.cpp
+++ b/apps/vaporgui/MainForm.cpp
@@ -158,7 +158,14 @@ MainForm::MainForm(vector<QString> files, QApplication *app, bool interactive, s
     });
 
     _captureController = new CaptureController(_controlExec);
-    connect(_captureController, SIGNAL(animationCaptureStarted()), _animationController, SLOT(AnimationPlayForward()));
+    //connect(_captureController, SIGNAL(animationCaptureStarted()), _animationController, SLOT(AnimationPlayForward()));
+    connect(_captureController, &CaptureController::animationCaptureStarted, [this]() {
+        _animationController->AnimationPlayForward();
+
+        GUIStateParams *p = (GUIStateParams*)_paramsMgr->GetParams(GUIStateParams::GetClassType());
+        _capturingAnimationVizName = p->GetActiveVizName();
+        _animationCapture = true;
+    });
 
     _leftPanel = new LeftPanel(_controlExec, _captureController, this);
     const int dpi = qApp->desktop()->logicalDpiX();

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -46,6 +46,7 @@ class VProjectionStringFrame;
 class ErrorReporter;
 class ParamsWidgetDemo;
 class AppSettingsMenu;
+class CaptureController;
 
 class LeftPanel;
 
@@ -125,6 +126,7 @@ private:
     VAPoR::ControlExec *_controlExec;
     VAPoR::ParamsMgr *  _paramsMgr;
     AnimationController *_animationController;
+    CaptureController*  _captureController;
     VizWinMgr *         _vizWinMgr;
     string              _capturingAnimationVizName;
 

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -21,6 +21,7 @@
 #include "AnimationController.h"
 #include "PWidgetsFwd.h"
 #include "QEnableable.h"
+#include "DatasetExistsAction.h"
 
 class QApplication;
 class QSpacerItem;
@@ -63,10 +64,6 @@ public:
 
     int RenderAndExit(int start, int end, const std::string &baseFile, int width, int height);
     static QWidget* Instance() { assert(_instance); return _instance; }
-
-    // Needed for Import/Data widget
-    enum DatasetExistsAction { Prompt, AddNew, ReplaceFirst };
-    void ImportDataset(const std::vector<string> &files, string format, DatasetExistsAction existsAction = Prompt, string name="");
 
     // Needed for Export/Capture widget
     void AnimationPlayForward() const;
@@ -187,7 +184,6 @@ private:
     void SaveSession();
     void SaveSession(string path);
     void SaveSessionAs();
-    string _getDataSetName(string file, DatasetExistsAction existsAction = Prompt);
 
 private slots:
     void _plotClosed();

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -47,6 +47,7 @@ class ErrorReporter;
 class ParamsWidgetDemo;
 class AppSettingsMenu;
 class CaptureController;
+class DatasetImporter;
 
 class LeftPanel;
 
@@ -123,6 +124,7 @@ private:
     VAPoR::ParamsMgr *  _paramsMgr;
     AnimationController *_animationController;
     CaptureController*  _captureController;
+    DatasetImporter*    _datasetImporter;
     VizWinMgr *         _vizWinMgr;
     string              _capturingAnimationVizName;
 

--- a/apps/vaporgui/MainForm.h
+++ b/apps/vaporgui/MainForm.h
@@ -68,11 +68,7 @@ public:
     void ImportDataset(const std::vector<string> &files, string format, DatasetExistsAction existsAction = Prompt, string name="");
 
     // Needed for Export/Capture widget
-    bool StartAnimCapture(string baseFile, string defaultSuffix = "tiff");
     void AnimationPlayForward() const;
-
-public slots:
-    void CaptureSingleImage(string filter, string defaultSuffix);
 
 protected:
     void Render(bool fast=false, bool skipSync=false);
@@ -197,7 +193,6 @@ private slots:
     void closeProjectionFrame();
     void helpAbout();
     void sessionNew();
-    void endAnimCapture();
     void launchStats();
     void launchPlotUtility();
     void launchPythonVariables();

--- a/apps/vaporgui/PCaptureWidget.cpp
+++ b/apps/vaporgui/PCaptureWidget.cpp
@@ -25,7 +25,7 @@ const std::string PngStrings::FileFilter = "PNG (*.png)";
 const std::string PngStrings::FileSuffix = "png";
 
 PCaptureHBox::PCaptureHBox(VAPoR::ControlExec *ce, CaptureController *cc)
-    : PWidget("", _hBox = new VHBoxWidget()), _ce(ce)
+    : PWidget("", _hBox = new VHBoxWidget()), _ce(ce), _cc(cc)
 {
     _hBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 

--- a/apps/vaporgui/PCaptureWidget.cpp
+++ b/apps/vaporgui/PCaptureWidget.cpp
@@ -1,4 +1,3 @@
-#include "MainForm.h"
 #include "CaptureController.h"
 #include "PCaptureWidget.h"
 #include "PTimeRangeSelector.h"
@@ -25,8 +24,8 @@ const std::string TiffStrings::FileSuffix = "tif";
 const std::string PngStrings::FileFilter = "PNG (*.png)";
 const std::string PngStrings::FileSuffix = "png";
 
-PCaptureHBox::PCaptureHBox(VAPoR::ControlExec *ce, CaptureController *cc, MainForm *mf)
-    : PWidget("", _hBox = new VHBoxWidget()), _ce(ce), _cc(cc), _mf(mf)
+PCaptureHBox::PCaptureHBox(VAPoR::ControlExec *ce, CaptureController *cc)
+    : PWidget("", _hBox = new VHBoxWidget()), _ce(ce)
 {
     _hBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
@@ -91,8 +90,8 @@ void PCaptureHBox::_captureTimeSeries() {
     }
 }
 
-PCaptureWidget::PCaptureWidget(VAPoR::ControlExec *ce, CaptureController *cc, MainForm *mf)
-    : PWidget("", _section = new PSection("Image(s)")), _ce(ce), _mf(mf)
+PCaptureWidget::PCaptureWidget(VAPoR::ControlExec *ce, CaptureController *cc)
+    : PWidget("", _section = new PSection("Image(s)")), _ce(ce)
 {
     _section->Add(new PRadioButtons(AnimationParams::CaptureModeTag, {"Current frame", "Time series range"}));
 
@@ -100,7 +99,7 @@ PCaptureWidget::PCaptureWidget(VAPoR::ControlExec *ce, CaptureController *cc, Ma
     t->EnableBasedOnParam(AnimationParams::CaptureModeTag, 1);
     _section->Add(t);
 
-    _section->Add(new PCaptureHBox(ce, cc, mf));
+    _section->Add(new PCaptureHBox(ce, cc));
 }
 
 void PCaptureWidget::updateGUI() const {    

--- a/apps/vaporgui/PCaptureWidget.cpp
+++ b/apps/vaporgui/PCaptureWidget.cpp
@@ -35,7 +35,7 @@ PCaptureHBox::PCaptureHBox(VAPoR::ControlExec *ce, CaptureController *cc, MainFo
     _fileLabel = new VLabel("");
     _fileLabel->MakeSelectable();
 
-    _captureButton = new PButton("Export", [this](VAPoR::ParamsBase*){_captureSingleImage();});
+    _captureButton = new PButton("Export", [this](VAPoR::ParamsBase*){_cc->CaptureSingleImage();});
     _captureButton->ShowBasedOnParam(AnimationParams::CaptureModeTag, AnimationParams::SingleImage);
 
     _captureTimeSeriesButton = new PButton("Export", [this](VAPoR::ParamsBase*){_captureTimeSeries();});
@@ -82,50 +82,12 @@ void PCaptureHBox::updateGUI() const {
     _captureTimeSeriesButton->Update(ap);
 }
 
-void PCaptureHBox::_captureSingleImage() {
-    AnimationParams* ap = (AnimationParams*)_ce->GetParamsMgr()->GetParams(AnimationParams::GetClassType());
-    std::string defaultPath = ap->GetValueString(AnimationParams::CaptureFileDirTag, FileUtils::HomeDir());
-
-        //_mf->CaptureSingleImage(TiffStrings::FileFilter, "."+TiffStrings::FileSuffix);
-        //_mf->CaptureSingleImage(PngStrings::FileFilter, "."+PngStrings::FileSuffix);
-    if (ap->GetValueLong(AnimationParams::CaptureTypeTag, 0) == 0)
-        _cc->CaptureSingleImage(TiffStrings::FileFilter, "."+TiffStrings::FileSuffix);
-    else 
-        _cc->CaptureSingleImage(PngStrings::FileFilter, "."+PngStrings::FileSuffix);
-
-    ap->SetValueString(AnimationParams::CaptureFileTimeTag, "Capture file time", STLUtils::GetCurrentDateTimestamp());
-}
-
 void PCaptureHBox::_captureTimeSeries() {
-    AnimationParams* ap = (AnimationParams*)_ce->GetParamsMgr()->GetParams(AnimationParams::GetClassType());
-   
-    std::string filter, defaultSuffix;
-    if (ap->GetValueLong(AnimationParams::CaptureTypeTag, 0) == 0) { // .tiff
-         filter = TiffStrings::FileFilter;
-         defaultSuffix =  TiffStrings::FileSuffix;
-    }
-    else {                                                          // .png
-         filter = PngStrings::FileFilter;
-         defaultSuffix =  PngStrings::FileSuffix;
-    }
-
-    std::string defaultPath = ap->GetValueString(AnimationParams::CaptureFileDirTag, FileUtils::HomeDir());
-    std::string fileName = QFileDialog::getSaveFileName(this, "Select Filename Prefix", QString::fromStdString(defaultPath), QString::fromStdString(filter)).toStdString();
-    if (fileName.empty()) return;
-
-    // Qt does not always append the filetype to the selection from the QFileDialog, so manually add it if this happens
-    if (fileName.find(defaultSuffix) == std::string::npos) fileName = fileName + "." + defaultSuffix;
-
-    ap->SetValueString(AnimationParams::CaptureFileDirTag, "Capture animation file directory", FileUtils::Dirname(fileName));
-    ap->SetValueString(AnimationParams::CaptureTimeSeriesFileNameTag, "Capture animation file name", FileUtils::Basename(fileName));
-    ap->SetValueString(AnimationParams::CaptureTimeSeriesTimeTag, "Capture file time", STLUtils::GetCurrentDateTimestamp());
-
-    //bool rc = _mf->StartAnimCapture(fileName, defaultSuffix);  // User may cancel to prevent file overwrite, so capture return code
-    bool rc = _cc->EnableAnimationCapture(fileName, defaultSuffix);  // User may cancel to prevent file overwrite, so capture return code
+    bool rc = _cc->EnableAnimationCapture();  // User may cancel to prevent file overwrite, so capture return code
     if (rc) {
+        AnimationParams* ap = (AnimationParams*)_ce->GetParamsMgr()->GetParams(AnimationParams::GetClassType());
         NavigationUtils::SetTimestep(_ce, ap->GetValueLong(AnimationParams::CaptureStartTag, ap->GetStartTimestep()));
         _cc->StartAnimationCapture();
-        //_mf->AnimationPlayForward();
     }
 }
 

--- a/apps/vaporgui/PCaptureWidget.h
+++ b/apps/vaporgui/PCaptureWidget.h
@@ -9,7 +9,6 @@ class ControlExec;
 class PSection;
 class PEnumDropdownStandalone;
 class VLabel;
-class MainForm;
 class CaptureController;
 class PButton;
 class VHBoxWidget;
@@ -31,7 +30,6 @@ class PCaptureHBox : public PWidget {
 
     ControlExec *_ce;
     CaptureController *_cc;
-    MainForm *_mf;
     VHBoxWidget *_hBox;
     PStringDropdown *_fileTypeSelector;
     const std::vector<long> _enumMap;
@@ -42,7 +40,7 @@ class PCaptureHBox : public PWidget {
     PButton *_captureTimeSeriesButton;
 
 public:
-    PCaptureHBox(VAPoR::ControlExec *ce, CaptureController* cc, MainForm *mf);
+    PCaptureHBox(VAPoR::ControlExec *ce, CaptureController* cc);
 
 protected:
     virtual void updateGUI() const;
@@ -56,11 +54,10 @@ class PCaptureWidget : public PWidget {
     Q_OBJECT
 
     ControlExec *_ce;
-    MainForm *_mf;
     PSection *_section;
 
 public:
-    PCaptureWidget(VAPoR::ControlExec *ce, CaptureController *cc, MainForm *mf);
+    PCaptureWidget(VAPoR::ControlExec *ce, CaptureController *cc);
 
 protected:
     virtual void updateGUI() const;

--- a/apps/vaporgui/PCaptureWidget.h
+++ b/apps/vaporgui/PCaptureWidget.h
@@ -10,6 +10,7 @@ class PSection;
 class PEnumDropdownStandalone;
 class VLabel;
 class MainForm;
+class CaptureController;
 class PButton;
 class VHBoxWidget;
 class VComboBox;
@@ -29,6 +30,7 @@ class PCaptureHBox : public PWidget {
     Q_OBJECT;
 
     ControlExec *_ce;
+    CaptureController *_cc;
     MainForm *_mf;
     VHBoxWidget *_hBox;
     PStringDropdown *_fileTypeSelector;
@@ -40,7 +42,7 @@ class PCaptureHBox : public PWidget {
     PButton *_captureTimeSeriesButton;
 
 public:
-    PCaptureHBox(VAPoR::ControlExec *ce, MainForm *mf);
+    PCaptureHBox(VAPoR::ControlExec *ce, CaptureController* cc, MainForm *mf);
 
 protected:
     virtual void updateGUI() const;
@@ -59,7 +61,7 @@ class PCaptureWidget : public PWidget {
     PSection *_section;
 
 public:
-    PCaptureWidget(VAPoR::ControlExec *ce, MainForm *mf);
+    PCaptureWidget(VAPoR::ControlExec *ce, CaptureController *cc, MainForm *mf);
 
 protected:
     virtual void updateGUI() const;

--- a/apps/vaporgui/PCaptureWidget.h
+++ b/apps/vaporgui/PCaptureWidget.h
@@ -49,7 +49,6 @@ protected:
 
 private slots:
     void _dropdownIndexChanged(int index);
-    void _captureSingleImage();
     void _captureTimeSeries();
 };
     

--- a/apps/vaporgui/PImportDataButton.cpp
+++ b/apps/vaporgui/PImportDataButton.cpp
@@ -1,5 +1,5 @@
 #include "PImportDataButton.h"
-#include "MainForm.h"
+#include "DatasetImporter.h"
 #include "VHBoxWidget.h"
 #include "VLabel.h"
 #include "DatasetTypeLookup.h"
@@ -10,7 +10,7 @@
 #include <QFileDialog>
 #include <QPushButton>
 
-PImportDataButton::PImportDataButton(VAPoR::ControlExec* ce, MainForm *mf) : PWidget("", _hBox = new VHBoxWidget()), _ce(ce), _mf(mf) {
+PImportDataButton::PImportDataButton(VAPoR::ControlExec* ce, DatasetImporter *di) : PWidget("", _hBox = new VHBoxWidget()), _ce(ce), _di(di) {
     _hBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
     QHBoxLayout* layout = qobject_cast<QHBoxLayout*>(_hBox->layout());
@@ -34,7 +34,7 @@ void PImportDataButton::_importDataset() {
     if (fileNames.empty()) return;
 
     std::string format = GetDatasets()[getParams()->GetValueLong(GUIStateParams::ImportDataTypeTag, 0)].first;
-    _mf->ImportDataset(fileNames, format);
+    _di->ImportDataset(fileNames, format);
 }
 
 void PImportDataButton::updateGUI() const {

--- a/apps/vaporgui/PImportDataButton.h
+++ b/apps/vaporgui/PImportDataButton.h
@@ -5,7 +5,7 @@
 namespace VAPoR {
     class ControlExec;
 }
-class MainForm;
+class DatasetImporter;
 class VHBoxWidget;
 class VLabel;
 class PButton;
@@ -14,7 +14,7 @@ class PImportDataButton : public PWidget {
     Q_OBJECT
 
     VAPoR::ControlExec *_ce;
-    MainForm *_mf;
+    DatasetImporter *_di;
     VHBoxWidget *_hBox;
     VLabel *_fileLabel;
     PButton *_importButton;
@@ -22,7 +22,7 @@ class PImportDataButton : public PWidget {
     void _importDataset();
 
 public:
-    PImportDataButton(VAPoR::ControlExec* ce, MainForm *mf);
+    PImportDataButton(VAPoR::ControlExec* ce, DatasetImporter *di);
 
 protected:
     void updateGUI() const override;

--- a/apps/vaporgui/PImportDataWidget.cpp
+++ b/apps/vaporgui/PImportDataWidget.cpp
@@ -1,5 +1,5 @@
 #include "DatasetTypeLookup.h"
-#include "MainForm.h"
+#include "DatasetImporter.h"
 #include "PImportDataWidget.h"
 #include "PImportDataButton.h"
 #include "PRadioButtons.h"
@@ -8,10 +8,10 @@
 #include "vapor/ControlExecutive.h"
 #include "vapor/GUIStateParams.h"
 
-PImportDataWidget::PImportDataWidget(VAPoR::ControlExec* ce, MainForm* mf) : PGroup() {
+PImportDataWidget::PImportDataWidget(VAPoR::ControlExec* ce, DatasetImporter* di) : PGroup() {
     std::vector<std::string> types = GetDatasetTypeDescriptions();
     PRadioButtons* prb = new PRadioButtons(GUIStateParams::ImportDataTypeTag, types);
     Add(prb);
     
-    Add(new PImportDataButton(ce, mf));
+    Add(new PImportDataButton(ce, di));
 }

--- a/apps/vaporgui/PImportDataWidget.h
+++ b/apps/vaporgui/PImportDataWidget.h
@@ -7,11 +7,11 @@
 namespace VAPoR {
     class ControlExec;
 }
-class MainForm;
+class DatasetImporter;
 
 class PImportDataWidget : public PGroup {
     Q_OBJECT
 
 public:
-    PImportDataWidget(VAPoR::ControlExec* ce, MainForm *mf);
+    PImportDataWidget(VAPoR::ControlExec* ce, DatasetImporter *di);
 };

--- a/lib/params/AnimationParams.cpp
+++ b/lib/params/AnimationParams.cpp
@@ -82,7 +82,7 @@ void AnimationParams::_init()
     SetCurrentTimestep(0);
     SetMaxFrameRate(10);
     SetValueLong(AnimationParams::CaptureModeTag, "Set default value for image capture mode", AnimationParams::SingleImage);
-    SetValueLong(AnimationParams::CaptureTypeTag, "Set default value for capture mode image filetype", AnimationParams::TIFF);
+    SetValueLong(AnimationParams::CaptureTypeTag, "Set default value for capture mode image filetype", AnimationParams::PNG);
     SetValueLong(AnimationParams::CaptureStartTag, "Set default value for capturing imagery start time", GetStartTimestep());
     SetValueLong(AnimationParams::CaptureEndTag, "Set default value for capturing imagery end time", GetEndTimestep());
 }


### PR DESCRIPTION
Separates MainForm's image-capture and import-data functionality into the classes CaptureController and DatasetImporter so these tools can be used by the LeftPanel.

Submitted as a draft because of one question: MainForm.cpp:1246 (on main) has the following logic:

```
    string          vizName = p->GetActiveVizName();
    if (vizName != _capturingAnimationVizName) { MSG_WARN("Terminating capture in non-active visualizer"); }
    if (_controlExec->EnableAnimationCapture(_capturingAnimationVizName, false)) MSG_WARN("Image Capture Warning;\nCurrent active visualizer is not capturing images");
```

Is this warning still achievable?  I am not able to produce it when changing visualizers during an image capture, or any other way I can think of.  I've removed it in this PR, but we can keep it if the MainForm communicates _capturingAnimationVizName to the CaptureController whenever it changes.  It was added in 2017 and does not appear to be needed anymore, from what I can tell.