### PR TITLE
Fix issue #3614

### DIFF
--- a/lib/common/ResourcePath.cpp
+++ b/lib/common/ResourcePath.cpp
@@ -81,6 +81,13 @@ string GetResourcePathFromCallback(const std::string &name)
     return "";
 }
 
+string GetAppImageResourceRoot()
+{
+    string appDir = string(Wasp::GetEnvironmentalVariable("APPDIR"));
+    if (appDir.empty()) return "";
+    return appDir;
+}
+
 std::string Wasp::GetResourcePath(const std::string &name)
 {
 #if FORCE_USE_DEV_LIBS
@@ -88,6 +95,7 @@ std::string Wasp::GetResourcePath(const std::string &name)
 #else
     TRY_PATH(GetResourcePathFromCallback(name));
     TRY_PATH(FileUtils::JoinPaths({GetInstalledResourceRoot(), name}));
+    TRY_PATH(FileUtils::JoinPaths({GetAppImageResourceRoot(), name}));
     TRY_PATH(FileUtils::JoinPaths({SOURCE_DIR, name}));
     TRY_PATH(FileUtils::JoinPaths({THIRD_PARTY_DIR, name}));
     TRY_PATH(CallGetAppPathForResourceName(name));
@@ -96,7 +104,10 @@ std::string Wasp::GetResourcePath(const std::string &name)
     return "";
 }
 
-std::string Wasp::GetSharePath(const std::string &name) { return GetResourcePath("share/" + name); }
+std::string Wasp::GetSharePath(const std::string &name) { 
+    
+    return GetResourcePath("share/" + name); 
+}
 
 #if defined(WIN32)
     #define PYTHON_MODULE_SUBDIR ("python" + string(PYTHON_VERSION))

--- a/lib/params/ImageParams.cpp
+++ b/lib/params/ImageParams.cpp
@@ -69,16 +69,8 @@ std::string ImageParams::GetImagePath() const
     std::string defaultImage = Wasp::GetSharePath("images/NaturalEarth.tms");
     std::string savedPath = GetValueString(_fileNameTag, defaultImage);
 
-    if (!Wasp::FileUtils::Exists(savedPath)) {
-        std::string appDir = Wasp::GetEnvironmentalVariable("APPDIR");
-        if (!appDir.empty()) {
-            std::string appImagePath = Wasp::FileUtils::JoinPaths({appDir, "share", "images", "NaturalEarth.tms"});
-            if (Wasp::FileUtils::Exists(appImagePath)) {
-                return appImagePath;
-            }
-        }
+    if (!Wasp::FileUtils::Exists(savedPath))
         return defaultImage;
-    }
 
     return savedPath;
 }

--- a/lib/params/ImageParams.cpp
+++ b/lib/params/ImageParams.cpp
@@ -1,6 +1,8 @@
 #include <vapor/ImageParams.h>
 #include <vapor/ResourcePath.h>
 #include <vapor/DataMgrUtils.h>
+#include <vapor/FileUtils.h>
+#include <vapor/CFuncs.h>
 
 using namespace VAPoR;
 
@@ -65,6 +67,18 @@ int ImageParams::Initialize()
 std::string ImageParams::GetImagePath() const
 {
     std::string defaultImage = Wasp::GetSharePath("images/NaturalEarth.tms");
+    std::string savedPath = GetValueString(_fileNameTag, defaultImage);
 
-    return GetValueString(_fileNameTag, defaultImage);
+    if (!Wasp::FileUtils::Exists(savedPath)) {
+        std::string appDir = Wasp::GetEnvironmentalVariable("APPDIR");
+        if (!appDir.empty()) {
+            std::string appImagePath = Wasp::FileUtils::JoinPaths({appDir, "share", "images", "NaturalEarth.tms"});
+            if (Wasp::FileUtils::Exists(appImagePath)) {
+                return appImagePath;
+            }
+        }
+        return defaultImage;
+    }
+
+    return savedPath;
 }


### PR DESCRIPTION
Fix #3614.  The problem with spack also lies with the AppImage implementation, which mounts the VAPOR executable in a temporary directory that's inconsistent between instances.  This PR adds a fallback for when the image cannot be found, to check the currently mounted AppImage location for the image.