### PR TITLE
Render ordering

### DIFF
--- a/apps/vaporgui/VizWin.cpp
+++ b/apps/vaporgui/VizWin.cpp
@@ -879,7 +879,7 @@ void VizWin::_updateOriginGlyph()
 {
     _glManager->matrixManager->PushMatrix();
     Renderer::ApplyDatasetTransform(_glManager, _getDataMgrTransform());
-    Renderer::ApplyTransform(_glManager, _getDataMgrTransform(), _getRenderParams()->GetTransform());
+    Renderer::ApplyTransform(_glManager->matrixManager, _getDataMgrTransform(), _getRenderParams()->GetTransform());
 
     VAPoR::RenderParams *rp = _getRenderParams();
     double               xOrigin = rp->GetValueDouble(RenderParams::XSlicePlaneOriginTag, 0.);
@@ -943,7 +943,7 @@ void VizWin::_drawContourSliceQuad()
 {
     _glManager->matrixManager->PushMatrix();
     Renderer::ApplyDatasetTransform(_glManager, _getDataMgrTransform());
-    Renderer::ApplyTransform(_glManager, _getDataMgrTransform(), _getRenderParams()->GetTransform());
+    Renderer::ApplyTransform(_glManager->matrixManager, _getDataMgrTransform(), _getRenderParams()->GetTransform());
 
     auto quad = _getRenderParams()->GetSlicePlaneQuad();
 

--- a/include/vapor/Renderer.h
+++ b/include/vapor/Renderer.h
@@ -30,6 +30,7 @@ namespace VAPoR {
 
 class ShaderProgram;
 struct GLManager;
+class MatrixManager;
 
 //! \class RendererBase
 //! \ingroup Public_Render
@@ -100,6 +101,7 @@ public:
     //! to ensure the correct OpenGL context is bound
     void FlagForDeletion();
     bool IsFlaggedForDeletion() const;
+    DataMgr *GetDataMgr() const { return _dataMgr; }
 
     RendererBase() {}
 
@@ -254,7 +256,8 @@ public:
 
     Transform *GetDatasetTransform() const { return GetViewpointParams()->GetTransform(_dataSetName); }
 
-    static void ApplyTransform(GLManager *gl, const Transform *dataset, const Transform *renderer);
+    void ApplyTransform(MatrixManager *mm) const;
+    static void ApplyTransform(MatrixManager *mm, const Transform *dataset, const Transform *renderer);
 
     static void ApplyDatasetTransform(GLManager *gl, const Transform *dataset);
 

--- a/lib/render/Renderer.cpp
+++ b/lib/render/Renderer.cpp
@@ -122,11 +122,7 @@ int Renderer::paintGL(bool fast)
     mm->MatrixModeModelView();
     mm->PushMatrix();
 
-    if (dynamic_cast<TwoDDataRenderer*>(this) != nullptr) {
-        float zOffset = GetDefaultZ(_dataMgr, GetActiveParams()->GetCurrentTimestep());
-        _glManager->matrixManager->Translate(0, 0, zOffset);
-    }
-    ApplyTransform(_glManager, GetDatasetTransform(), rParams->GetTransform());
+    ApplyTransform(_glManager->matrixManager);
 
     int rc = _paintGL(fast);
 
@@ -143,10 +139,18 @@ int Renderer::paintGL(bool fast)
     return (0);
 }
 
-void Renderer::ApplyTransform(GLManager *gl, const Transform *dataset, const Transform *renderer)
+void Renderer::ApplyTransform(MatrixManager *mm) const
 {
-    MatrixManager *mm = gl->matrixManager;
+    if (dynamic_cast<const TwoDDataRenderer*>(this) != nullptr) {
+        float zOffset = GetDefaultZ(_dataMgr, GetActiveParams()->GetCurrentTimestep());
+        _glManager->matrixManager->Translate(0, 0, zOffset);
+    }
 
+    ApplyTransform(mm, GetDatasetTransform(), GetActiveParams()->GetTransform());
+}
+
+void Renderer::ApplyTransform(MatrixManager *mm, const Transform *dataset, const Transform *renderer)
+{
     vector<double> translate = renderer->GetTranslations();
     vector<double> rotate = renderer->GetRotations();
     vector<double> scale = renderer->GetScales();

--- a/lib/render/VolumeCellTraversal.cpp
+++ b/lib/render/VolumeCellTraversal.cpp
@@ -102,7 +102,11 @@ static vec3 GetCoordAtIndex(const ivec3 &index, const float *data, const ivec3 &
     const int y = index.y;
     const int z = index.z;
     VAssert(x >= 0 && x < w && y >= 0 && y < h && z >= 0 && z < d);
-    return vec3(data[3 * (z * w * h + y * w + x)], data[3 * (z * w * h + y * w + x) + 1], data[3 * (z * w * h + y * w + x) + 2]);
+    return vec3(
+        data[3 * ((long)z * w * h + y * w + x)],
+        data[3 * ((long)z * w * h + y * w + x) + 1],
+        data[3 * ((long)z * w * h + y * w + x) + 2]
+    );
 }
 
 static void GetFaceVertices(const ivec3 &cellIndex, const ivec3 &face, const float *data, const ivec3 &dims, vec3 &v0, vec3 &v1, vec3 &v2, vec3 &v3)


### PR DESCRIPTION
Solved transparency and renderer ordering in Vapor. Automatically reorders renderers based on orientation with respect to camera. Handles Volume renderer overlap. Also automatically handles 2D renderers on the same plane without z-fighting. Enforces deterministic order for these behaviors to allow consistent visualizations between sessions.