### PR TITLE
Fix Python binding: set annotation axis color #3795

### DIFF
--- a/lib/params/AxisAnnotation.cpp
+++ b/lib/params/AxisAnnotation.cpp
@@ -111,7 +111,6 @@ std::vector<double> AxisAnnotation::GetAxisColor() const
 
 void AxisAnnotation::SetAxisColor(std::vector<double> color)
 {
-    return;
     string msg = "Axis annotation text color";
     SetValueDoubleVec(_colorTag, msg, color);
 }


### PR DESCRIPTION
Fix #3795